### PR TITLE
eval/downstream/runner.py: in-process eval driver + vocab/determinism guards

### DIFF
--- a/eval/downstream/__init__.py
+++ b/eval/downstream/__init__.py
@@ -20,10 +20,13 @@ What B1 has shipped so far:
     contract + bottom-quintile filter
   * grader.py: gold_margin_bits computation + per-task graders +
     HardnessIndex assembly + JSONL round-trip
+  * runner.py (kernel): EvalConfig + vocab/determinism guards +
+    in-process run_downstream_eval driver (B1-D6, B1-D7 closed)
 
 What B1 will ship (separate commits within the phase):
+  * runner.py subprocess wrapper: CLI + JSON IPC + weights_only
+    checkpoint load + structural-patch path (B1-D5, B1-D13)
   * calibration.py: N=10 baseline runs → noise_floors_v1.json
-  * runner.py: subprocess-isolated entrypoint
 
 Reference scope: docs/build_scope/02_scope_B1.md.
 """
@@ -65,6 +68,13 @@ from .private_hard import (
     select_hardness_subset,
     to_private_hard_cell_result,
 )
+from .runner import (
+    KARPA_VOCAB_SIZE,
+    EvalConfig,
+    check_vocab_compatibility,
+    run_downstream_eval,
+    set_eval_determinism,
+)
 from .scorer import (
     LMExample,
     MCExample,
@@ -96,10 +106,12 @@ __all__ = [
     "DCLM_EVAL_BUNDLE_SHA256",
     "DCLM_EVAL_BUNDLE_URL",
     "DownstreamReport",
+    "EvalConfig",
     "HARNESS_VERSION",
     "HF_DATASET_IDS",
     "HardnessIndex",
     "HardnessIndexRow",
+    "KARPA_VOCAB_SIZE",
     "LMExample",
     "LMRawRow",
     "MCExample",
@@ -118,6 +130,7 @@ __all__ = [
     "TaskSpec",
     "aggregate_pareto",
     "assemble_hardness_index",
+    "check_vocab_compatibility",
     "compute_bottom_quintile",
     "evaluate_lm_task_lambada",
     "evaluate_mc_task",
@@ -130,12 +143,14 @@ __all__ = [
     "make_mc_example",
     "make_schema_example",
     "read_hardness_index_jsonl",
+    "run_downstream_eval",
     "score_lm",
     "score_mc",
     "score_mc_logprobs",
     "score_schema",
     "score_schema_logprobs",
     "select_hardness_subset",
+    "set_eval_determinism",
     "to_cell_result",
     "to_private_hard_cell_result",
     "write_hardness_index_jsonl",

--- a/eval/downstream/runner.py
+++ b/eval/downstream/runner.py
@@ -1,0 +1,341 @@
+"""In-process downstream-eval driver (B1).
+
+Composes core22.py + private_hard.py evaluators into one call that
+returns a `DownstreamReport`. The validator's subprocess wrapper (next
+PR) shells out to a CLI that imports this kernel + a forward function
+loaded from a miner checkpoint.
+
+What this module ships:
+
+  * `EvalConfig` — JSON-serializable run parameters (tasks,
+    n_examples_per_task, seed, scale_label, length_normalize_mc).
+    Frozen dataclass with `to_dict` / `from_dict` so the subprocess
+    wrapper can ship configs over IPC without ad-hoc serialization
+    glue.
+  * `KARPA_VOCAB_SIZE = 50257` — the GPT-2 BPE vocab lock. Submissions
+    whose checkpoint config reports a different vocab are rejected at
+    runner time. Closes **B1-D6**.
+  * `check_vocab_compatibility(actual_vocab_size)` — raises ValueError
+    with a clear message when actual != 50257.
+  * `set_eval_determinism(seed)` — pins
+    `torch.use_deterministic_algorithms(True)` +
+    `CUBLAS_WORKSPACE_CONFIG=:4096:8` env var + `torch.manual_seed` (+
+    CUDA seed if available). Closes **B1-D7**.
+  * `run_downstream_eval(forward_logits, *, config, task_loaders,
+    tokenize, bundle_sha256, vocab_size, hardness_index, wall_clock_s)`
+    — the pure in-process driver. Dispatches core22 tasks through
+    `evaluate_mc_task` / `evaluate_schema_task` /
+    `evaluate_lm_task_lambada` by `TaskSpec.mode`; dispatches
+    private_hard tasks through `evaluate_private_hard_task` with the
+    provided `HardnessIndex`. Returns a `DownstreamReport`.
+
+What this module does NOT ship (next PR):
+
+  * Subprocess wrapper (subprocess.run + JSON IPC + stderr handling).
+  * Checkpoint loading (torch.load with weights_only=True). Closes
+    **B1-D5** (the "weights_only blocks pickle RCE but not forward()
+    code execution" caveat is documented as part of that wrapper).
+  * The argparse CLI entrypoint.
+  * Structural-patch handling (`--patch` / `--karpa-root` args).
+    Closes **B1-D13**.
+
+Cell-key construction: `{task_name}:{scale_label}` for accuracy cells.
+The `:bpb` suffix (lower-is-better direction-flip) is reserved for the
+report-assembly layer where bytes-per-token is known; the in-process
+kernel emits the raw NLL in `CellResult.accuracy` for LM tasks and the
+caller does the bpb conversion if needed.
+
+Wall-clock: defaults to 0.0. The in-process kernel is deterministic
+data-flow; the subprocess wrapper measures real elapsed seconds and
+injects them via the `wall_clock_s` argument.
+
+Reference scope: docs/build_scope/02_scope_B1.md "runner.py".
+"""
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+
+from .core22 import (
+    TASK_SPECS,
+    evaluate_lm_task_lambada,
+    evaluate_mc_task,
+    evaluate_schema_task,
+    make_lm_example,
+    make_mc_example,
+    make_schema_example,
+    to_cell_result,
+)
+from .private_hard import (
+    PRIVATE_HARD_TASK_SPECS,
+    HardnessIndex,
+    evaluate_private_hard_task,
+    to_private_hard_cell_result,
+)
+from .types import (
+    HARNESS_VERSION,
+    CellResult,
+    DownstreamReport,
+)
+
+# GPT-2 BPE vocab size. The runner accepts only models whose `vocab_size`
+# matches; mismatched-vocab submissions fail clean here instead of
+# silently producing nonsensical scores. Closes B1-D6.
+KARPA_VOCAB_SIZE = 50257
+
+
+# ----------------------------------------------------------------------------
+# EvalConfig
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EvalConfig:
+    """Inputs to `run_downstream_eval`, JSON-serializable.
+
+    Frozen so the config can be hashed into cache keys / chain logs
+    without defensive copying.
+
+    Fields:
+      * `tasks` — tuple of task names. Every task must be in `TASK_SPECS`
+        (core22) OR `PRIVATE_HARD_TASK_SPECS` (the hardness subset).
+        Empty tuple rejected.
+      * `n_examples_per_task` — truncate task loaders to the first N
+        rows. 0 = use all. Negative rejected.
+      * `seed` — passed to `torch.manual_seed` via `set_eval_determinism`
+        and stamped into every `CellResult.seed` so multi-seed scaffolding
+        downstream can re-derive provenance.
+      * `scale_label` — cell-key suffix. Validator passes "S1"/"S2"/"S3"
+        for the ladder rungs. Empty string rejected.
+      * `length_normalize_mc` — pass-through to `evaluate_mc_task`. Default
+        True matches DCLM / lm-eval-harness convention for MMLU/ARC.
+    """
+
+    tasks: tuple[str, ...]
+    n_examples_per_task: int = 0
+    seed: int = 0
+    scale_label: str = "S3"
+    length_normalize_mc: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.tasks:
+            raise ValueError("EvalConfig.tasks must be non-empty")
+        if self.n_examples_per_task < 0:
+            raise ValueError(
+                f"EvalConfig.n_examples_per_task must be >= 0; "
+                f"got {self.n_examples_per_task}"
+            )
+        if not self.scale_label:
+            raise ValueError("EvalConfig.scale_label must be non-empty")
+
+    def to_dict(self) -> dict:
+        """Serialize to a plain dict (JSON-safe). Round-trips via from_dict."""
+        return {
+            "tasks": list(self.tasks),
+            "n_examples_per_task": self.n_examples_per_task,
+            "seed": self.seed,
+            "scale_label": self.scale_label,
+            "length_normalize_mc": self.length_normalize_mc,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> EvalConfig:
+        """Inverse of `to_dict`. Tolerant of missing optional fields.
+
+        Converts the tasks list back to a tuple for frozen-dataclass
+        hashability. Missing `tasks` raises KeyError so the caller sees
+        the bug immediately instead of an empty-tasks ValueError.
+        """
+        return cls(
+            tasks=tuple(d["tasks"]),
+            n_examples_per_task=d.get("n_examples_per_task", 0),
+            seed=d.get("seed", 0),
+            scale_label=d.get("scale_label", "S3"),
+            length_normalize_mc=d.get("length_normalize_mc", True),
+        )
+
+
+# ----------------------------------------------------------------------------
+# Vocab + determinism guards
+# ----------------------------------------------------------------------------
+
+
+def check_vocab_compatibility(actual_vocab_size: int) -> None:
+    """Reject submissions whose tokenizer vocab != 50257 (GPT-2 BPE).
+
+    Why this is necessary (not just nice-to-have): tokens for the same
+    input string differ across vocabs, so the per-token log-probability
+    space is incomparable across models. Two models that report different
+    `vocab_size` cannot be compared on the SAME private hardness subset
+    without an entirely different scoring protocol. Rather than silently
+    produce non-comparable numbers, we fail clean at runner time.
+
+    Closes B1-D6.
+    """
+    if actual_vocab_size != KARPA_VOCAB_SIZE:
+        raise ValueError(
+            f"vocab_size mismatch: forward function reports "
+            f"{actual_vocab_size}, runner requires {KARPA_VOCAB_SIZE} "
+            "(GPT-2 BPE). Submissions with divergent vocab must extend "
+            "or pad to vocab=50257 or be evaluated under a different "
+            "harness."
+        )
+
+
+def set_eval_determinism(seed: int) -> None:
+    """Configure torch for byte-identical results across runs.
+
+    Sets `CUBLAS_WORKSPACE_CONFIG=:4096:8` env var (required for CUDA
+    deterministic matmul kernels) BEFORE flipping the deterministic
+    algorithm flag, then seeds CPU + (if present) CUDA RNGs.
+
+    Idempotent: safe to call multiple times in the same process.
+    Side-effecting: the deterministic-algorithms flag is process-wide;
+    the subprocess wrapper (next PR) keeps each run in a fresh process so
+    this state doesn't leak. In-process tests rely on the same property.
+
+    Closes B1-D7.
+    """
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    torch.use_deterministic_algorithms(True, warn_only=False)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+# ----------------------------------------------------------------------------
+# In-process driver
+# ----------------------------------------------------------------------------
+
+# A task loader is a no-arg callable that returns the raw rows for one
+# task. For core22 tasks the elements are MCRawRow / SchemaRawRow /
+# LMRawRow; for private_hard tasks the elements are (item_id, raw_row)
+# tuples. The loader's identity (HF, local cache, synthetic, etc.) is
+# the wrapper's concern, not the kernel's.
+TaskLoader = Callable[[], list]
+
+
+def run_downstream_eval(
+    forward_logits: Callable[[torch.Tensor], torch.Tensor],
+    *,
+    config: EvalConfig,
+    task_loaders: dict[str, TaskLoader],
+    tokenize: Callable[[str], list[int]],
+    bundle_sha256: str,
+    vocab_size: int,
+    hardness_index: HardnessIndex | None = None,
+    wall_clock_s: float = 0.0,
+) -> DownstreamReport:
+    """Run the configured tasks and assemble a `DownstreamReport`.
+
+    Dispatching:
+      * task in TASK_SPECS → dispatch by spec.mode:
+          mode == "mc"     → evaluate_mc_task
+          mode == "schema" → evaluate_schema_task
+          mode == "lm"     → evaluate_lm_task_lambada
+      * task in PRIVATE_HARD_TASK_SPECS → evaluate_private_hard_task
+        with `hardness_index` (None → ValueError).
+      * task in neither → ValueError.
+
+    Truncation: `config.n_examples_per_task > 0` slices the loaded raw
+    rows BEFORE tokenization. For private_hard tasks it slices BEFORE
+    the hardness filter — the runner exposes a row budget, not a hardness
+    budget. In production the validator passes 0 (use all).
+
+    Cell keys: `{task_name}:{config.scale_label}` for every cell. The
+    `:bpb` suffix is constructed by the report-assembly layer when LM
+    accuracy gets converted to bits-per-byte.
+
+    Determinism: `set_eval_determinism(config.seed)` is called BEFORE
+    the first task runs, so any RNG inside the forward function or
+    tokenize callable gets a pinned seed.
+    """
+    check_vocab_compatibility(vocab_size)
+    set_eval_determinism(config.seed)
+
+    cells: dict[str, CellResult] = {}
+    total_examples = 0
+
+    for task_name in config.tasks:
+        in_core22 = task_name in TASK_SPECS
+        in_private_hard = task_name in PRIVATE_HARD_TASK_SPECS
+        if not in_core22 and not in_private_hard:
+            raise ValueError(
+                f"unknown task {task_name!r}: not in TASK_SPECS "
+                "(core22) or PRIVATE_HARD_TASK_SPECS"
+            )
+        if task_name not in task_loaders:
+            raise ValueError(
+                f"no loader registered for task {task_name!r}; pass "
+                "it in task_loaders"
+            )
+
+        raw = task_loaders[task_name]()
+        if config.n_examples_per_task > 0:
+            raw = raw[: config.n_examples_per_task]
+
+        if in_private_hard:
+            if hardness_index is None:
+                raise ValueError(
+                    f"private-hard task {task_name!r} requires a "
+                    "hardness_index (got None). The validator constructs "
+                    "the index once per calibration cycle and reuses it "
+                    "across submissions."
+                )
+            acc, n = evaluate_private_hard_task(
+                forward_logits,
+                raw,
+                hardness_index,
+                task_name,
+                tokenize,
+                length_normalize=config.length_normalize_mc,
+            )
+            cell = to_private_hard_cell_result(
+                task_name,
+                acc,
+                n,
+                scale=config.scale_label,
+                seed=config.seed,
+            )
+        else:
+            spec = TASK_SPECS[task_name]
+            if spec.mode == "mc":
+                examples = [make_mc_example(r, tokenize) for r in raw]
+                acc, n = evaluate_mc_task(
+                    forward_logits,
+                    examples,
+                    length_normalize=config.length_normalize_mc,
+                )
+            elif spec.mode == "schema":
+                examples = [make_schema_example(r, tokenize) for r in raw]
+                acc, n = evaluate_schema_task(forward_logits, examples)
+            elif spec.mode == "lm":
+                examples = [make_lm_example(r, tokenize) for r in raw]
+                acc, n = evaluate_lm_task_lambada(forward_logits, examples)
+            else:
+                raise ValueError(
+                    f"task {task_name!r} has unsupported mode "
+                    f"{spec.mode!r}; expected mc/schema/lm"
+                )
+            cell = to_cell_result(
+                task_name,
+                acc,
+                n,
+                scale=config.scale_label,
+                seed=config.seed,
+            )
+
+        cells[f"{task_name}:{config.scale_label}"] = cell
+        total_examples += n
+
+    return DownstreamReport(
+        harness_version=HARNESS_VERSION,
+        bundle_sha256=bundle_sha256,
+        seed=config.seed,
+        total_examples=total_examples,
+        wall_clock_s=wall_clock_s,
+        cells=cells,
+    )

--- a/tests/test_downstream_runner.py
+++ b/tests/test_downstream_runner.py
@@ -1,0 +1,581 @@
+"""Tests for eval/downstream/runner.py — in-process kernel only.
+
+Pins the EvalConfig contract + the vocab/determinism guards + the
+in-process eval driver. The subprocess wrapper (next PR) is tested in
+test_downstream_runner_subprocess.py.
+
+Covers:
+  * EvalConfig: validation, JSON round-trip, defaults, frozen-ness.
+  * check_vocab_compatibility: pass/fail at 50257.
+  * set_eval_determinism: idempotent + seeds RNG.
+  * run_downstream_eval: core22 dispatch (mc/schema/lm), private_hard
+    dispatch with HardnessIndex, scale_label propagation, truncation,
+    unknown-task rejection, missing-loader rejection, determinism.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from eval.downstream.core22 import (
+    LMRawRow,
+    MCRawRow,
+    SchemaRawRow,
+)
+from eval.downstream.private_hard import (
+    HardnessIndex,
+    HardnessIndexRow,
+)
+from eval.downstream.runner import (
+    KARPA_VOCAB_SIZE,
+    EvalConfig,
+    check_vocab_compatibility,
+    run_downstream_eval,
+    set_eval_determinism,
+)
+from eval.downstream.types import (
+    HARNESS_VERSION,
+    DownstreamReport,
+)
+
+# Test fixtures ---------------------------------------------------------------
+
+VOCAB = 256  # Covers ord(c) for all ASCII chars used by _char_tokenize.
+
+
+def _char_tokenize(text: str) -> list[int]:
+    return [ord(c) for c in text]
+
+
+def _uniform_forward(input_ids: torch.Tensor) -> torch.Tensor:
+    """Uniform logits → arg-max stable tie-break picks choice 0."""
+    return torch.zeros((1, input_ids.size(1), VOCAB))
+
+
+def _make_loader(rows):
+    return lambda: rows
+
+
+# ============================================================================
+# EvalConfig
+# ============================================================================
+
+
+class TestEvalConfig:
+    def test_minimum_valid_config(self):
+        cfg = EvalConfig(tasks=("arc_easy",))
+        assert cfg.tasks == ("arc_easy",)
+        assert cfg.n_examples_per_task == 0
+        assert cfg.seed == 0
+        assert cfg.scale_label == "S3"
+        assert cfg.length_normalize_mc is True
+
+    def test_empty_tasks_rejected(self):
+        with pytest.raises(ValueError, match=r"tasks must be non-empty"):
+            EvalConfig(tasks=())
+
+    def test_negative_n_examples_rejected(self):
+        with pytest.raises(ValueError, match=r"n_examples_per_task must be >= 0"):
+            EvalConfig(tasks=("arc_easy",), n_examples_per_task=-1)
+
+    def test_zero_n_examples_accepted(self):
+        cfg = EvalConfig(tasks=("arc_easy",), n_examples_per_task=0)
+        assert cfg.n_examples_per_task == 0
+
+    def test_empty_scale_label_rejected(self):
+        with pytest.raises(ValueError, match=r"scale_label must be non-empty"):
+            EvalConfig(tasks=("arc_easy",), scale_label="")
+
+    def test_to_dict_round_trip(self):
+        cfg = EvalConfig(
+            tasks=("arc_easy", "piqa"),
+            n_examples_per_task=10,
+            seed=42,
+            scale_label="S2",
+            length_normalize_mc=False,
+        )
+        roundtripped = EvalConfig.from_dict(cfg.to_dict())
+        assert roundtripped == cfg
+
+    def test_from_dict_defaults(self):
+        cfg = EvalConfig.from_dict({"tasks": ["arc_easy"]})
+        assert cfg.tasks == ("arc_easy",)
+        assert cfg.n_examples_per_task == 0
+        assert cfg.seed == 0
+        assert cfg.scale_label == "S3"
+        assert cfg.length_normalize_mc is True
+
+    def test_from_dict_converts_list_to_tuple(self):
+        cfg = EvalConfig.from_dict({"tasks": ["a", "b"]})
+        assert isinstance(cfg.tasks, tuple)
+        assert cfg.tasks == ("a", "b")
+
+    def test_from_dict_missing_tasks_raises(self):
+        with pytest.raises(KeyError):
+            EvalConfig.from_dict({})
+
+    def test_frozen(self):
+        cfg = EvalConfig(tasks=("a",))
+        with pytest.raises(Exception):
+            cfg.seed = 5  # type: ignore[misc]
+
+    def test_json_serializable(self):
+        cfg = EvalConfig(tasks=("arc_easy",), seed=1, scale_label="X")
+        encoded = json.dumps(cfg.to_dict())
+        restored = EvalConfig.from_dict(json.loads(encoded))
+        assert restored == cfg
+
+    def test_hashable(self):
+        """Frozen dataclass must be hashable for cache keys / chain logs."""
+        cfg = EvalConfig(tasks=("a",))
+        d = {cfg: 1}
+        assert d[cfg] == 1
+
+
+# ============================================================================
+# check_vocab_compatibility (B1-D6)
+# ============================================================================
+
+
+class TestVocabCheck:
+    def test_pass_at_50257(self):
+        check_vocab_compatibility(50257)  # no raise
+
+    def test_pass_at_constant(self):
+        check_vocab_compatibility(KARPA_VOCAB_SIZE)
+
+    def test_reject_smaller(self):
+        with pytest.raises(ValueError, match=r"vocab_size mismatch"):
+            check_vocab_compatibility(50000)
+
+    def test_reject_larger(self):
+        with pytest.raises(ValueError, match=r"vocab_size mismatch"):
+            check_vocab_compatibility(50500)
+
+    def test_reject_zero(self):
+        with pytest.raises(ValueError, match=r"vocab_size mismatch"):
+            check_vocab_compatibility(0)
+
+    def test_message_mentions_gpt2(self):
+        with pytest.raises(ValueError, match=r"GPT-2"):
+            check_vocab_compatibility(40000)
+
+    def test_message_includes_actual_value(self):
+        with pytest.raises(ValueError, match=r"40000"):
+            check_vocab_compatibility(40000)
+
+
+# ============================================================================
+# set_eval_determinism (B1-D7)
+# ============================================================================
+
+
+class TestDeterminism:
+    def test_enables_deterministic_algorithms(self):
+        set_eval_determinism(42)
+        assert torch.are_deterministic_algorithms_enabled()
+
+    def test_sets_cublas_env_var(self):
+        # Clear the var first to verify the helper sets it; restore after.
+        saved = os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+        try:
+            set_eval_determinism(42)
+            assert os.environ.get("CUBLAS_WORKSPACE_CONFIG") == ":4096:8"
+        finally:
+            if saved is not None:
+                os.environ["CUBLAS_WORKSPACE_CONFIG"] = saved
+
+    def test_preserves_existing_cublas_env_var(self):
+        """`setdefault` semantics: don't override if caller already set it."""
+        saved = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
+        try:
+            set_eval_determinism(0)
+            assert os.environ["CUBLAS_WORKSPACE_CONFIG"] == ":16:8"
+        finally:
+            if saved is None:
+                del os.environ["CUBLAS_WORKSPACE_CONFIG"]
+            else:
+                os.environ["CUBLAS_WORKSPACE_CONFIG"] = saved
+
+    def test_idempotent(self):
+        set_eval_determinism(42)
+        set_eval_determinism(42)  # second call must not raise
+
+    def test_seeds_same_rng_state(self):
+        set_eval_determinism(7)
+        x = torch.randn(3)
+        set_eval_determinism(7)
+        y = torch.randn(3)
+        assert torch.allclose(x, y)
+
+    def test_different_seeds_diverge(self):
+        set_eval_determinism(1)
+        x = torch.randn(3)
+        set_eval_determinism(2)
+        y = torch.randn(3)
+        assert not torch.allclose(x, y)
+
+
+# ============================================================================
+# run_downstream_eval — core22 dispatch
+# ============================================================================
+
+
+class TestRunDownstreamEvalCore22:
+    def test_single_mc_task(self):
+        rows = [
+            MCRawRow(query="q1", choices=["a", "b"], gold=0),
+            MCRawRow(query="q2", choices=["a", "b"], gold=0),
+            MCRawRow(query="q3", choices=["a", "b"], gold=0),
+        ]
+        cfg = EvalConfig(tasks=("arc_easy",))
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"arc_easy": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="abc123",
+            vocab_size=50257,
+        )
+        assert isinstance(report, DownstreamReport)
+        assert report.harness_version == HARNESS_VERSION
+        assert report.bundle_sha256 == "abc123"
+        assert report.seed == 0
+        assert report.total_examples == 3
+        assert "arc_easy:S3" in report.cells
+        # Uniform logits → tie → tie-break index 0 → all gold=0 → acc=1.0
+        assert report.cells["arc_easy:S3"].accuracy == 1.0
+        assert report.cells["arc_easy:S3"].n_examples == 3
+
+    def test_schema_task_dispatch(self):
+        rows = [
+            SchemaRawRow(contexts=["x"], continuations=["y"], gold=0),
+            SchemaRawRow(contexts=["a"], continuations=["b"], gold=0),
+        ]
+        cfg = EvalConfig(tasks=("winogrande",))
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"winogrande": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        assert "winogrande:S3" in report.cells
+        assert report.cells["winogrande:S3"].n_examples == 2
+
+    def test_lm_task_dispatch(self):
+        rows = [
+            LMRawRow(context="hello", target=" world"),
+            LMRawRow(context="foo", target=" bar"),
+        ]
+        cfg = EvalConfig(tasks=("lambada_openai",))
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"lambada_openai": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        assert "lambada_openai:S3" in report.cells
+        assert report.cells["lambada_openai:S3"].n_examples == 2
+        # Uniform logits over VOCAB=256 → NLL per token ≈ log(256) ≈ 5.545 nats.
+        # The reported "accuracy" field carries mean NLL for LM tasks.
+        assert report.cells["lambada_openai:S3"].accuracy > 0
+
+    def test_multi_task_dispatch(self):
+        mc_rows = [MCRawRow(query="q", choices=["a", "b"], gold=0)]
+        sc_rows = [SchemaRawRow(contexts=["x"], continuations=["y"], gold=0)]
+        cfg = EvalConfig(tasks=("arc_easy", "winogrande"))
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={
+                "arc_easy": _make_loader(mc_rows),
+                "winogrande": _make_loader(sc_rows),
+            },
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        assert len(report.cells) == 2
+        assert "arc_easy:S3" in report.cells
+        assert "winogrande:S3" in report.cells
+        assert report.total_examples == 2
+
+
+# ============================================================================
+# run_downstream_eval — config knobs
+# ============================================================================
+
+
+class TestRunDownstreamEvalConfig:
+    def test_scale_label_in_cell_key(self):
+        rows = [MCRawRow(query="q", choices=["a", "b"], gold=0)]
+        cfg = EvalConfig(tasks=("arc_easy",), scale_label="S1")
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"arc_easy": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        assert "arc_easy:S1" in report.cells
+        assert "arc_easy:S3" not in report.cells
+
+    def test_scale_label_in_cell_result(self):
+        rows = [MCRawRow(query="q", choices=["a", "b"], gold=0)]
+        cfg = EvalConfig(tasks=("arc_easy",), scale_label="S2")
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"arc_easy": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        # Cell key uses scale label but CellResult.task stays bare.
+        assert report.cells["arc_easy:S2"].task == "arc_easy"
+
+    def test_n_examples_zero_uses_all(self):
+        rows = [MCRawRow(query=f"q{i}", choices=["a", "b"], gold=0) for i in range(5)]
+        cfg = EvalConfig(tasks=("arc_easy",), n_examples_per_task=0)
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"arc_easy": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        assert report.cells["arc_easy:S3"].n_examples == 5
+
+    def test_n_examples_truncates(self):
+        rows = [MCRawRow(query=f"q{i}", choices=["a", "b"], gold=0) for i in range(10)]
+        cfg = EvalConfig(tasks=("arc_easy",), n_examples_per_task=3)
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"arc_easy": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        assert report.cells["arc_easy:S3"].n_examples == 3
+
+    def test_n_examples_larger_than_dataset_uses_all(self):
+        rows = [MCRawRow(query=f"q{i}", choices=["a", "b"], gold=0) for i in range(2)]
+        cfg = EvalConfig(tasks=("arc_easy",), n_examples_per_task=100)
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"arc_easy": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        assert report.cells["arc_easy:S3"].n_examples == 2
+
+    def test_seed_in_report_and_cell(self):
+        rows = [MCRawRow(query="q", choices=["a", "b"], gold=0)]
+        cfg = EvalConfig(tasks=("arc_easy",), seed=99)
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"arc_easy": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        assert report.seed == 99
+        assert report.cells["arc_easy:S3"].seed == 99
+
+    def test_total_examples_sums_across_cells(self):
+        mc1 = [MCRawRow(query="q", choices=["a", "b"], gold=0) for _ in range(3)]
+        mc2 = [MCRawRow(query="q", choices=["a", "b"], gold=0) for _ in range(5)]
+        cfg = EvalConfig(tasks=("arc_easy", "piqa"))
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={
+                "arc_easy": _make_loader(mc1),
+                "piqa": _make_loader(mc2),
+            },
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        assert report.total_examples == 8
+
+    def test_wall_clock_passthrough(self):
+        rows = [MCRawRow(query="q", choices=["a", "b"], gold=0)]
+        cfg = EvalConfig(tasks=("arc_easy",))
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"arc_easy": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+            wall_clock_s=12.5,
+        )
+        assert report.wall_clock_s == 12.5
+
+    def test_wall_clock_defaults_to_zero(self):
+        rows = [MCRawRow(query="q", choices=["a", "b"], gold=0)]
+        cfg = EvalConfig(tasks=("arc_easy",))
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"arc_easy": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        assert report.wall_clock_s == 0.0
+
+
+# ============================================================================
+# run_downstream_eval — error paths
+# ============================================================================
+
+
+class TestRunDownstreamEvalErrors:
+    def test_unknown_task_rejected(self):
+        cfg = EvalConfig(tasks=("not_a_task",))
+        with pytest.raises(ValueError, match=r"unknown task"):
+            run_downstream_eval(
+                _uniform_forward,
+                config=cfg,
+                task_loaders={"not_a_task": _make_loader([])},
+                tokenize=_char_tokenize,
+                bundle_sha256="x",
+                vocab_size=50257,
+            )
+
+    def test_missing_loader_rejected(self):
+        cfg = EvalConfig(tasks=("arc_easy",))
+        with pytest.raises(ValueError, match=r"no loader registered"):
+            run_downstream_eval(
+                _uniform_forward,
+                config=cfg,
+                task_loaders={},
+                tokenize=_char_tokenize,
+                bundle_sha256="x",
+                vocab_size=50257,
+            )
+
+    def test_vocab_mismatch_rejects_early(self):
+        """Vocab check happens before any task work — empty loaders fine."""
+        cfg = EvalConfig(tasks=("arc_easy",))
+        with pytest.raises(ValueError, match=r"vocab_size mismatch"):
+            run_downstream_eval(
+                _uniform_forward,
+                config=cfg,
+                task_loaders={"arc_easy": _make_loader([])},
+                tokenize=_char_tokenize,
+                bundle_sha256="x",
+                vocab_size=40000,
+            )
+
+
+# ============================================================================
+# run_downstream_eval — private_hard dispatch
+# ============================================================================
+
+
+class TestRunDownstreamEvalPrivateHard:
+    def test_private_hard_routing(self):
+        rows = [
+            ("a1", MCRawRow(query="q1", choices=["a", "b"], gold=0)),
+            ("a2", MCRawRow(query="q2", choices=["a", "b"], gold=0)),
+        ]
+        idx = HardnessIndex(
+            version="v1",
+            rows=[
+                HardnessIndexRow(
+                    dataset="arc_challenge_hard",
+                    item_id="a1",
+                    gold_margin_bits=0.0,
+                ),
+            ],
+        )
+        cfg = EvalConfig(tasks=("arc_challenge_hard",))
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"arc_challenge_hard": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+            hardness_index=idx,
+        )
+        # Only 1 of 2 items in index → cell has n=1.
+        assert report.cells["arc_challenge_hard:S3"].n_examples == 1
+        assert report.total_examples == 1
+
+    def test_private_hard_requires_index(self):
+        rows = [("a1", MCRawRow(query="q", choices=["a", "b"], gold=0))]
+        cfg = EvalConfig(tasks=("arc_challenge_hard",))
+        with pytest.raises(ValueError, match=r"requires a hardness_index"):
+            run_downstream_eval(
+                _uniform_forward,
+                config=cfg,
+                task_loaders={"arc_challenge_hard": _make_loader(rows)},
+                tokenize=_char_tokenize,
+                bundle_sha256="x",
+                vocab_size=50257,
+                hardness_index=None,
+            )
+
+    def test_private_hard_empty_index_yields_zero_cell(self):
+        rows = [("a1", MCRawRow(query="q", choices=["a", "b"], gold=0))]
+        idx = HardnessIndex(version="v1", rows=[])
+        cfg = EvalConfig(tasks=("arc_challenge_hard",))
+        report = run_downstream_eval(
+            _uniform_forward,
+            config=cfg,
+            task_loaders={"arc_challenge_hard": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+            hardness_index=idx,
+        )
+        # Empty index → filter excludes all → (0.0, 0) cell.
+        assert report.cells["arc_challenge_hard:S3"].n_examples == 0
+        assert report.cells["arc_challenge_hard:S3"].accuracy == 0.0
+
+
+# ============================================================================
+# run_downstream_eval — determinism
+# ============================================================================
+
+
+class TestRunDownstreamEvalDeterminism:
+    def test_byte_identical_same_seed(self):
+        rows = [MCRawRow(query="q", choices=["a", "b"], gold=0)]
+        cfg = EvalConfig(tasks=("arc_easy",), seed=7)
+        kwargs = dict(
+            forward_logits=_uniform_forward,
+            config=cfg,
+            task_loaders={"arc_easy": _make_loader(rows)},
+            tokenize=_char_tokenize,
+            bundle_sha256="x",
+            vocab_size=50257,
+        )
+        r1 = run_downstream_eval(**kwargs)
+        r2 = run_downstream_eval(**kwargs)
+        assert r1.cells["arc_easy:S3"].accuracy == r2.cells["arc_easy:S3"].accuracy
+        assert r1.total_examples == r2.total_examples
+        assert r1.seed == r2.seed


### PR DESCRIPTION
What this commit ships:

  1. EvalConfig — JSON-serializable, frozen, hashable run parameters (tasks, n_examples_per_task, seed, scale_label, length_normalize_mc). to_dict / from_dict round-trip via plain dicts so the future subprocess wrapper can ship configs over IPC without bespoke serialization glue.

     Validation: * tasks must be non-empty * n_examples_per_task must be >= 0 * scale_label must be non-empty

  2. KARPA_VOCAB_SIZE = 50257 + check_vocab_compatibility() — the GPT-2 BPE vocab lock. Submissions whose checkpoint config reports a different vocab are rejected at runner time with a clear error message instead of silently producing non-comparable scores.

     Closes B1-D6 in DEFERRED.md.

  3. set_eval_determinism(seed) — pins torch.use_deterministic_algorithms(True) + CUBLAS_WORKSPACE_CONFIG=:4096:8 env var + torch.manual_seed + CUDA seed (if available). Idempotent. Uses setdefault for the env var so an already-set workspace config isn't clobbered.

     Closes B1-D7 in DEFERRED.md.

  4. run_downstream_eval(forward_logits, *, config, task_loaders, tokenize, bundle_sha256, vocab_size, hardness_index, wall_clock_s) — the pure in-process driver.

     Routing: * task in TASK_SPECS → spec.mode dispatch to evaluate_mc_task / evaluate_schema_task / evaluate_lm_task_lambada * task in PRIVATE_HARD_TASK_SPECS → evaluate_private_hard_task with hardness_index (None → ValueError with a hint to the calibration-cycle pattern) * task in neither → ValueError naming the task

     Cell-key construction: {task_name}:{scale_label} for every cell. The :bpb suffix (lower-is-better direction-flip) is reserved for the report-assembly layer where bytes-per-token is known. LM tasks emit raw NLL in CellResult.accuracy; the runner does NOT do the bpb conversion in-process.

     Truncation: config.n_examples_per_task > 0 slices BEFORE tokenization and BEFORE the hardness filter (for private_hard tasks). In production the validator passes 0 (use all); the truncation knob is for dev / smoke tests.

     Determinism: set_eval_determinism(config.seed) runs BEFORE the first task so any RNG inside forward / tokenize gets a pinned seed.

     Wall-clock: defaults to 0.0. The in-process kernel is deterministic data-flow; the subprocess wrapper measures real elapsed seconds and injects them via wall_clock_s.

What this commit does NOT ship (next PR):

  * Subprocess wrapper (subprocess.run + JSON IPC + stderr handling).
  * Checkpoint loading (torch.load with weights_only=True). Closes B1-D5 (the "weights_only blocks pickle RCE but not forward() code execution" caveat goes into the wrapper docs).
  * The argparse CLI entrypoint.
  * Structural-patch handling (--patch / --karpa-root). Closes B1-D13.

Tests (45 cases in test_downstream_runner.py):

  * EvalConfig: 12 cases — validation, JSON round-trip, frozen-ness, hashability, from_dict default-tolerance, list-to-tuple conversion, missing-tasks KeyError.
  * check_vocab_compatibility: 7 cases — pass at 50257, reject smaller / larger / zero, message mentions GPT-2 + actual value.
  * set_eval_determinism: 6 cases — enables deterministic algos, sets CUBLAS env var, setdefault semantics, idempotent, same seed → same RNG, different seeds → divergent RNG.
  * run_downstream_eval (core22): 4 cases — single mc task, schema dispatch, lm dispatch, multi-task.
  * run_downstream_eval (config): 9 cases — scale_label in cell key
    + CellResult, n_examples=0/N/>dataset, seed in report + cell, total_examples sum, wall_clock pass-through / default.
  * run_downstream_eval (errors): 3 cases — unknown task, missing loader, vocab mismatch (rejects BEFORE any loader runs).
  * run_downstream_eval (private_hard): 3 cases — routing through HardnessIndex, requires-index ValueError, empty-index zero cell.
  * run_downstream_eval (determinism): 1 case — byte-identical output across two runs with same kwargs.

Also updates eval/downstream/__init__.py to re-export runner symbols
+ update the "What B1 has shipped so far" docstring section.

Full suite: 349/349 passing. Ruff clean on all touched files.