### PR TITLE
validator/multiseed.py::_mean_stderr: fix floating-point flake on byte-identical samples

### DIFF
--- a/validator/multiseed.py
+++ b/validator/multiseed.py
@@ -117,13 +117,24 @@ def _mean_stderr(xs: list[float]) -> tuple[float, float]:
     correction (ddof=1). For n=1 the stderr is 0 by convention — there is
     only one observation, no within-sample variance to estimate. For
     byte-identical samples (n>=2 but all values equal) stderr is also 0.
+
+    Identical-sample short-circuit: when every element of `xs` equals
+    `xs[0]`, the mean is exactly `xs[0]` and stderr is exactly 0.0.
+    Without this guard, `sum(xs)/n` for n copies of X is generally NOT
+    equal to X in floating-point arithmetic — e.g. for n=3 the result
+    can differ from X in the last bit, which causes
+    `test_multiseed_three_runs_produce_byte_identical_results` to flake
+    on whichever values of X happen to round through `3X/3 != X`.
     """
     n = len(xs)
     if n == 0:
         return 0.0, 0.0
-    mean = sum(xs) / n
     if n == 1:
-        return mean, 0.0
+        return xs[0], 0.0
+    first = xs[0]
+    if all(x == first for x in xs):
+        return first, 0.0
+    mean = sum(xs) / n
     var = sum((x - mean) ** 2 for x in xs) / (n - 1)
     sample_std = math.sqrt(var)
     return mean, sample_std / math.sqrt(n)


### PR DESCRIPTION
Cause of the chronic CI flake on
`test_multiseed_three_runs_produce_byte_identical_results`:

When k=3 byte-identical seeds all return the same `val_bpb` value X (which is the v0.10 invariant — deterministic single-seed eval means all three runs produce the same number), the mean computation `sum(xs) / n` for `[X, X, X]` is NOT guaranteed to equal X in floating-point arithmetic. `3 * X / 3` can land one ULP off from X depending on the specific bits of X.

The test asserts `result.val_bpb_mean == val_bpbs[0]` (strict equality). The flake fires whenever the run's val_bpb happens to be a value where `(X+X+X)/3 != X` — which is most floats. The "passes in isolation but flakes in CI" pattern is because torch RNG state from prior tests in the same pytest process pushes val_bpb to different fp-bit values across runs, some of which round cleanly and some of which don't.

Fix: short-circuit `_mean_stderr` when all input values are equal — return the common value as the mean and 0.0 as the stderr. This is:

  * Mathematically exact (no fp arithmetic involved).
  * Semantically equivalent to the general path for the equal-values case (the true mean of N copies of X is exactly X).
  * Cleaner than the general path's output for byte-identical samples — stderr lands at exactly 0.0 instead of ~1e-16.

No test changes needed; the test's "byte-identical → mean equals common value" assertion is now satisfied by construction.

All 304 tests pass on main; the previously flaky test now passes reliably in isolation AND in the full suite.