### PR TITLE
eval/downstream/private_hard.py: 4-task private hardness subset + HrdnessIndex contract

### DIFF
--- a/eval/downstream/private_hard.py
+++ b/eval/downstream/private_hard.py
@@ -1,0 +1,301 @@
+"""Private hardness-graded subset (B1).
+
+The 4-task private subset that scores submissions at the S₃ rung alongside
+the public CORE-22 (see core22.py). The subset's purpose is twofold:
+
+  1. Hold a slice of the eval surface PRIVATE so a miner cannot trivially
+     overfit to the public bundle's contents.
+  2. Focus on the HIGH-DIFFICULTY tail of each task — the items where
+     models near the 124M-param coordination point separate the most.
+
+The 4 tasks are pinned at:
+
+  * ARC-Challenge bottom-quintile — `allenai/ai2_arc` config `ARC-Challenge`,
+    retain the 20% of val items with the smallest gold_margin (per a
+    grader.py reference-model pre-pass).
+  * winogrande — `allenai/winogrande` config `winogrande_xl`. Schema mode.
+  * tinyARC — `tinyBenchmarks/tinyARC` (or constructed from `ai2_arc` if
+    the tinyBenchmarks distribution does not ship it; verified at B1 start).
+  * tinyMMLU — `tinyBenchmarks/tinyMMLU`, all 14 task subsets, scored via
+    the IRT++ projection to full-MMLU rank.
+
+Provenance of this 4-task set: `docs/license/hardness_subset_decision.md`
+(2026-06-10 decision; closed B1-D1, pre-swap of OpenBookQA + SciQ which
+were CC-BY-NC and therefore incompatible with the protocol's commercial
+emission use). Per B1-D11, this subset is bundled into Karpa's eval
+surface but is NOT yet part of the attested container measurement — the
+container bump is a mainnet-activation deliverable, not B1's.
+
+What this commit ships:
+
+  * PRIVATE_HARD_TASKS — the 4-task name tuple.
+  * PRIVATE_HARD_TASK_SPECS — mode/baseline/pool dict matching core22.py
+    conventions.
+  * HF_DATASET_IDS — the HuggingFace dataset identifiers each task pulls
+    from.
+  * HardnessIndexRow / HardnessIndex — the contract grader.py emits and
+    private_hard.py consumes for the bottom-quintile selection.
+  * select_hardness_subset(rows, index, task_name) — deterministic filter
+    that keeps only the rows whose item_id appears in the index.
+  * evaluate_private_hard_task — per-task driver wrapping evaluate_mc_task
+    / evaluate_schema_task with the hardness filter applied first.
+  * load_task_examples — stub that raises NotImplementedError pointing at
+    the protocol the first downloader commit must follow.
+
+What this commit does NOT ship:
+
+  * HuggingFace dataset download + caching — gated on the runner's HF
+    auth posture and the per-task split/configuration parsing.
+  * Hardness-graded item construction (grader.py) — separate B1 module.
+  * tinyMMLU IRT++ projection — defers to the tinyBenchmarks package,
+    pulled in by the runner.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from .core22 import (
+    LMRawRow,
+    MCRawRow,
+    SchemaRawRow,
+    evaluate_mc_task,
+    evaluate_schema_task,
+    make_mc_example,
+    make_schema_example,
+)
+from .types import (
+    POOL_PRIVATE_HARD,
+    CellResult,
+    TaskSpec,
+)
+
+# ----------------------------------------------------------------------------
+# Task registry (per docs/license/hardness_subset_decision.md)
+# ----------------------------------------------------------------------------
+
+PRIVATE_HARD_TASKS: tuple[str, ...] = (
+    "arc_challenge_hard",
+    "winogrande_hard",
+    "tiny_arc",
+    "tiny_mmlu",
+)
+"""The 4 tasks in the private hardness subset, in canonical Karpa order.
+
+Suffix conventions: `_hard` for bottom-quintile-by-margin filters of
+public datasets; `tiny_*` for the tinyBenchmarks-curated IRT++ subsets
+(which are themselves already hardness-graded by their construction).
+"""
+
+assert len(PRIVATE_HARD_TASKS) == 4, "private hardness subset must be exactly 4 tasks"
+
+
+PRIVATE_HARD_TASK_SPECS: dict[str, TaskSpec] = {
+    "arc_challenge_hard": TaskSpec("arc_challenge_hard", "mc",     0.25, POOL_PRIVATE_HARD),
+    "winogrande_hard":    TaskSpec("winogrande_hard",    "schema", 0.50, POOL_PRIVATE_HARD),
+    "tiny_arc":           TaskSpec("tiny_arc",           "mc",     0.25, POOL_PRIVATE_HARD),
+    "tiny_mmlu":          TaskSpec("tiny_mmlu",          "mc",     0.25, POOL_PRIVATE_HARD),
+}
+
+assert set(PRIVATE_HARD_TASK_SPECS.keys()) == set(PRIVATE_HARD_TASKS)
+
+
+HF_DATASET_IDS: dict[str, tuple[str, str | None]] = {
+    "arc_challenge_hard": ("allenai/ai2_arc",            "ARC-Challenge"),
+    "winogrande_hard":    ("allenai/winogrande",         "winogrande_xl"),
+    "tiny_arc":           ("tinyBenchmarks/tinyArc",     None),
+    "tiny_mmlu":          ("tinyBenchmarks/tinyMMLU",    None),
+}
+"""HuggingFace dataset identifiers per task: `(repo_id, config)`.
+
+`config` is `None` for datasets whose default config we accept (the tiny*
+sets ship a single config each). The runner.py author confirms the exact
+identifiers at B1 start (HF repos rotate occasionally; pin by SHA if a
+stable version is required) and adds a `test_hf_dataset_ids_resolve`
+test against a frozen HF Hub snapshot.
+"""
+
+assert set(HF_DATASET_IDS.keys()) == set(PRIVATE_HARD_TASKS), \
+    "every private-hard task must have an HF dataset identifier"
+
+
+# ----------------------------------------------------------------------------
+# HardnessIndex — the contract grader.py emits, this module consumes
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HardnessIndexRow:
+    """One row in the hardness index `parquet` grader.py produces.
+
+    `gold_margin_bits` is `log_p(gold) - max_{d != gold} log_p(d)` under a
+    fixed reference model (a 50M-param Karpa baseline run once at
+    calibration time). Smaller margin → harder item; the bottom 20% by
+    margin are selected as the hardness subset.
+
+    For tinyBenchmarks tasks the parquet still ships row-per-item but the
+    margin column is informational only — the tinyBenchmarks set is
+    already hardness-curated externally via IRT++.
+    """
+
+    dataset: str        # one of PRIVATE_HARD_TASKS
+    item_id: str        # the upstream HF dataset's identifier for the row
+    gold_margin_bits: float
+
+
+@dataclass(frozen=True)
+class HardnessIndex:
+    """The full index — emitted once by grader.py, consumed by this module.
+
+    Stored on disk as `eval/private/hardness/index.parquet` (gitignored).
+    The `version` field bumps every time grader.py regenerates against a
+    new reference checkpoint or with a new bottom-quintile rule; the
+    runner records this version into the DownstreamReport so a future
+    auditor can replay the selection deterministically.
+    """
+
+    version: str
+    rows: list[HardnessIndexRow] = field(default_factory=list)
+
+    def for_task(self, task_name: str) -> set[str]:
+        """Return the set of item_ids that belong to the bottom-quintile
+        filter for the given task. Empty set if the task is unknown or
+        absent from the index."""
+        return {r.item_id for r in self.rows if r.dataset == task_name}
+
+
+# ----------------------------------------------------------------------------
+# Hardness selection
+# ----------------------------------------------------------------------------
+
+
+def select_hardness_subset(
+    rows: list[tuple[str, MCRawRow | SchemaRawRow | LMRawRow]],
+    index: HardnessIndex,
+    task_name: str,
+) -> list[MCRawRow | SchemaRawRow | LMRawRow]:
+    """Keep only the rows whose item_id is in the index for `task_name`.
+
+    `rows` is a list of `(item_id, raw_row)` tuples. The loader supplies the
+    item_id from the upstream HF dataset (e.g., ARC's `id` column); the
+    grader_index marks which item_ids belong to the bottom-quintile.
+
+    Returns the raw_row objects in the same order they appeared in `rows`
+    (stable, deterministic). Empty input → empty output (no error).
+    """
+    accept = index.for_task(task_name)
+    if not accept:
+        return []
+    return [raw for item_id, raw in rows if item_id in accept]
+
+
+# ----------------------------------------------------------------------------
+# Per-task evaluator
+# ----------------------------------------------------------------------------
+
+Tokenize = Callable[[str], list[int]]
+
+
+def evaluate_private_hard_task(
+    forward_logits: Callable,
+    raw_rows: list[tuple[str, MCRawRow | SchemaRawRow | LMRawRow]],
+    index: HardnessIndex,
+    task_name: str,
+    tokenize: Tokenize,
+    *,
+    length_normalize: bool = True,
+) -> tuple[float, int]:
+    """Apply the hardness filter, tokenize, dispatch to the right scorer.
+
+    Returns (accuracy, n_examples_after_filter). If the index is empty for
+    this task or the filter leaves zero rows, returns (0.0, 0) — the
+    aggregator treats an empty cell as a no-data sentinel rather than a
+    legitimate zero accuracy.
+    """
+    if task_name not in PRIVATE_HARD_TASK_SPECS:
+        raise ValueError(f"unknown private-hard task {task_name!r}")
+
+    spec = PRIVATE_HARD_TASK_SPECS[task_name]
+    filtered = select_hardness_subset(raw_rows, index, task_name)
+    if not filtered:
+        return 0.0, 0
+
+    if spec.mode == "mc":
+        examples = [make_mc_example(r, tokenize) for r in filtered if isinstance(r, MCRawRow)]
+        return evaluate_mc_task(forward_logits, examples, length_normalize=length_normalize)
+    elif spec.mode == "schema":
+        examples = [make_schema_example(r, tokenize) for r in filtered if isinstance(r, SchemaRawRow)]
+        return evaluate_schema_task(forward_logits, examples)
+    else:
+        # LM mode is reserved — no current private-hard task uses it. If a
+        # future task lands as LM mode, plug make_lm_example +
+        # evaluate_lm_task_lambada here.
+        raise NotImplementedError(
+            f"LM mode not yet supported in private_hard.py; task={task_name}"
+        )
+
+
+def to_private_hard_cell_result(
+    task_name: str,
+    accuracy: float,
+    n_examples: int,
+    *,
+    scale: str = "S3",  # noqa: ARG001 — accepted for symmetry with to_cell_result
+    seed: int = 0,
+) -> CellResult:
+    """Wrap a private-hard task measurement as a CellResult.
+
+    Validates against PRIVATE_HARD_TASK_SPECS specifically (not the
+    union of core22 + private_hard) so a task name typo doesn't silently
+    misroute through the wrong pool. The Pareto kernel reads `cell.task`
+    to look up the noise floor; the pool selection is implicit in the
+    cell-key suffix the runner constructs (`{task_name}:S3` for
+    accuracy cells; `:bpb` reserved for val_bpb carriers).
+    """
+    if task_name not in PRIVATE_HARD_TASK_SPECS:
+        raise ValueError(
+            f"unknown private-hard task {task_name!r}; "
+            f"expected one of {sorted(PRIVATE_HARD_TASKS)}"
+        )
+    return CellResult(
+        task=task_name,
+        accuracy=accuracy,
+        accuracy_stderr=0.0,
+        n_examples=n_examples,
+        seed=seed,
+    )
+
+
+# ----------------------------------------------------------------------------
+# Bundle / dataset loader — stub
+# ----------------------------------------------------------------------------
+
+
+def load_task_examples(task_name: str):
+    """Load raw rows for a private-hard task from HuggingFace Hub.
+
+    NOT IMPLEMENTED in this commit. The first commit that wires the HF
+    download must:
+
+      1. Verify each HF dataset's license matches the v0.10 commercial
+         posture (B1-D1 closed: tinyBenchmarks=MIT, ai2_arc=CC-BY-SA-4.0,
+         winogrande=CC-BY-4.0).
+      2. Cache datasets locally under
+         `eval/private/downstream_pool/private_hard/<task>/`.
+      3. Pin a SHA of the cached snapshot in this module so silent HF Hub
+         rotations are caught at load time.
+      4. Implement per-task parsing into MCRawRow / SchemaRawRow rows
+         keyed by the upstream `id` column.
+      5. Add tests/test_downstream_private_hard_loader.py with one task
+         driven end-to-end against the real dataset.
+
+    Until then this stub raises a clear error. Callers that test against
+    fixture rows can bypass this loader and pass `(item_id, raw_row)`
+    tuples directly to `evaluate_private_hard_task`.
+    """
+    raise NotImplementedError(
+        f"load_task_examples({task_name!r}) is not implemented in B1 "
+        "foundation. The first commit that downloads HF datasets must "
+        "follow the protocol in eval/downstream/private_hard.py docstring + "
+        "DEFERRED.md items B1-D1 / B1-D4 / B1-D8."
+    )

--- a/tests/test_downstream_private_hard.py
+++ b/tests/test_downstream_private_hard.py
@@ -1,0 +1,320 @@
+"""Tests for the private hardness subset (B1).
+
+Pins the 4-task registry, the HF dataset identifiers, the HardnessIndex
+contract, the bottom-quintile selection logic, and the per-task evaluator
+dispatch. Covers the loader stub's NotImplementedError + the
+to_private_hard_cell_result wrapper.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from eval.downstream import (
+    POOL_PRIVATE_HARD,
+    CellResult,
+)
+from eval.downstream.core22 import (
+    MCRawRow,
+    SchemaRawRow,
+)
+from eval.downstream.private_hard import (
+    HF_DATASET_IDS,
+    PRIVATE_HARD_TASK_SPECS,
+    PRIVATE_HARD_TASKS,
+    HardnessIndex,
+    HardnessIndexRow,
+    evaluate_private_hard_task,
+    load_task_examples,
+    select_hardness_subset,
+    to_private_hard_cell_result,
+)
+
+# ----------------------------------------------------------------------------
+# Pinned registry
+# ----------------------------------------------------------------------------
+
+
+def test_private_hard_task_count():
+    """Exactly 4 tasks, per docs/license/hardness_subset_decision.md."""
+    assert len(PRIVATE_HARD_TASKS) == 4
+
+
+def test_private_hard_task_names_pinned():
+    """Names locked to the license decision's pool."""
+    assert PRIVATE_HARD_TASKS == (
+        "arc_challenge_hard",
+        "winogrande_hard",
+        "tiny_arc",
+        "tiny_mmlu",
+    )
+
+
+def test_private_hard_no_openbookqa():
+    """OpenBookQA pre-swapped out (CC-BY-NC-SA-4.0 incompatible with
+    Karpa's commercial emission use)."""
+    assert "openbook_qa" not in PRIVATE_HARD_TASKS
+    assert "openbookqa" not in PRIVATE_HARD_TASKS
+
+
+def test_private_hard_no_sciq():
+    """SciQ pre-swapped out (CC-BY-NC-3.0)."""
+    assert "sciq" not in PRIVATE_HARD_TASKS
+
+
+# ----------------------------------------------------------------------------
+# TASK_SPECS
+# ----------------------------------------------------------------------------
+
+
+def test_task_specs_keys_match_task_list():
+    assert set(PRIVATE_HARD_TASK_SPECS.keys()) == set(PRIVATE_HARD_TASKS)
+
+
+def test_task_specs_all_in_private_hard_pool():
+    for spec in PRIVATE_HARD_TASK_SPECS.values():
+        assert spec.pool == POOL_PRIVATE_HARD
+
+
+def test_task_specs_modes():
+    """ARC variants + tinyMMLU = mc; winogrande_hard = schema (matches
+    DCLM's winogrande mode in core22)."""
+    assert PRIVATE_HARD_TASK_SPECS["arc_challenge_hard"].mode == "mc"
+    assert PRIVATE_HARD_TASK_SPECS["winogrande_hard"].mode == "schema"
+    assert PRIVATE_HARD_TASK_SPECS["tiny_arc"].mode == "mc"
+    assert PRIVATE_HARD_TASK_SPECS["tiny_mmlu"].mode == "mc"
+
+
+def test_task_specs_random_baselines():
+    """ARC + tinyMMLU baselines = 0.25 (4-choice); winogrande = 0.50
+    (2-choice schema)."""
+    assert PRIVATE_HARD_TASK_SPECS["arc_challenge_hard"].random_baseline == 0.25
+    assert PRIVATE_HARD_TASK_SPECS["winogrande_hard"].random_baseline == 0.50
+    assert PRIVATE_HARD_TASK_SPECS["tiny_arc"].random_baseline == 0.25
+    assert PRIVATE_HARD_TASK_SPECS["tiny_mmlu"].random_baseline == 0.25
+
+
+# ----------------------------------------------------------------------------
+# HF_DATASET_IDS
+# ----------------------------------------------------------------------------
+
+
+def test_hf_dataset_ids_cover_every_task():
+    assert set(HF_DATASET_IDS.keys()) == set(PRIVATE_HARD_TASKS)
+
+
+def test_hf_dataset_ids_pin_canonical_paths():
+    """Pin the exact HF repo IDs the loader will pull from. If HF rotates
+    a repo, this test must be updated in lock-step with the loader."""
+    assert HF_DATASET_IDS["arc_challenge_hard"] == ("allenai/ai2_arc", "ARC-Challenge")
+    assert HF_DATASET_IDS["winogrande_hard"] == ("allenai/winogrande", "winogrande_xl")
+    assert HF_DATASET_IDS["tiny_arc"] == ("tinyBenchmarks/tinyArc", None)
+    assert HF_DATASET_IDS["tiny_mmlu"] == ("tinyBenchmarks/tinyMMLU", None)
+
+
+# ----------------------------------------------------------------------------
+# HardnessIndex + HardnessIndexRow
+# ----------------------------------------------------------------------------
+
+
+def test_hardness_index_default_empty():
+    idx = HardnessIndex(version="v0")
+    assert idx.rows == []
+    assert idx.for_task("arc_challenge_hard") == set()
+
+
+def test_hardness_index_for_task_filters_by_dataset():
+    rows = [
+        HardnessIndexRow(dataset="arc_challenge_hard", item_id="a1", gold_margin_bits=0.5),
+        HardnessIndexRow(dataset="arc_challenge_hard", item_id="a2", gold_margin_bits=0.3),
+        HardnessIndexRow(dataset="winogrande_hard",    item_id="w1", gold_margin_bits=0.2),
+    ]
+    idx = HardnessIndex(version="v1", rows=rows)
+    assert idx.for_task("arc_challenge_hard") == {"a1", "a2"}
+    assert idx.for_task("winogrande_hard") == {"w1"}
+    assert idx.for_task("tiny_arc") == set()
+
+
+def test_hardness_index_version_required():
+    """No default version — every emit MUST carry a version string from
+    grader.py so a future auditor can re-derive the selection."""
+    idx = HardnessIndex(version="grader-v0.0.1-abc123")
+    assert idx.version == "grader-v0.0.1-abc123"
+
+
+# ----------------------------------------------------------------------------
+# select_hardness_subset
+# ----------------------------------------------------------------------------
+
+
+def _mc_rows(items: list[tuple[str, str]]) -> list:
+    """Build (item_id, MCRawRow) pairs from (id, query) tuples."""
+    return [
+        (item_id, MCRawRow(query=q, choices=["a", "b", "c", "d"], gold=0))
+        for item_id, q in items
+    ]
+
+
+def test_select_filters_to_indexed_item_ids():
+    rows = _mc_rows([("a1", "q1"), ("a2", "q2"), ("a3", "q3")])
+    idx = HardnessIndex(
+        version="v1",
+        rows=[
+            HardnessIndexRow(dataset="arc_challenge_hard", item_id="a1", gold_margin_bits=0.1),
+            HardnessIndexRow(dataset="arc_challenge_hard", item_id="a3", gold_margin_bits=0.2),
+        ],
+    )
+    selected = select_hardness_subset(rows, idx, "arc_challenge_hard")
+    assert len(selected) == 2
+    queries = [r.query for r in selected]
+    assert queries == ["q1", "q3"]  # original order preserved
+
+
+def test_select_empty_index_returns_empty():
+    rows = _mc_rows([("a1", "q1")])
+    idx = HardnessIndex(version="v1")
+    assert select_hardness_subset(rows, idx, "arc_challenge_hard") == []
+
+
+def test_select_empty_rows_returns_empty():
+    idx = HardnessIndex(
+        version="v1",
+        rows=[HardnessIndexRow(dataset="arc_challenge_hard", item_id="a1", gold_margin_bits=0.1)],
+    )
+    assert select_hardness_subset([], idx, "arc_challenge_hard") == []
+
+
+def test_select_unknown_task_returns_empty():
+    rows = _mc_rows([("a1", "q1")])
+    idx = HardnessIndex(version="v1", rows=[])
+    assert select_hardness_subset(rows, idx, "not_a_real_task") == []
+
+
+# ----------------------------------------------------------------------------
+# evaluate_private_hard_task
+# ----------------------------------------------------------------------------
+
+
+VOCAB = 256  # Covers ord(c) for all ASCII chars, used by _char_tokenize.
+
+
+def _char_tokenize(text: str) -> list[int]:
+    return [ord(c) for c in text]
+
+
+def _uniform_forward(input_ids: torch.Tensor) -> torch.Tensor:
+    return torch.zeros((1, input_ids.size(1), VOCAB))
+
+
+def test_evaluate_private_hard_task_mc_path():
+    """MC task → routes through evaluate_mc_task. With uniform logits +
+    gold=0 across all examples, accuracy = 1.0 (argmax tie picks index 0)."""
+    rows = _mc_rows([("a1", "q1"), ("a2", "q2"), ("a3", "q3")])
+    idx = HardnessIndex(
+        version="v1",
+        rows=[
+            HardnessIndexRow(dataset="arc_challenge_hard", item_id="a1", gold_margin_bits=0.0),
+            HardnessIndexRow(dataset="arc_challenge_hard", item_id="a2", gold_margin_bits=0.1),
+        ],
+    )
+    acc, n = evaluate_private_hard_task(
+        _uniform_forward, rows, idx, "arc_challenge_hard", _char_tokenize,
+    )
+    assert n == 2
+    # All gold=0, uniform → ties → tie-break picks 0 → all correct
+    assert acc == 1.0
+
+
+def test_evaluate_private_hard_task_schema_path():
+    """Schema task → routes through evaluate_schema_task."""
+    rows = [
+        ("w1", SchemaRawRow(contexts=["a"], continuations=["b"], gold=0)),
+        ("w2", SchemaRawRow(contexts=["c"], continuations=["d"], gold=0)),
+    ]
+    idx = HardnessIndex(
+        version="v1",
+        rows=[
+            HardnessIndexRow(dataset="winogrande_hard", item_id="w1", gold_margin_bits=0.05),
+        ],
+    )
+    acc, n = evaluate_private_hard_task(
+        _uniform_forward, rows, idx, "winogrande_hard", _char_tokenize,
+    )
+    # Only w1 selected. 1 variant → trivially scoring picks 0 → matches gold
+    assert n == 1
+    assert acc == 1.0
+
+
+def test_evaluate_private_hard_task_empty_index_returns_zero():
+    """No index entries for task → filter yields zero rows → (0.0, 0)."""
+    rows = _mc_rows([("a1", "q1")])
+    idx = HardnessIndex(version="v1")
+    acc, n = evaluate_private_hard_task(
+        _uniform_forward, rows, idx, "arc_challenge_hard", _char_tokenize,
+    )
+    assert acc == 0.0
+    assert n == 0
+
+
+def test_evaluate_private_hard_task_rejects_unknown_task():
+    rows = _mc_rows([("a1", "q1")])
+    idx = HardnessIndex(version="v1")
+    with pytest.raises(ValueError, match=r"unknown private-hard task"):
+        evaluate_private_hard_task(
+            _uniform_forward, rows, idx, "not_a_real_task", _char_tokenize,
+        )
+
+
+# ----------------------------------------------------------------------------
+# to_private_hard_cell_result
+# ----------------------------------------------------------------------------
+
+
+def test_to_private_hard_cell_result_happy():
+    cr = to_private_hard_cell_result("tiny_arc", 0.78, 100)
+    assert isinstance(cr, CellResult)
+    assert cr.task == "tiny_arc"
+    assert cr.accuracy == 0.78
+    assert cr.n_examples == 100
+    assert cr.seed == 0
+
+
+def test_to_private_hard_cell_result_rejects_unknown_task():
+    with pytest.raises(ValueError, match=r"unknown private-hard task"):
+        to_private_hard_cell_result("mmlu", 0.5, 10)
+
+
+def test_to_private_hard_cell_result_rejects_core22_task_name():
+    """Even a valid CORE-22 task name gets rejected — pool routing is by
+    name, not by mode. The runner constructs cell keys based on which
+    helper it calls; cross-pool name leakage would silently misroute."""
+    with pytest.raises(ValueError, match=r"unknown private-hard task"):
+        to_private_hard_cell_result("hellaswag", 0.5, 10)
+
+
+# ----------------------------------------------------------------------------
+# load_task_examples stub
+# ----------------------------------------------------------------------------
+
+
+def test_load_task_examples_raises_not_implemented():
+    """Stub raises with a clear pointer to the DEFERRED.md item the first
+    downloader commit must follow."""
+    with pytest.raises(NotImplementedError) as exc_info:
+        load_task_examples("arc_challenge_hard")
+    msg = str(exc_info.value)
+    assert "DEFERRED.md" in msg
+    assert "B1-D1" in msg
+
+
+def test_load_task_examples_message_names_task():
+    """The error message includes the requested task name so a caller
+    can trace which load attempt blew up."""
+    with pytest.raises(NotImplementedError, match=r"tiny_mmlu"):
+        load_task_examples("tiny_mmlu")


### PR DESCRIPTION
The private hardness subset that scores submissions at S₃ alongside CORE-22. Holds part of the eval surface PRIVATE so a miner cannot trivially overfit to the public bundle, and focuses on the high-difficulty tail of each task where 124M-class models separate the most.

What this commit ships:

* PRIVATE_HARD_TASKS — the 4 tasks pinned in docs/license/hardness_subset_decision.md (closed B1-D1 + B1-D4 license review):
    - arc_challenge_hard  (allenai/ai2_arc ARC-Challenge, bottom-quintile by margin)
    - winogrande_hard     (allenai/winogrande winogrande_xl, bottom-quintile)
    - tiny_arc            (tinyBenchmarks/tinyArc, IRT++ curated)
    - tiny_mmlu           (tinyBenchmarks/tinyMMLU, IRT++ curated)
* PRIVATE_HARD_TASK_SPECS — mode/baseline/pool dict matching core22 conventions
* HF_DATASET_IDS — pinned (repo_id, config) per task
* HardnessIndexRow / HardnessIndex — the contract grader.py emits and
  private_hard.py consumes. Each row = (dataset, item_id, gold_margin_bits)
  computed by a 50M reference model run once at calibration time. Bottom-
  quintile-by-margin items become the hardness subset.
* select_hardness_subset(rows, index, task_name) — deterministic filter
  preserving the original row order, returns [] on missing index
* evaluate_private_hard_task — applies the filter then dispatches to
  evaluate_mc_task or evaluate_schema_task based on spec.mode
* to_private_hard_cell_result — wraps a measurement as CellResult,
  rejects unknown task names AND core22 names so cross-pool name leakage
  cannot silently misroute
* load_task_examples — stub raising NotImplementedError with a pointer
  to the protocol the first HF-downloader commit must follow


25 new tests, 245 → 270 total. The 4-task pinning, schema-mode for winogrande (matching DCLM's core22 treatment), HF repo IDs verbatim, HardnessIndex filter + version contract, evaluator MC + schema paths, CellResult wrapper reject-unknown + reject-core22-name-leakage, and the loader stub error message.

All green. ruff clean. One pre-existing multiseed flake in the suite (torch RNG state pollution from another test; passes in isolation) is unrelated.