### PR TITLE
eval/downstream/grader.py: one-shot offline grader + HardnessIndex JSONL round-trip

### DIFF
--- a/eval/downstream/__init__.py
+++ b/eval/downstream/__init__.py
@@ -12,14 +12,16 @@ What B1 has shipped so far:
     algorithm of the new king-selection gate
   * scorer.py: score_mc / score_schema / score_lm kernels (pure functions
     over pre-tokenized examples; model-agnostic via a forward_logits
-    callable)
+    callable) + score_mc_logprobs / score_schema_logprobs for grader
   * core22.py: the 22-task registry + per-task evaluators that wire scorer
     kernels to CellResult outputs. Bundle URL pinned (B1-D2); bundle
     download itself stubbed until the SHA-pin commit.
+  * private_hard.py: the 4-task hardness subset registry + HardnessIndex
+    contract + bottom-quintile filter
+  * grader.py: gold_margin_bits computation + per-task graders +
+    HardnessIndex assembly + JSONL round-trip
 
 What B1 will ship (separate commits within the phase):
-  * private_hard.py: the 4-task private hardness subset adapter
-  * grader.py: one-shot offline grader → eval/private/hardness/index.parquet
   * calibration.py: N=10 baseline runs → noise_floors_v1.json
   * runner.py: subprocess-isolated entrypoint
 
@@ -33,10 +35,35 @@ from .core22 import (
     DCLM_EVAL_BUNDLE_SHA256,
     DCLM_EVAL_BUNDLE_URL,
     TASK_SPECS,
+    LMRawRow,
+    MCRawRow,
+    SchemaRawRow,
     evaluate_lm_task_lambada,
     evaluate_mc_task,
     evaluate_schema_task,
+    make_lm_example,
+    make_mc_example,
+    make_schema_example,
     to_cell_result,
+)
+from .grader import (
+    assemble_hardness_index,
+    compute_bottom_quintile,
+    gold_margin_bits,
+    grade_mc_task,
+    grade_schema_task,
+    read_hardness_index_jsonl,
+    write_hardness_index_jsonl,
+)
+from .private_hard import (
+    HF_DATASET_IDS,
+    PRIVATE_HARD_TASK_SPECS,
+    PRIVATE_HARD_TASKS,
+    HardnessIndex,
+    HardnessIndexRow,
+    evaluate_private_hard_task,
+    select_hardness_subset,
+    to_private_hard_cell_result,
 )
 from .scorer import (
     LMExample,
@@ -44,7 +71,9 @@ from .scorer import (
     SchemaExample,
     score_lm,
     score_mc,
+    score_mc_logprobs,
     score_schema,
+    score_schema_logprobs,
 )
 from .types import (
     BPB_SUFFIX,
@@ -68,23 +97,46 @@ __all__ = [
     "DCLM_EVAL_BUNDLE_URL",
     "DownstreamReport",
     "HARNESS_VERSION",
+    "HF_DATASET_IDS",
+    "HardnessIndex",
+    "HardnessIndexRow",
     "LMExample",
+    "LMRawRow",
     "MCExample",
+    "MCRawRow",
     "NoiseFloorTable",
     "POOL_CORE22",
     "POOL_PRIVATE_HARD",
     "POOL_S2_VAL_BPB",
+    "PRIVATE_HARD_TASKS",
+    "PRIVATE_HARD_TASK_SPECS",
     "ParetoOutcome",
     "ParetoVerdict",
     "SchemaExample",
+    "SchemaRawRow",
     "TASK_SPECS",
     "TaskSpec",
     "aggregate_pareto",
+    "assemble_hardness_index",
+    "compute_bottom_quintile",
     "evaluate_lm_task_lambada",
     "evaluate_mc_task",
+    "evaluate_private_hard_task",
     "evaluate_schema_task",
+    "gold_margin_bits",
+    "grade_mc_task",
+    "grade_schema_task",
+    "make_lm_example",
+    "make_mc_example",
+    "make_schema_example",
+    "read_hardness_index_jsonl",
     "score_lm",
     "score_mc",
+    "score_mc_logprobs",
     "score_schema",
+    "score_schema_logprobs",
+    "select_hardness_subset",
     "to_cell_result",
+    "to_private_hard_cell_result",
+    "write_hardness_index_jsonl",
 ]

--- a/eval/downstream/grader.py
+++ b/eval/downstream/grader.py
@@ -1,0 +1,301 @@
+"""One-shot offline grader for the private hardness subset (B1).
+
+Computes per-item `gold_margin_bits` under a fixed reference model — typically
+a 50M-param Karpa baseline trained once at calibration time. The bottom 20%
+of items by margin become the hardness subset that `private_hard.py`
+consumes via `select_hardness_subset` at scoring time.
+
+This module ships the GRADING + INDEX-ASSEMBLY logic:
+
+  * `gold_margin_bits(choice_logprobs, gold)` — the core scalar.
+    Margin = log_p(gold) − max_{d != gold} log_p(d), converted from nats
+    to bits (divide by log 2). Tasks with a single choice trivially
+    return +∞ (infinitely confident); empty input returns 0.0.
+  * `grade_mc_task` / `grade_schema_task` — per-task drivers that take
+    pre-keyed `(item_id, raw_row)` inputs, tokenize, score, and emit
+    `HardnessIndexRow` per item.
+  * `compute_bottom_quintile(rows, quintile=0.20)` — deterministic sort
+    + slice. Stable across re-runs because Python's sort is stable.
+  * `assemble_hardness_index(per_task, version, *, quintile=0.20)` —
+    combine across tasks, apply the bottom-quintile rule per task,
+    return a `HardnessIndex` ready for `write_hardness_index_jsonl`.
+  * `write_hardness_index_jsonl` / `read_hardness_index_jsonl` — JSONL
+    round-trip. Chosen over parquet for B1 because (a) zero new
+    dependencies (b) human-readable for audit (c) row counts are tiny
+    (~hundreds per task × 4 tasks ≈ few thousand rows total).
+    A parquet upgrade path is recorded in `WRITER_FORMAT` for a future
+    runner.py that needs columnar reads.
+
+This module does NOT ship the reference-model checkpoint or the HF dataset
+download — those are runner.py / calibration.py concerns. Tests drive the
+grader with synthetic logits, which is enough to pin the math, the
+sort-and-slice, the per-task assembly, and the JSONL round-trip.
+
+Reference scope: docs/build_scope/02_scope_B1.md "grader.py".
+"""
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Callable
+from pathlib import Path
+
+from .core22 import (
+    MCRawRow,
+    SchemaRawRow,
+    make_mc_example,
+    make_schema_example,
+)
+from .private_hard import (
+    HardnessIndex,
+    HardnessIndexRow,
+)
+from .scorer import (
+    score_mc_logprobs,
+    score_schema_logprobs,
+)
+
+# JSONL on disk today; switch to parquet via a one-line dispatcher when
+# runner.py needs columnar reads at scale. Bumping this string is the
+# signal that the on-disk format has changed.
+WRITER_FORMAT = "jsonl-v1"
+
+
+# ----------------------------------------------------------------------------
+# Core scalar
+# ----------------------------------------------------------------------------
+
+
+def gold_margin_bits(choice_logprobs: list[float], gold: int) -> float:
+    """Return `log_p(gold) - max_{d != gold} log_p(d)`, in bits.
+
+    Input log-probabilities are in NATS (the scorer's natural-log
+    log_softmax output). Output is in bits via division by `log(2)`.
+
+    Edge cases (each tested in test_downstream_grader.py):
+      * Empty input → 0.0 (the empty argmax convention).
+      * Single choice → +inf (no distractors → infinitely confident).
+      * `gold` out of range → ValueError (caller bug).
+    """
+    if not choice_logprobs:
+        return 0.0
+    if gold < 0 or gold >= len(choice_logprobs):
+        raise ValueError(
+            f"gold={gold} out of range for {len(choice_logprobs)} choices"
+        )
+    if len(choice_logprobs) == 1:
+        return float("inf")
+    gold_lp = choice_logprobs[gold]
+    other_lps = [lp for i, lp in enumerate(choice_logprobs) if i != gold]
+    return (gold_lp - max(other_lps)) / math.log(2)
+
+
+# ----------------------------------------------------------------------------
+# Per-task graders
+# ----------------------------------------------------------------------------
+
+Tokenize = Callable[[str], list[int]]
+
+
+def grade_mc_task(
+    forward_logits: Callable,
+    items: list[tuple[str, MCRawRow]],
+    tokenize: Tokenize,
+    task_name: str,
+    *,
+    length_normalize: bool = True,
+) -> list[HardnessIndexRow]:
+    """Grade every (item_id, MCRawRow) under the reference model.
+
+    Returns one `HardnessIndexRow` per item with `gold_margin_bits`
+    computed as above. Order preserved from input.
+    """
+    if not items:
+        return []
+    examples = [make_mc_example(row, tokenize) for _, row in items]
+    per_choice = score_mc_logprobs(
+        forward_logits, examples, length_normalize=length_normalize,
+    )
+    out: list[HardnessIndexRow] = []
+    for (item_id, row), choice_logprobs in zip(items, per_choice):
+        margin = gold_margin_bits(choice_logprobs, row.gold)
+        out.append(HardnessIndexRow(
+            dataset=task_name, item_id=item_id, gold_margin_bits=margin,
+        ))
+    return out
+
+
+def grade_schema_task(
+    forward_logits: Callable,
+    items: list[tuple[str, SchemaRawRow]],
+    tokenize: Tokenize,
+    task_name: str,
+) -> list[HardnessIndexRow]:
+    """Same as grade_mc_task but for schema rows (winogrande_hard etc.)."""
+    if not items:
+        return []
+    examples = [make_schema_example(row, tokenize) for _, row in items]
+    per_variant = score_schema_logprobs(forward_logits, examples)
+    out: list[HardnessIndexRow] = []
+    for (item_id, row), variant_logprobs in zip(items, per_variant):
+        margin = gold_margin_bits(variant_logprobs, row.gold)
+        out.append(HardnessIndexRow(
+            dataset=task_name, item_id=item_id, gold_margin_bits=margin,
+        ))
+    return out
+
+
+# ----------------------------------------------------------------------------
+# Bottom-quintile selection
+# ----------------------------------------------------------------------------
+
+
+def compute_bottom_quintile(
+    rows: list[HardnessIndexRow],
+    quintile_fraction: float = 0.20,
+) -> list[HardnessIndexRow]:
+    """Return the `quintile_fraction` of rows with the smallest
+    gold_margin_bits values.
+
+    Smaller margin = harder. Sort is stable (Python's Timsort), so two
+    runs with identical inputs produce identical outputs.
+
+    For N input rows, exactly `round(N * quintile_fraction)` are
+    returned — clipped to `[0, N]`. Empty input → empty output. Quintile
+    fraction outside `[0, 1]` raises ValueError.
+
+    The rows are returned in ascending-margin order, NOT in the input
+    order. This makes the hardness subset itself a useful diagnostic:
+    the first row is the hardest item, the last row is the
+    boundary-of-quintile item.
+    """
+    if not 0.0 <= quintile_fraction <= 1.0:
+        raise ValueError(
+            f"quintile_fraction must be in [0, 1]; got {quintile_fraction}"
+        )
+    if not rows:
+        return []
+    n = len(rows)
+    take = round(n * quintile_fraction)
+    take = max(0, min(take, n))
+    return sorted(rows, key=lambda r: r.gold_margin_bits)[:take]
+
+
+# ----------------------------------------------------------------------------
+# Index assembly
+# ----------------------------------------------------------------------------
+
+
+def assemble_hardness_index(
+    per_task_rows: dict[str, list[HardnessIndexRow]],
+    version: str,
+    *,
+    quintile_fraction: float = 0.20,
+) -> HardnessIndex:
+    """Apply the bottom-quintile filter per task, then merge into a single
+    `HardnessIndex`.
+
+    `per_task_rows` is a dict `task_name → all rows graded for that task`.
+    The output index contains only the bottom-quintile rows from each
+    task. Tasks with empty input contribute zero rows.
+
+    Determinism: the merged row order is `(task_name in dict order,
+    margin ascending within task)`. The dict iteration order in Python
+    3.7+ is insertion order, so callers control the merged order by the
+    order they assemble the input dict.
+    """
+    if not version:
+        raise ValueError(
+            "version must be non-empty; grader.py is the only caller, "
+            "supply a grader-vX.Y.Z-<commit-sha> identifier so future "
+            "auditors can replay the index"
+        )
+    merged: list[HardnessIndexRow] = []
+    for task_name, rows in per_task_rows.items():
+        bottom = compute_bottom_quintile(rows, quintile_fraction)
+        # Re-stamp the dataset field if a caller fed in rows from a
+        # different task. The grader emits one task per call; mismatches
+        # here are caller bugs but we silently coerce because the result
+        # is unambiguous given the dict key.
+        for r in bottom:
+            if r.dataset != task_name:
+                r = HardnessIndexRow(
+                    dataset=task_name,
+                    item_id=r.item_id,
+                    gold_margin_bits=r.gold_margin_bits,
+                )
+            merged.append(r)
+    return HardnessIndex(version=version, rows=merged)
+
+
+# ----------------------------------------------------------------------------
+# JSONL I/O
+# ----------------------------------------------------------------------------
+
+
+def write_hardness_index_jsonl(index: HardnessIndex, path: Path) -> None:
+    """Write a `HardnessIndex` to disk as JSONL.
+
+    Line 1 is a header `{"_meta": ..., "version": ..., "format": ...}`.
+    Lines 2..N are one `HardnessIndexRow` per line, encoded as JSON.
+
+    Atomic-write via `path.with_suffix(".tmp")` + rename so a crashed
+    write never leaves a half-written file the runner consumes.
+    """
+    path = Path(path)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tmp.open("w") as f:
+        header = {
+            "_meta": "karpa-hardness-index",
+            "version": index.version,
+            "format": WRITER_FORMAT,
+            "n_rows": len(index.rows),
+        }
+        f.write(json.dumps(header, sort_keys=True) + "\n")
+        for row in index.rows:
+            f.write(json.dumps({
+                "dataset": row.dataset,
+                "item_id": row.item_id,
+                "gold_margin_bits": row.gold_margin_bits,
+            }, sort_keys=True) + "\n")
+    tmp.replace(path)
+
+
+def read_hardness_index_jsonl(path: Path) -> HardnessIndex:
+    """Inverse of `write_hardness_index_jsonl`.
+
+    Raises ValueError if the header is missing / malformed, or if the
+    format string doesn't match WRITER_FORMAT. The format-check exists
+    so a forward-compat parquet writer doesn't get silently consumed by
+    an old JSONL reader.
+    """
+    path = Path(path)
+    text = path.read_text()
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        raise ValueError(f"empty hardness-index file at {path}")
+    try:
+        header = json.loads(lines[0])
+    except json.JSONDecodeError as e:
+        raise ValueError(f"header line is not valid JSON: {e}") from e
+    if header.get("_meta") != "karpa-hardness-index":
+        raise ValueError(
+            f"unexpected _meta marker {header.get('_meta')!r}; "
+            "is this a karpa hardness-index file?"
+        )
+    if header.get("format") != WRITER_FORMAT:
+        raise ValueError(
+            f"format mismatch: file is {header.get('format')!r}, "
+            f"this reader expects {WRITER_FORMAT!r}"
+        )
+    version = header.get("version", "")
+    rows: list[HardnessIndexRow] = []
+    for ln in lines[1:]:
+        d = json.loads(ln)
+        rows.append(HardnessIndexRow(
+            dataset=d["dataset"],
+            item_id=d["item_id"],
+            gold_margin_bits=float(d["gold_margin_bits"]),
+        ))
+    return HardnessIndex(version=version, rows=rows)

--- a/eval/downstream/scorer.py
+++ b/eval/downstream/scorer.py
@@ -253,6 +253,46 @@ def score_schema(
     return predictions
 
 
+def score_mc_logprobs(
+    forward_logits: Callable[[torch.Tensor], torch.Tensor],
+    examples: list[MCExample],
+    *,
+    length_normalize: bool = True,
+) -> list[list[float]]:
+    """Like score_mc but returns the per-choice log-probabilities instead
+    of the argmax index.
+
+    Used by grader.py to compute `gold_margin_bits = log_p(gold) -
+    max_{d != gold} log_p(d)` per example. Inner lists are in choice
+    order; lengths match `examples[i].choice_ids` lengths.
+    """
+    result: list[list[float]] = []
+    for ex in examples:
+        scores: list[float] = []
+        for choice_ids in ex.choice_ids:
+            lp = _logprob_of_continuation(forward_logits, ex.context_ids, choice_ids)
+            if length_normalize and len(choice_ids) > 0:
+                lp = lp / len(choice_ids)
+            scores.append(lp)
+        result.append(scores)
+    return result
+
+
+def score_schema_logprobs(
+    forward_logits: Callable[[torch.Tensor], torch.Tensor],
+    examples: list[SchemaExample],
+) -> list[list[float]]:
+    """Like score_schema but returns per-variant log-probabilities instead
+    of the argmax index. Symmetric to score_mc_logprobs; used by grader.py."""
+    result: list[list[float]] = []
+    for ex in examples:
+        scores: list[float] = []
+        for ctx, cont in zip(ex.context_ids, ex.continuation_ids):
+            scores.append(_logprob_of_continuation(forward_logits, ctx, cont))
+        result.append(scores)
+    return result
+
+
 def score_lm(
     forward_logits: Callable[[torch.Tensor], torch.Tensor],
     examples: list[LMExample],

--- a/tests/test_downstream_grader.py
+++ b/tests/test_downstream_grader.py
@@ -1,0 +1,358 @@
+"""Tests for grader.py — gold-margin computation, bottom-quintile selection,
+index assembly, and JSONL round-trip.
+
+20-ish cases cover the math (margin sign, unit conversion, edge cases),
+the deterministic sort+slice, the index merge, and the JSONL header
++ format-mismatch rejection.
+"""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from eval.downstream.core22 import (
+    MCRawRow,
+    SchemaRawRow,
+)
+from eval.downstream.grader import (
+    WRITER_FORMAT,
+    assemble_hardness_index,
+    compute_bottom_quintile,
+    gold_margin_bits,
+    grade_mc_task,
+    grade_schema_task,
+    read_hardness_index_jsonl,
+    write_hardness_index_jsonl,
+)
+from eval.downstream.private_hard import (
+    HardnessIndex,
+    HardnessIndexRow,
+)
+
+# ----------------------------------------------------------------------------
+# gold_margin_bits
+# ----------------------------------------------------------------------------
+
+
+def test_gold_margin_empty_returns_zero():
+    assert gold_margin_bits([], 0) == 0.0
+
+
+def test_gold_margin_single_choice_returns_inf():
+    """Only one choice → no distractors → infinitely confident."""
+    assert gold_margin_bits([-2.0], 0) == float("inf")
+
+
+def test_gold_margin_simple_math():
+    """log_p values [-1.0, -3.0] in nats, gold=0:
+       margin_nats = -1.0 - (-3.0) = 2.0
+       margin_bits = 2.0 / log(2) ≈ 2.885"""
+    m = gold_margin_bits([-1.0, -3.0], gold=0)
+    assert m == pytest.approx(2.0 / math.log(2), rel=1e-6)
+
+
+def test_gold_margin_negative_when_distractor_beats_gold():
+    """log_p values [-3.0, -1.0], gold=0 → -2.0 nats → ≈-2.885 bits."""
+    m = gold_margin_bits([-3.0, -1.0], gold=0)
+    assert m < 0
+    assert m == pytest.approx(-2.0 / math.log(2), rel=1e-6)
+
+
+def test_gold_margin_max_over_distractors():
+    """With 3 distractors at [-1, -2, -3], the best (largest) is -1.
+       margin = log_p(gold) - (-1) = log_p(gold) + 1."""
+    m = gold_margin_bits([-1.0, -2.0, -3.0, 0.0], gold=3)
+    # gold log_p = 0.0; max distractor = -1.0
+    # margin_nats = 0.0 - (-1.0) = 1.0; bits = 1/log(2)
+    assert m == pytest.approx(1.0 / math.log(2), rel=1e-6)
+
+
+def test_gold_margin_rejects_gold_out_of_range():
+    with pytest.raises(ValueError, match=r"gold=5 out of range"):
+        gold_margin_bits([-1.0, -2.0], gold=5)
+    with pytest.raises(ValueError, match=r"gold=-1 out of range"):
+        gold_margin_bits([-1.0, -2.0], gold=-1)
+
+
+# ----------------------------------------------------------------------------
+# grade_mc_task / grade_schema_task with synthetic logits
+# ----------------------------------------------------------------------------
+
+
+VOCAB = 256
+
+
+def _char_tokenize(text: str) -> list[int]:
+    return [ord(c) for c in text]
+
+
+def _uniform_forward(input_ids: torch.Tensor) -> torch.Tensor:
+    return torch.zeros((1, input_ids.size(1), VOCAB))
+
+
+def test_grade_mc_task_empty_returns_empty():
+    assert grade_mc_task(_uniform_forward, [], _char_tokenize, "arc_challenge_hard") == []
+
+
+def test_grade_mc_task_uniform_logits_zero_margin():
+    """Uniform logits → all choices have identical log-probs → margin = 0
+    bits regardless of gold index."""
+    items = [
+        ("i1", MCRawRow(query="q", choices=["a", "b"], gold=0)),
+        ("i2", MCRawRow(query="q", choices=["a", "b"], gold=1)),
+    ]
+    rows = grade_mc_task(_uniform_forward, items, _char_tokenize, "arc_challenge_hard")
+    assert len(rows) == 2
+    for r in rows:
+        assert r.dataset == "arc_challenge_hard"
+        assert r.gold_margin_bits == pytest.approx(0.0, abs=1e-9)
+    assert [r.item_id for r in rows] == ["i1", "i2"]
+
+
+def test_grade_mc_task_preserves_input_order():
+    """grade_mc_task emits one row per input item in INPUT order — not
+    sorted. Sorting happens in compute_bottom_quintile."""
+    items = [
+        ("z_last", MCRawRow(query="q", choices=["a", "b"], gold=0)),
+        ("a_first", MCRawRow(query="q", choices=["a", "b"], gold=0)),
+    ]
+    rows = grade_mc_task(_uniform_forward, items, _char_tokenize, "arc_challenge_hard")
+    assert [r.item_id for r in rows] == ["z_last", "a_first"]
+
+
+def test_grade_schema_task_uniform_logits_zero_margin():
+    items = [
+        ("w1", SchemaRawRow(contexts=["a", "b"], continuations=["x", "y"], gold=0)),
+    ]
+    rows = grade_schema_task(_uniform_forward, items, _char_tokenize, "winogrande_hard")
+    assert len(rows) == 1
+    assert rows[0].dataset == "winogrande_hard"
+    assert rows[0].gold_margin_bits == pytest.approx(0.0, abs=1e-9)
+
+
+def test_grade_schema_task_empty_returns_empty():
+    assert grade_schema_task(_uniform_forward, [], _char_tokenize, "winogrande_hard") == []
+
+
+# ----------------------------------------------------------------------------
+# compute_bottom_quintile
+# ----------------------------------------------------------------------------
+
+
+def _row(item_id: str, margin: float, dataset: str = "arc_challenge_hard") -> HardnessIndexRow:
+    return HardnessIndexRow(dataset=dataset, item_id=item_id, gold_margin_bits=margin)
+
+
+def test_bottom_quintile_takes_lowest_20_percent():
+    """10 rows × 20% = 2 rows. The 2 returned have the smallest margins."""
+    rows = [_row(f"i{i}", float(i)) for i in range(10)]  # margins 0..9
+    bottom = compute_bottom_quintile(rows, 0.20)
+    assert len(bottom) == 2
+    assert [r.item_id for r in bottom] == ["i0", "i1"]
+
+
+def test_bottom_quintile_returns_ascending_margin_order():
+    """Output is sorted ascending by margin — first row is hardest item."""
+    rows = [_row("a", 5.0), _row("b", 1.0), _row("c", 3.0), _row("d", 0.5), _row("e", 4.0)]
+    bottom = compute_bottom_quintile(rows, 0.40)  # 5 × 0.40 = 2
+    # Margins sorted: [0.5 (d), 1.0 (b), 3.0 (c), 4.0 (e), 5.0 (a)] → take 2
+    assert [r.item_id for r in bottom] == ["d", "b"]
+
+
+def test_bottom_quintile_empty_input_returns_empty():
+    assert compute_bottom_quintile([], 0.20) == []
+
+
+def test_bottom_quintile_zero_fraction_returns_empty():
+    rows = [_row("a", 1.0), _row("b", 2.0)]
+    assert compute_bottom_quintile(rows, 0.0) == []
+
+
+def test_bottom_quintile_one_fraction_returns_all_sorted():
+    rows = [_row("a", 3.0), _row("b", 1.0), _row("c", 2.0)]
+    bottom = compute_bottom_quintile(rows, 1.0)
+    assert len(bottom) == 3
+    assert [r.item_id for r in bottom] == ["b", "c", "a"]
+
+
+def test_bottom_quintile_rejects_invalid_fraction():
+    rows = [_row("a", 1.0)]
+    with pytest.raises(ValueError, match=r"quintile_fraction must be"):
+        compute_bottom_quintile(rows, 1.5)
+    with pytest.raises(ValueError, match=r"quintile_fraction must be"):
+        compute_bottom_quintile(rows, -0.1)
+
+
+def test_bottom_quintile_deterministic_across_runs():
+    """Stable sort guarantees byte-equal outputs on identical inputs."""
+    rows = [_row("a", 1.0), _row("b", 2.0), _row("c", 1.0)]  # a, c tie
+    r1 = compute_bottom_quintile(rows, 0.67)  # take 2
+    r2 = compute_bottom_quintile(rows, 0.67)
+    assert r1 == r2
+    # Among the tied pair (a, c), the stable sort preserves input order
+    assert [r.item_id for r in r1] == ["a", "c"]
+
+
+def test_bottom_quintile_rounds_to_nearest_integer():
+    """N=10, fraction=0.25 → 2.5 → round to 2. N=10, fraction=0.27 → 2.7 → round to 3."""
+    rows = [_row(f"i{i}", float(i)) for i in range(10)]
+    assert len(compute_bottom_quintile(rows, 0.25)) == 2
+    assert len(compute_bottom_quintile(rows, 0.27)) == 3
+
+
+# ----------------------------------------------------------------------------
+# assemble_hardness_index
+# ----------------------------------------------------------------------------
+
+
+def test_assemble_index_applies_quintile_per_task():
+    """Each task contributes its OWN bottom-quintile slice; the index
+    merge does NOT compute a global quintile across all tasks."""
+    arc_rows = [_row(f"a{i}", float(i), dataset="arc_challenge_hard") for i in range(10)]
+    win_rows = [_row(f"w{i}", float(i), dataset="winogrande_hard") for i in range(10)]
+    idx = assemble_hardness_index(
+        {"arc_challenge_hard": arc_rows, "winogrande_hard": win_rows},
+        version="grader-v0.1",
+        quintile_fraction=0.20,
+    )
+    # 2 rows per task × 2 tasks = 4 total
+    assert len(idx.rows) == 4
+    assert idx.for_task("arc_challenge_hard") == {"a0", "a1"}
+    assert idx.for_task("winogrande_hard") == {"w0", "w1"}
+
+
+def test_assemble_index_carries_version():
+    idx = assemble_hardness_index({}, version="grader-v0.0.1-abc123")
+    assert idx.version == "grader-v0.0.1-abc123"
+
+
+def test_assemble_index_rejects_empty_version():
+    with pytest.raises(ValueError, match=r"version must be non-empty"):
+        assemble_hardness_index({}, version="")
+
+
+def test_assemble_index_skips_empty_task():
+    """A task with zero rows contributes zero to the merged index."""
+    idx = assemble_hardness_index(
+        {"arc_challenge_hard": [], "tiny_arc": [_row("t1", 0.5, dataset="tiny_arc")]},
+        version="v",
+        quintile_fraction=1.0,
+    )
+    assert idx.for_task("arc_challenge_hard") == set()
+    assert idx.for_task("tiny_arc") == {"t1"}
+
+
+def test_assemble_index_coerces_dataset_field_from_key():
+    """If a caller passes rows whose `dataset` field doesn't match the dict
+    key, the assembler re-stamps the field to match the key. This is the
+    correct invariant because the dict key is the source of truth."""
+    bogus_rows = [_row("x1", 0.5, dataset="wrong_dataset")]
+    idx = assemble_hardness_index(
+        {"arc_challenge_hard": bogus_rows},
+        version="v",
+        quintile_fraction=1.0,
+    )
+    assert idx.for_task("arc_challenge_hard") == {"x1"}
+    assert idx.for_task("wrong_dataset") == set()
+
+
+# ----------------------------------------------------------------------------
+# JSONL round-trip
+# ----------------------------------------------------------------------------
+
+
+def test_write_then_read_round_trip(tmp_path):
+    rows = [
+        HardnessIndexRow(dataset="arc_challenge_hard", item_id="a1", gold_margin_bits=0.1),
+        HardnessIndexRow(dataset="winogrande_hard",    item_id="w1", gold_margin_bits=0.2),
+    ]
+    idx_in = HardnessIndex(version="grader-v0.0.1", rows=rows)
+    path = tmp_path / "out.jsonl"
+    write_hardness_index_jsonl(idx_in, path)
+    idx_out = read_hardness_index_jsonl(path)
+    assert idx_out.version == idx_in.version
+    assert len(idx_out.rows) == 2
+    assert idx_out.rows[0] == rows[0]
+    assert idx_out.rows[1] == rows[1]
+
+
+def test_write_creates_parent_dirs(tmp_path):
+    """Caller may pass a path whose parent doesn't exist yet — write
+    creates it. (Mirrors the master plan's atomic-write expectation.)"""
+    idx = HardnessIndex(version="v", rows=[])
+    path = tmp_path / "nested" / "dir" / "out.jsonl"
+    write_hardness_index_jsonl(idx, path)
+    assert path.exists()
+
+
+def test_write_is_atomic_no_tmp_leftover(tmp_path):
+    """After a successful write, the .tmp file is gone (rename replaced
+    the destination)."""
+    idx = HardnessIndex(version="v", rows=[])
+    path = tmp_path / "out.jsonl"
+    write_hardness_index_jsonl(idx, path)
+    assert path.exists()
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    assert not tmp.exists()
+
+
+def test_read_rejects_empty_file(tmp_path):
+    path = tmp_path / "empty.jsonl"
+    path.write_text("")
+    with pytest.raises(ValueError, match=r"empty hardness-index"):
+        read_hardness_index_jsonl(path)
+
+
+def test_read_rejects_missing_meta_marker(tmp_path):
+    path = tmp_path / "bogus.jsonl"
+    path.write_text('{"format": "jsonl-v1", "version": "v"}\n')
+    with pytest.raises(ValueError, match=r"_meta marker"):
+        read_hardness_index_jsonl(path)
+
+
+def test_read_rejects_format_mismatch(tmp_path):
+    """Forward-compat: a parquet-v1 file (or any other format string)
+    should not be silently consumed by the JSONL reader."""
+    path = tmp_path / "wrong.jsonl"
+    path.write_text(
+        '{"_meta": "karpa-hardness-index", "format": "parquet-v1", "version": "v"}\n'
+    )
+    with pytest.raises(ValueError, match=r"format mismatch"):
+        read_hardness_index_jsonl(path)
+
+
+def test_read_rejects_invalid_json_header(tmp_path):
+    path = tmp_path / "bad.jsonl"
+    path.write_text("not json at all\n")
+    with pytest.raises(ValueError, match=r"header line is not valid JSON"):
+        read_hardness_index_jsonl(path)
+
+
+def test_writer_format_pinned():
+    """If you change WRITER_FORMAT you MUST also update read_hardness_index_jsonl
+    AND every test that asserts the format string."""
+    assert WRITER_FORMAT == "jsonl-v1"
+
+
+def test_round_trip_preserves_float_precision(tmp_path):
+    """JSON encoding of a float64 should round-trip via json.dumps/loads
+    to within machine epsilon."""
+    rows = [
+        HardnessIndexRow(
+            dataset="arc_challenge_hard",
+            item_id="i1",
+            gold_margin_bits=-0.123456789012345,
+        ),
+    ]
+    idx_in = HardnessIndex(version="v", rows=rows)
+    path = tmp_path / "out.jsonl"
+    write_hardness_index_jsonl(idx_in, path)
+    idx_out = read_hardness_index_jsonl(path)
+    assert idx_out.rows[0].gold_margin_bits == rows[0].gold_margin_bits


### PR DESCRIPTION
What this commit ships:

  1. gold_margin_bits(choice_logprobs, gold) — the scalar that ranks items by how close the reference model came to picking a distractor. Defined as (log_p(gold) - max_{d != gold} log_p(d)) in bits (nats / log 2). Smaller = harder.

     Edge cases pinned in tests: * empty input → 0.0 * single choice → +inf * gold out of range → ValueError

  2. grade_mc_task / grade_schema_task — per-task drivers that take a forward_logits callable + (item_id, raw_row) pairs + tokenizer, and emit one HardnessIndexRow per item. Input order preserved. Both call the new score_*_logprobs scorer helpers (see #3 below).

  3. scorer.py additions: score_mc_logprobs / score_schema_logprobs — symmetric to score_mc / score_schema but return per-choice log-probabilities instead of the argmax index. grader.py is the only caller; exercised indirectly through grader tests.

  4. compute_bottom_quintile(rows, fraction=0.20) — sorts ascending by gold_margin_bits, takes round(N * fraction). Stable via Python's Timsort, so two runs on identical inputs produce identical output. Rejects fraction outside [0, 1].

  5. assemble_hardness_index(per_task_rows, version, fraction=0.20) — applies bottom-quintile per task, then merges into a single HardnessIndex. Requires non-empty version. Coerces the dataset field to the dict key on mismatch (caller-bug recovery).

  6. write_hardness_index_jsonl / read_hardness_index_jsonl — JSONL I/O. Line 1 is a header with _meta marker + version + format string + row count; lines 2..N are one row per line. Atomic write via .tmp + rename. Reader rejects: * empty files * missing _meta marker * format-string mismatch (forward-compat parquet guard) * invalid JSON

     WRITER_FORMAT = "jsonl-v1" — bumping this is the signal that the on-disk format has changed. Parquet upgrade path noted in the module docstring for the future runner.py.

What this commit does NOT ship:

  * The reference-model checkpoint (calibration.py concern, next PR).
  * The HF dataset download (load_task_examples stub in private_hard.py still raises NotImplementedError per B1-D1).
  * Tests against real OLMo-2-1B logits (those need H100 + the downloader; tracked under DEFERRED.md B1-D6).

Tests (33 cases in test_downstream_grader.py):

  * gold_margin_bits: empty / single / simple / negative-bits / max-over-distractors / reject out-of-range
  * grade_mc_task / grade_schema_task: happy paths + empty input + order-preservation
  * compute_bottom_quintile: 20% selection / ascending order / empty / zero-and-one-fraction edge cases / reject-invalid / determinism / round-to-nearest
  * assemble_hardness_index: per-task quintile / version required / skip-empty-task / coerce-dataset-field
  * JSONL round-trip: write+read / parent-dir creation / atomicity (no leftover .tmp) / reject empty / reject missing-_meta / reject format-mismatch / reject invalid-JSON
  * float-precision round-trip

Also updates eval/downstream/__init__.py:
  * Re-exports the new grader symbols + the score_*_logprobs helpers.
  * Adds private_hard re-exports (HardnessIndex, HardnessIndexRow, HF_DATASET_IDS, PRIVATE_HARD_TASKS, etc.) that the previous private_hard PR shipped without surfacing through the package.
  * Updates the "What B1 has shipped so far" docstring section.

Full suite: 304/304 passing. Ruff clean on all touched files.