### PR TITLE
eval/downstream/core22.py: 22-task registry + per-task evaluators

### DIFF
--- a/eval/downstream/__init__.py
+++ b/eval/downstream/__init__.py
@@ -13,9 +13,11 @@ What B1 has shipped so far:
   * scorer.py: score_mc / score_schema / score_lm kernels (pure functions
     over pre-tokenized examples; model-agnostic via a forward_logits
     callable)
+  * core22.py: the 22-task registry + per-task evaluators that wire scorer
+    kernels to CellResult outputs. Bundle URL pinned (B1-D2); bundle
+    download itself stubbed until the SHA-pin commit.
 
 What B1 will ship (separate commits within the phase):
-  * core22.py: the 22-task DCLM CORE eval bundle adapter
   * private_hard.py: the 4-task private hardness subset adapter
   * grader.py: one-shot offline grader → eval/private/hardness/index.parquet
   * calibration.py: N=10 baseline runs → noise_floors_v1.json
@@ -26,6 +28,16 @@ Reference scope: docs/build_scope/02_scope_B1.md.
 from __future__ import annotations
 
 from .aggregate import aggregate_pareto
+from .core22 import (
+    DCLM_CORE_22_TASKS,
+    DCLM_EVAL_BUNDLE_SHA256,
+    DCLM_EVAL_BUNDLE_URL,
+    TASK_SPECS,
+    evaluate_lm_task_lambada,
+    evaluate_mc_task,
+    evaluate_schema_task,
+    to_cell_result,
+)
 from .scorer import (
     LMExample,
     MCExample,
@@ -51,6 +63,9 @@ from .types import (
 __all__ = [
     "BPB_SUFFIX",
     "CellResult",
+    "DCLM_CORE_22_TASKS",
+    "DCLM_EVAL_BUNDLE_SHA256",
+    "DCLM_EVAL_BUNDLE_URL",
     "DownstreamReport",
     "HARNESS_VERSION",
     "LMExample",
@@ -62,9 +77,14 @@ __all__ = [
     "ParetoOutcome",
     "ParetoVerdict",
     "SchemaExample",
+    "TASK_SPECS",
     "TaskSpec",
     "aggregate_pareto",
+    "evaluate_lm_task_lambada",
+    "evaluate_mc_task",
+    "evaluate_schema_task",
     "score_lm",
     "score_mc",
     "score_schema",
+    "to_cell_result",
 ]

--- a/eval/downstream/core22.py
+++ b/eval/downstream/core22.py
@@ -1,0 +1,323 @@
+"""DCLM CORE-22 task registry + per-task evaluator (B1).
+
+Adapts DCLM's CORE-22 eval bundle to the Karpa downstream-eval harness.
+The 22 tasks are pinned from DCLM's `low_variance_datasets` aggregation
+(see eval/downstream/DEFERRED.md B1-D3 for provenance). Each task is
+catalogued by:
+
+  * `name` — canonical DCLM task identifier
+  * `mode` — "mc" / "schema" / "lm", routing to score_mc / score_schema /
+    score_lm in scorer.py
+  * `random_baseline` — DCLM's published random-guessing-or-majority
+    baseline as a fraction in [0, 1]
+
+The bundle URL + SHA pin are constants here so the runner can verify the
+on-disk mirror against the expected upstream version. The actual bundle
+fetch + jsonl parsing is deferred to a follow-up commit once the bundle
+is downloaded and its SHA is pinned (B1-D2 protocol). For now the
+loader stub raises a clear NotImplementedError that the runner.py
+author will resolve.
+
+Reference scope: docs/build_scope/02_scope_B1.md "core22.py".
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from .scorer import (
+    LMExample,
+    MCExample,
+    SchemaExample,
+    score_lm,
+    score_mc,
+    score_schema,
+)
+from .types import (
+    POOL_CORE22,
+    CellResult,
+    TaskSpec,
+)
+
+# ----------------------------------------------------------------------------
+# Bundle constants (per B1-D2)
+# ----------------------------------------------------------------------------
+
+DCLM_EVAL_BUNDLE_URL = "https://karpathy-public.s3.us-west-2.amazonaws.com/eval_bundle.zip"
+"""DCLM CORE-22 eval bundle source URL.
+
+Verified 2026-06-10 via nanochat/scripts/base_eval.py constant
+EVAL_BUNDLE_URL. The bundle is hosted in Karpathy's personal S3, which
+means it CAN rotate without notice — the SHA pin below is the guard.
+"""
+
+DCLM_EVAL_BUNDLE_SHA256: str | None = None
+"""SHA256 of the canonical bundle. Pinned at first download.
+
+Today (B1 foundation) this is None — the bundle has not been
+downloaded yet. The first B1 code commit that actually fetches the
+bundle MUST update this constant with the verbatim sha256 and a
+matching `test_dclm_bundle_sha_pinned` test. Until then, callers
+should skip integrity verification with a clear log message.
+"""
+
+
+# ----------------------------------------------------------------------------
+# Task registry (per B1-D3)
+# ----------------------------------------------------------------------------
+
+DCLM_CORE_22_TASKS: tuple[str, ...] = (
+    "hellaswag_zeroshot",
+    "jeopardy",
+    "bigbench_qa_wikidata",
+    "arc_easy",
+    "arc_challenge",
+    "copa",
+    "commonsense_qa",
+    "piqa",
+    "openbook_qa",
+    "lambada_openai",
+    "hellaswag",
+    "winograd",
+    "winogrande",
+    "bigbench_dyck_languages",
+    "agi_eval_lsat_ar",
+    "bigbench_cs_algorithms",
+    "bigbench_operators",
+    "bigbench_repeat_copy_logic",
+    "squad",
+    "coqa",
+    "boolq",
+    "bigbench_language_identification",
+)
+"""The verbatim 22-task list from DCLM's `low_variance_datasets`
+aggregation (additional_aggregation.json). Order preserved from the
+source so cross-references against DCLM tooling stay byte-equal."""
+
+assert len(DCLM_CORE_22_TASKS) == 22, "CORE-22 must be exactly 22 tasks"
+
+
+# Per-task metadata sourced verbatim from DCLM's eval/eval_meta_data.csv on
+# 2026-06-10. Random baselines are decimal fractions in [0, 1]; DCLM
+# reports percents which are converted here. The scoring mode determines
+# which scorer.py entrypoint the per-task evaluator dispatches to.
+TASK_SPECS: dict[str, TaskSpec] = {
+    "hellaswag_zeroshot":               TaskSpec("hellaswag_zeroshot",               "mc",     0.25, POOL_CORE22),
+    "jeopardy":                         TaskSpec("jeopardy",                         "lm",     0.0,  POOL_CORE22),
+    "bigbench_qa_wikidata":             TaskSpec("bigbench_qa_wikidata",             "lm",     0.0,  POOL_CORE22),
+    "arc_easy":                         TaskSpec("arc_easy",                         "mc",     0.25, POOL_CORE22),
+    "arc_challenge":                    TaskSpec("arc_challenge",                    "mc",     0.25, POOL_CORE22),
+    "copa":                             TaskSpec("copa",                             "mc",     0.50, POOL_CORE22),
+    "commonsense_qa":                   TaskSpec("commonsense_qa",                   "mc",     0.403, POOL_CORE22),
+    "piqa":                             TaskSpec("piqa",                             "mc",     0.50, POOL_CORE22),
+    "openbook_qa":                      TaskSpec("openbook_qa",                      "mc",     0.25, POOL_CORE22),
+    "lambada_openai":                   TaskSpec("lambada_openai",                   "lm",     0.0,  POOL_CORE22),
+    "hellaswag":                        TaskSpec("hellaswag",                        "mc",     0.25, POOL_CORE22),
+    "winograd":                         TaskSpec("winograd",                         "schema", 0.50, POOL_CORE22),
+    "winogrande":                       TaskSpec("winogrande",                       "schema", 0.50, POOL_CORE22),
+    "bigbench_dyck_languages":          TaskSpec("bigbench_dyck_languages",          "lm",     0.0,  POOL_CORE22),
+    "agi_eval_lsat_ar":                 TaskSpec("agi_eval_lsat_ar",                 "mc",     0.25, POOL_CORE22),
+    "bigbench_cs_algorithms":           TaskSpec("bigbench_cs_algorithms",           "lm",     0.0,  POOL_CORE22),
+    "bigbench_operators":               TaskSpec("bigbench_operators",               "lm",     0.0,  POOL_CORE22),
+    "bigbench_repeat_copy_logic":       TaskSpec("bigbench_repeat_copy_logic",       "lm",     0.0,  POOL_CORE22),
+    "squad":                            TaskSpec("squad",                            "lm",     0.0,  POOL_CORE22),
+    "coqa":                             TaskSpec("coqa",                             "lm",     0.0,  POOL_CORE22),
+    # boolq's 0.62 is DCLM's majority-class baseline, not the 0.50 you'd
+    # expect from a binary task — boolq has skewed True/False prevalence.
+    "boolq":                            TaskSpec("boolq",                            "mc",     0.62, POOL_CORE22),
+    "bigbench_language_identification": TaskSpec("bigbench_language_identification", "mc",     0.25, POOL_CORE22),
+}
+
+assert set(TASK_SPECS.keys()) == set(DCLM_CORE_22_TASKS), \
+    "TASK_SPECS keys must exactly match DCLM_CORE_22_TASKS"
+
+
+# ----------------------------------------------------------------------------
+# Raw-row → tokenized-example converters
+# ----------------------------------------------------------------------------
+
+# A tokenize callable: text → list of token ids. Caller supplies the actual
+# tokenizer (tiktoken GPT-2 BPE per DCLM convention); we don't import it
+# here so tests can mock it trivially.
+Tokenize = Callable[[str], list[int]]
+
+
+@dataclass(frozen=True)
+class MCRawRow:
+    """A multiple-choice raw row from the DCLM bundle's jsonl."""
+
+    query: str
+    choices: list[str]
+    gold: int
+
+
+@dataclass(frozen=True)
+class SchemaRawRow:
+    """A schema raw row — each variant has its own context/continuation."""
+
+    contexts: list[str]
+    continuations: list[str]
+    gold: int
+
+
+@dataclass(frozen=True)
+class LMRawRow:
+    """A language-modeling raw row.
+
+    `accept_set` is the set of valid completion strings — LAMBADA-style
+    tasks have exactly one accept; some other LM tasks have multiple
+    (e.g., a question with several phrasings of the same answer all
+    counted as correct). Empty set → never-correct (test signal only).
+    """
+
+    context: str
+    target: str
+    accept_set: tuple[str, ...] = ()
+
+
+def make_mc_example(row: MCRawRow, tokenize: Tokenize) -> MCExample:
+    return MCExample(
+        context_ids=tokenize(row.query),
+        choice_ids=[tokenize(c) for c in row.choices],
+        gold=row.gold,
+    )
+
+
+def make_schema_example(row: SchemaRawRow, tokenize: Tokenize) -> SchemaExample:
+    return SchemaExample(
+        context_ids=[tokenize(c) for c in row.contexts],
+        continuation_ids=[tokenize(c) for c in row.continuations],
+        gold=row.gold,
+    )
+
+
+def make_lm_example(row: LMRawRow, tokenize: Tokenize) -> LMExample:
+    return LMExample(
+        context_ids=tokenize(row.context),
+        target_ids=tokenize(row.target),
+    )
+
+
+# ----------------------------------------------------------------------------
+# Per-task evaluators
+# ----------------------------------------------------------------------------
+
+
+def evaluate_mc_task(
+    forward_logits: Callable,
+    examples: list[MCExample],
+    *,
+    length_normalize: bool = True,
+) -> tuple[float, int]:
+    """Run score_mc on `examples` and return (accuracy, n_examples).
+
+    Accuracy = fraction of examples where the predicted choice index
+    equals the gold index. Returns (0.0, 0) on an empty list (no
+    division-by-zero; the caller's aggregator handles the empty cell).
+    """
+    if not examples:
+        return 0.0, 0
+    preds = score_mc(forward_logits, examples, length_normalize=length_normalize)
+    correct = sum(1 for p, ex in zip(preds, examples) if p == ex.gold)
+    return correct / len(examples), len(examples)
+
+
+def evaluate_schema_task(
+    forward_logits: Callable,
+    examples: list[SchemaExample],
+) -> tuple[float, int]:
+    if not examples:
+        return 0.0, 0
+    preds = score_schema(forward_logits, examples)
+    correct = sum(1 for p, ex in zip(preds, examples) if p == ex.gold)
+    return correct / len(examples), len(examples)
+
+
+def evaluate_lm_task_lambada(
+    forward_logits: Callable,
+    examples: list[LMExample],
+) -> tuple[float, int]:
+    """Score an LM task using LAMBADA-style "is the gold target the most
+    likely continuation" accuracy.
+
+    For each example the per-token NLL of the target is the only signal.
+    For LAMBADA-style scoring we don't have distractors here; this is the
+    simplest LM-accuracy proxy and the same one DCLM uses for
+    `lambada_openai`. Tasks that need different accuracy logic (e.g.
+    SQuAD F1, CoQA bytes-per-byte) will get their own evaluators wired
+    by the runner.
+
+    Returns (mean target NLL in nats, n_examples). The Pareto kernel
+    treats LM cells as `:bpb`-suffixed (lower is better); the bpb
+    conversion happens at the report-assembly layer where bytes-per-token
+    is known.
+    """
+    if not examples:
+        return 0.0, 0
+    nlls = score_lm(forward_logits, examples)
+    return sum(nlls) / len(nlls), len(nlls)
+
+
+# ----------------------------------------------------------------------------
+# CellResult builder
+# ----------------------------------------------------------------------------
+
+
+def to_cell_result(
+    task_name: str,
+    accuracy: float,
+    n_examples: int,
+    *,
+    scale: str = "S3",
+    seed: int = 0,
+) -> CellResult:
+    """Wrap a (accuracy, n) measurement as a CellResult keyed for the
+    aggregate kernel.
+
+    The Pareto kernel keys cells by `{task_name}:{scale}` for downstream
+    accuracy cells, or `{task_name}:bpb` for val_bpb cells (lower-is-better
+    direction-flip via BPB_SUFFIX). This helper produces the accuracy form;
+    LM tasks that the runner converts to BPB pass the bpb value as
+    `accuracy` and the cell key gets the `:bpb` suffix at a higher layer.
+    """
+    if task_name not in TASK_SPECS:
+        raise ValueError(
+            f"unknown task {task_name!r}; not in DCLM_CORE_22_TASKS"
+        )
+    return CellResult(
+        task=task_name,
+        accuracy=accuracy,
+        accuracy_stderr=0.0,  # B1: deterministic eval, single-seed
+        n_examples=n_examples,
+        seed=seed,
+    )
+
+
+# ----------------------------------------------------------------------------
+# Bundle loader — stub until B1-D2 SHA pin lands
+# ----------------------------------------------------------------------------
+
+
+def load_task_examples(bundle_dir, task_name: str):
+    """Load raw rows for a task from the DCLM bundle.
+
+    NOT IMPLEMENTED in this commit. The bundle layout follows DCLM's
+    `eval_bundle/<task_name>.jsonl` convention with per-task schemas
+    that the runner.py author will parse.
+
+    Until the bundle SHA is pinned (B1-D2), this raises a clear error
+    pointing at the protocol the first downloader commit must follow.
+    Callers that test against fixture data can use
+    `make_mc_example` / `make_schema_example` / `make_lm_example`
+    directly without going through this loader.
+    """
+    raise NotImplementedError(
+        f"load_task_examples({task_name!r}) is not implemented in B1 "
+        "foundation. The first commit that downloads the bundle from "
+        f"{DCLM_EVAL_BUNDLE_URL} must (1) compute its SHA256, (2) update "
+        "DCLM_EVAL_BUNDLE_SHA256 in this module, (3) implement this "
+        "loader to parse <bundle_dir>/<task_name>.jsonl, and (4) add "
+        "tests/test_downstream_core22_bundle.py with one task driven "
+        "end-to-end against the real bundle. See eval/downstream/DEFERRED.md "
+        "items B1-D2 / B1-D13 / B1-D8 for the protocol."
+    )

--- a/tests/test_downstream_core22.py
+++ b/tests/test_downstream_core22.py
@@ -1,0 +1,364 @@
+"""Tests for the CORE-22 task registry + per-task evaluators (B1).
+
+Pins the 22-task list verbatim against DCLM's `low_variance_datasets`,
+verifies the per-task TaskSpec metadata (mode + random_baseline) matches
+DCLM's eval_meta_data.csv, exercises the per-task evaluators with
+synthetic logits, and confirms the bundle-loader stub raises a clear
+error pointing at the B1-D2 protocol.
+"""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from eval.downstream import (
+    POOL_CORE22,
+    CellResult,
+    LMExample,
+    MCExample,
+    SchemaExample,
+)
+from eval.downstream.core22 import (
+    DCLM_CORE_22_TASKS,
+    DCLM_EVAL_BUNDLE_SHA256,
+    DCLM_EVAL_BUNDLE_URL,
+    TASK_SPECS,
+    LMRawRow,
+    MCRawRow,
+    SchemaRawRow,
+    evaluate_lm_task_lambada,
+    evaluate_mc_task,
+    evaluate_schema_task,
+    load_task_examples,
+    make_lm_example,
+    make_mc_example,
+    make_schema_example,
+    to_cell_result,
+)
+
+# ----------------------------------------------------------------------------
+# Pinned constants
+# ----------------------------------------------------------------------------
+
+
+def test_dclm_core_22_count():
+    """Exactly 22 tasks. Pinned by DCLM's low_variance_datasets list +
+    Karpathy's nanochat #420 confirmation. Bumping this number requires a
+    matching change in DEFERRED.md B1-D3."""
+    assert len(DCLM_CORE_22_TASKS) == 22
+
+
+def test_dclm_core_22_verbatim_order():
+    """Order preserved from DCLM source. If DCLM rotates the order, a
+    future PR must update both this list and the TASK_SPECS dict so
+    cross-references stay byte-equal."""
+    expected = (
+        "hellaswag_zeroshot",
+        "jeopardy",
+        "bigbench_qa_wikidata",
+        "arc_easy",
+        "arc_challenge",
+        "copa",
+        "commonsense_qa",
+        "piqa",
+        "openbook_qa",
+        "lambada_openai",
+        "hellaswag",
+        "winograd",
+        "winogrande",
+        "bigbench_dyck_languages",
+        "agi_eval_lsat_ar",
+        "bigbench_cs_algorithms",
+        "bigbench_operators",
+        "bigbench_repeat_copy_logic",
+        "squad",
+        "coqa",
+        "boolq",
+        "bigbench_language_identification",
+    )
+    assert DCLM_CORE_22_TASKS == expected
+
+
+def test_bigbench_language_identification_included():
+    """B1-D3 explicitly settled the 22-vs-23 question. The
+    bigbench_language_identification task is IN the CORE-22 list."""
+    assert "bigbench_language_identification" in DCLM_CORE_22_TASKS
+
+
+def test_eval_bundle_url_pinned():
+    """The bundle source URL is pinned per B1-D2 from nanochat's
+    EVAL_BUNDLE_URL constant. Karpathy's personal S3 hosting means the
+    bundle CAN rotate without notice; the SHA pin (below) is the guard."""
+    assert DCLM_EVAL_BUNDLE_URL == (
+        "https://karpathy-public.s3.us-west-2.amazonaws.com/eval_bundle.zip"
+    )
+
+
+def test_eval_bundle_sha_is_unset_until_download():
+    """SHA pin is None at B1 foundation; the first commit that downloads
+    the bundle MUST update it (and add a re-hash test against the local
+    mirror) per the B1-D2 protocol."""
+    assert DCLM_EVAL_BUNDLE_SHA256 is None
+
+
+# ----------------------------------------------------------------------------
+# TASK_SPECS — mode + pool + random_baseline are all correct
+# ----------------------------------------------------------------------------
+
+
+def test_task_specs_keys_match_task_list():
+    """Every task in DCLM_CORE_22_TASKS has a TaskSpec; no extras."""
+    assert set(TASK_SPECS.keys()) == set(DCLM_CORE_22_TASKS)
+
+
+def test_task_specs_all_in_core22_pool():
+    """Every CORE-22 TaskSpec belongs to the CORE-22 pool."""
+    for spec in TASK_SPECS.values():
+        assert spec.pool == POOL_CORE22
+
+
+def test_task_specs_valid_modes():
+    """Every TaskSpec mode is one of mc / schema / lm (TaskSpec's own
+    __post_init__ would have caught anything else; the test pins the
+    invariant explicitly)."""
+    for spec in TASK_SPECS.values():
+        assert spec.mode in ("mc", "schema", "lm")
+
+
+def test_task_specs_known_mode_assignments():
+    """Spot-check the mode assignments against DCLM's eval_meta_data.csv:
+    multiple_choice → "mc", schema → "schema", language_modeling → "lm"."""
+    assert TASK_SPECS["winograd"].mode == "schema"
+    assert TASK_SPECS["winogrande"].mode == "schema"
+    assert TASK_SPECS["arc_easy"].mode == "mc"
+    assert TASK_SPECS["arc_challenge"].mode == "mc"
+    assert TASK_SPECS["lambada_openai"].mode == "lm"
+    assert TASK_SPECS["jeopardy"].mode == "lm"
+    assert TASK_SPECS["squad"].mode == "lm"
+    assert TASK_SPECS["coqa"].mode == "lm"
+    assert TASK_SPECS["copa"].mode == "mc"  # DCLM labels copa as MC
+    assert TASK_SPECS["boolq"].mode == "mc"
+    assert TASK_SPECS["bigbench_language_identification"].mode == "mc"
+
+
+def test_task_specs_random_baselines_are_fractions():
+    """Random baselines are stored as fractions in [0, 1]. DCLM's CSV
+    reports them as percents; the registry MUST convert."""
+    for spec in TASK_SPECS.values():
+        assert 0.0 <= spec.random_baseline <= 1.0, (
+            f"{spec.name} baseline {spec.random_baseline} out of [0,1]"
+        )
+
+
+def test_task_specs_known_baselines():
+    """Spot-check baselines against DCLM's eval_meta_data.csv."""
+    assert TASK_SPECS["hellaswag_zeroshot"].random_baseline == 0.25
+    assert TASK_SPECS["arc_easy"].random_baseline == 0.25
+    assert TASK_SPECS["piqa"].random_baseline == 0.50
+    assert TASK_SPECS["winogrande"].random_baseline == 0.50
+    assert TASK_SPECS["boolq"].random_baseline == 0.62  # majority-class baseline
+    assert TASK_SPECS["lambada_openai"].random_baseline == 0.0
+    assert TASK_SPECS["commonsense_qa"].random_baseline == pytest.approx(0.403)
+
+
+# ----------------------------------------------------------------------------
+# Raw-row → Example conversion
+# ----------------------------------------------------------------------------
+
+
+def _char_tokenize(text: str) -> list[int]:
+    """Trivial deterministic tokenizer for tests: each character → its ord."""
+    return [ord(c) for c in text]
+
+
+def test_make_mc_example_round_trip():
+    row = MCRawRow(query="Q?", choices=["a", "bb", "ccc"], gold=1)
+    ex = make_mc_example(row, _char_tokenize)
+    assert ex.context_ids == [ord("Q"), ord("?")]
+    assert ex.choice_ids == [[ord("a")], [ord("b"), ord("b")], [ord("c"), ord("c"), ord("c")]]
+    assert ex.gold == 1
+
+
+def test_make_schema_example_round_trip():
+    row = SchemaRawRow(
+        contexts=["one", "two"],
+        continuations=["x", "yy"],
+        gold=0,
+    )
+    ex = make_schema_example(row, _char_tokenize)
+    assert ex.context_ids == [[ord("o"), ord("n"), ord("e")], [ord("t"), ord("w"), ord("o")]]
+    assert ex.continuation_ids == [[ord("x")], [ord("y"), ord("y")]]
+    assert ex.gold == 0
+
+
+def test_make_lm_example_round_trip():
+    row = LMRawRow(context="abc", target="d")
+    ex = make_lm_example(row, _char_tokenize)
+    assert ex.context_ids == [ord("a"), ord("b"), ord("c")]
+    assert ex.target_ids == [ord("d")]
+
+
+# ----------------------------------------------------------------------------
+# evaluate_mc_task / evaluate_schema_task / evaluate_lm_task_lambada
+# ----------------------------------------------------------------------------
+
+
+VOCAB = 16
+
+
+def _uniform_forward(input_ids: torch.Tensor) -> torch.Tensor:
+    """Returns uniform logits of shape (1, T, V) for any input."""
+    return torch.zeros((1, input_ids.size(1), VOCAB))
+
+
+def _favor_token_forward(token: int, position: int):
+    """Returns a forward fn that boosts `token` at `position` in the
+    log-softmax — used to deterministically pick a specific choice."""
+
+    def fwd(input_ids: torch.Tensor) -> torch.Tensor:
+        T = input_ids.size(1)
+        logits = torch.zeros((1, T, VOCAB))
+        if 0 <= position < T:
+            logits[0, position, token] = 10.0
+        return logits
+
+    return fwd
+
+
+def test_evaluate_mc_task_empty_returns_zero():
+    """Empty example list → (0.0, 0). No division-by-zero."""
+    acc, n = evaluate_mc_task(_uniform_forward, [])
+    assert acc == 0.0
+    assert n == 0
+
+
+def test_evaluate_mc_task_uniform_logits_picks_choice_zero():
+    """All choices tied → argmax tie-break picks index 0 → only the
+    examples with gold==0 are 'correct'."""
+    examples = [
+        MCExample(context_ids=[1], choice_ids=[[2], [3]], gold=0),
+        MCExample(context_ids=[4], choice_ids=[[5], [6]], gold=1),
+        MCExample(context_ids=[7], choice_ids=[[8], [9]], gold=0),
+    ]
+    acc, n = evaluate_mc_task(_uniform_forward, examples)
+    # All examples score uniform → choice 0 wins → 2 of 3 correct
+    assert acc == pytest.approx(2 / 3)
+    assert n == 3
+
+
+def test_evaluate_mc_task_perfect_accuracy():
+    """When the forward function favors EXACTLY the gold-choice input
+    (not just any choice), accuracy is 1.0."""
+    # 2 examples each with 2 choices. Gold continuation tokens are 5 and 11.
+    examples = [
+        MCExample(context_ids=[1], choice_ids=[[2], [5]], gold=1),
+        MCExample(context_ids=[1], choice_ids=[[11], [2]], gold=0),
+    ]
+    # GOLD inputs are [1, 5] (ex0 gold) and [1, 11] (ex1 gold);
+    # WRONG inputs are both [1, 2]. The forward fn only boosts the gold
+    # inputs so the wrong choices score at the uniform-logits baseline.
+    def gold_only_forward(input_ids: torch.Tensor) -> torch.Tensor:
+        ids = tuple(input_ids.flatten().tolist())
+        T = input_ids.size(1)
+        logits = torch.zeros((1, T, VOCAB))
+        if ids == (1, 5):
+            logits[0, 0, 5] = 10.0
+        elif ids == (1, 11):
+            logits[0, 0, 11] = 10.0
+        return logits
+
+    acc, n = evaluate_mc_task(gold_only_forward, examples)
+    assert acc == 1.0
+    assert n == 2
+
+
+def test_evaluate_schema_task_empty():
+    acc, n = evaluate_schema_task(_uniform_forward, [])
+    assert acc == 0.0
+    assert n == 0
+
+
+def test_evaluate_schema_task_picks_higher_logprob_variant():
+    """Schema variants have different (context, continuation) pairs.
+    The forward function favors variant 1's continuation."""
+    ex = SchemaExample(
+        context_ids=[[1, 2], [3, 4]],
+        continuation_ids=[[5], [6]],
+        gold=1,
+    )
+
+    def smart_forward(input_ids: torch.Tensor) -> torch.Tensor:
+        ids = tuple(input_ids.flatten().tolist())
+        T = input_ids.size(1)
+        logits = torch.zeros((1, T, VOCAB))
+        # Boost the variant-1 path: input [3,4,6] gets a sharper logit at pos 1
+        if ids == (3, 4, 6):
+            logits[0, 1, 6] = 8.0
+        return logits
+
+    acc, n = evaluate_schema_task(smart_forward, [ex])
+    assert acc == 1.0
+    assert n == 1
+
+
+def test_evaluate_lm_task_lambada_returns_mean_nll():
+    """For 2 examples with deterministic uniform logits, mean NLL equals
+    per-token-NLL × mean-target-length."""
+    examples = [
+        LMExample(context_ids=[1], target_ids=[2]),       # 1 target token
+        LMExample(context_ids=[1, 2], target_ids=[3, 4]), # 2 target tokens
+    ]
+    mean_nll, n = evaluate_lm_task_lambada(_uniform_forward, examples)
+    # Uniform → per-token NLL = log(VOCAB)
+    # Example 0 NLL = 1 * log(VOCAB); Example 1 NLL = 2 * log(VOCAB)
+    # Mean = 1.5 * log(VOCAB)
+    assert mean_nll == pytest.approx(1.5 * math.log(VOCAB), rel=1e-5)
+    assert n == 2
+
+
+# ----------------------------------------------------------------------------
+# to_cell_result wrapper
+# ----------------------------------------------------------------------------
+
+
+def test_to_cell_result_default_scale_and_seed():
+    cr = to_cell_result("arc_easy", 0.42, 100)
+    assert isinstance(cr, CellResult)
+    assert cr.task == "arc_easy"
+    assert cr.accuracy == 0.42
+    assert cr.n_examples == 100
+    assert cr.accuracy_stderr == 0.0
+    assert cr.seed == 0
+
+
+def test_to_cell_result_custom_scale_seed():
+    cr = to_cell_result("mmlu" if False else "lambada_openai", 0.31, 50, scale="S2", seed=7)
+    assert cr.seed == 7
+
+
+def test_to_cell_result_rejects_unknown_task():
+    with pytest.raises(ValueError, match=r"unknown task"):
+        to_cell_result("not_a_real_task", 0.5, 10)
+
+
+# ----------------------------------------------------------------------------
+# load_task_examples stub
+# ----------------------------------------------------------------------------
+
+
+def test_load_task_examples_raises_not_implemented(tmp_path):
+    """The stub must raise loudly with a clear pointer to the protocol
+    the first downloader commit must follow."""
+    with pytest.raises(NotImplementedError) as exc_info:
+        load_task_examples(tmp_path, "arc_easy")
+    msg = str(exc_info.value)
+    assert "DEFERRED.md" in msg
+    assert "B1-D2" in msg
+    assert DCLM_EVAL_BUNDLE_URL in msg


### PR DESCRIPTION
DCLM CORE-22 task registry pinned verbatim against DCLM's low_variance_datasets aggregation (B1-D3 lock from mlfoundations/dclm/main/eval/additional_aggregation.json). Per-task metadata (mode + random_baseline + pool) sourced verbatim from DCLM's eval/eval_meta_data.csv on 2026-06-10.

What this commit ships:
* DCLM_CORE_22_TASKS — the 22-task name tuple, order preserved from DCLM source so cross-references stay byte-equal
* TASK_SPECS — dict of name -> TaskSpec with mc/schema/lm mode + random baseline as a fraction in [0, 1]. Baselines converted from DCLM's percent representation
* DCLM_EVAL_BUNDLE_URL — pinned from nanochat/scripts/base_eval.py (B1-D2)
* DCLM_EVAL_BUNDLE_SHA256 — None today; the first commit that fetches the bundle MUST update this + add a re-hash test against the local mirror per the B1-D2 protocol
* MCRawRow / SchemaRawRow / LMRawRow + make_mc_example / make_schema_example / make_lm_example — raw-row to scorer.py-typed Example conversion via a tokenize callable
* evaluate_mc_task / evaluate_schema_task / evaluate_lm_task_lambada — per-task drivers that call score_mc / score_schema / score_lm and return (accuracy_or_nll, n_examples). Empty list returns (0.0, 0)
* to_cell_result — wraps a measurement as a CellResult for the aggregate Pareto kernel; rejects unknown task names
* load_task_examples — stub that raises NotImplementedError with a clear pointer to the B1-D2/D13/D8 protocol the first downloader commit must follow

What it intentionally doesn't ship:
* Bundle download + SHA verification — gated on B1-D2 protocol
* Task-specific jsonl parsing — bundle layout not yet inspected
* runner.py subprocess orchestration — separate B1 commit
* Per-task accuracy-from-NLL logic for LM tasks beyond LAMBADA-style — runner.py per-task layer

Tests (24 new, 221 → 245 total): pin the task count + verbatim order, metadata mode/pool/baseline assignments, raw-row to Example conversion round-trips, evaluate_mc/schema/lm_task happy paths + empty inputs, to_cell_result success + reject-unknown-task, and the load_task_examples stub raises with B1-D2 / DEFERRED.md references in the error message.

All green. ruff clean.