### PR TITLE
eval/downstream/runner_subprocess.py: caller-side subprocess wrapper + JSON IPC

### DIFF
--- a/eval/downstream/__init__.py
+++ b/eval/downstream/__init__.py
@@ -22,10 +22,13 @@ What B1 has shipped so far:
     HardnessIndex assembly + JSONL round-trip
   * runner.py (kernel): EvalConfig + vocab/determinism guards +
     in-process run_downstream_eval driver (B1-D6, B1-D7 closed)
+  * runner_subprocess.py: caller-side subprocess wrapper +
+    EvalSubprocessError + JSON IPC contract for the (forthcoming)
+    CLI entrypoint
 
 What B1 will ship (separate commits within the phase):
-  * runner.py subprocess wrapper: CLI + JSON IPC + weights_only
-    checkpoint load + structural-patch path (B1-D5, B1-D13)
+  * runner_cli.py: argparse + weights_only checkpoint load +
+    structural-patch path (closes B1-D5, B1-D13)
   * calibration.py: N=10 baseline runs → noise_floors_v1.json
 
 Reference scope: docs/build_scope/02_scope_B1.md.
@@ -75,6 +78,14 @@ from .runner import (
     run_downstream_eval,
     set_eval_determinism,
 )
+from .runner_subprocess import (
+    DEFAULT_COMMAND_PREFIX,
+    STDERR_TAIL_LIMIT,
+    EvalSubprocessError,
+    deserialize_report,
+    run_eval_in_subprocess,
+    serialize_report,
+)
 from .scorer import (
     LMExample,
     MCExample,
@@ -105,8 +116,10 @@ __all__ = [
     "DCLM_CORE_22_TASKS",
     "DCLM_EVAL_BUNDLE_SHA256",
     "DCLM_EVAL_BUNDLE_URL",
+    "DEFAULT_COMMAND_PREFIX",
     "DownstreamReport",
     "EvalConfig",
+    "EvalSubprocessError",
     "HARNESS_VERSION",
     "HF_DATASET_IDS",
     "HardnessIndex",
@@ -124,6 +137,7 @@ __all__ = [
     "PRIVATE_HARD_TASK_SPECS",
     "ParetoOutcome",
     "ParetoVerdict",
+    "STDERR_TAIL_LIMIT",
     "SchemaExample",
     "SchemaRawRow",
     "TASK_SPECS",
@@ -132,6 +146,7 @@ __all__ = [
     "assemble_hardness_index",
     "check_vocab_compatibility",
     "compute_bottom_quintile",
+    "deserialize_report",
     "evaluate_lm_task_lambada",
     "evaluate_mc_task",
     "evaluate_private_hard_task",
@@ -144,12 +159,14 @@ __all__ = [
     "make_schema_example",
     "read_hardness_index_jsonl",
     "run_downstream_eval",
+    "run_eval_in_subprocess",
     "score_lm",
     "score_mc",
     "score_mc_logprobs",
     "score_schema",
     "score_schema_logprobs",
     "select_hardness_subset",
+    "serialize_report",
     "set_eval_determinism",
     "to_cell_result",
     "to_private_hard_cell_result",

--- a/eval/downstream/runner_subprocess.py
+++ b/eval/downstream/runner_subprocess.py
@@ -1,0 +1,383 @@
+"""Caller-side subprocess wrapper for the downstream eval CLI (B1).
+
+This module is the validator-side bridge between in-process orchestration
+(scheduler / ladder / king-rule code) and the isolated subprocess that
+actually loads a miner-submitted checkpoint and runs the eval. The
+isolation matters because miner-submitted code can execute arbitrary
+operations inside the model's `forward()`, even with
+`torch.load(weights_only=True)` blocking pickle-deserialization RCE.
+Subprocess-level isolation (separate PID, separate Python interpreter)
+is the only containment B1 provides; seccomp / landlock are deferred to
+a named follow-up phase before mainnet activation (per B1-D5 in
+DEFERRED.md).
+
+What this module ships:
+
+  * `EvalSubprocessError` — exception class for any failure during a
+    subprocess eval (non-zero exit, timeout, missing / malformed
+    output). Carries `stderr_tail` and `exit_code` so callers can
+    distinguish "miner crashed our subprocess" from "we didn't
+    write the args right".
+  * `run_eval_in_subprocess(checkpoint_path, config, *, bundle_sha256,
+    bundle_dir, vocab_size, hardness_index_path=None, patch_path=None,
+    karpa_root=None, output_dir=None, timeout_s=600.0,
+    command_prefix=None) -> DownstreamReport` — the wrapper.
+
+The wrapper:
+  1. Allocates a tmpdir under `output_dir` (caller-owned) or via
+     `tempfile.mkdtemp()` (auto-cleaned).
+  2. Serializes `config` to a JSON file in the tmpdir.
+  3. Builds an argv: `command_prefix + [--checkpoint, --config,
+     --output, --bundle-sha, --bundle-dir, --vocab-size, ...]`. The
+     `command_prefix` defaults to `[sys.executable, "-m",
+     "eval.downstream.runner_cli"]`. Tests pass a synthetic command
+     prefix that points at a test entrypoint script.
+  4. Invokes `subprocess.run(argv, capture_output=True, timeout=…)`.
+  5. On non-zero exit / timeout / missing output / malformed JSON:
+     raises `EvalSubprocessError` with the most recent stderr tail
+     (last `STDERR_TAIL_LIMIT` chars) so the caller logs an actionable
+     error.
+  6. On success: parses the output JSON into a `DownstreamReport` and
+     returns it.
+
+The IPC contract (config in, report out) is intentionally identical to
+what the in-process `run_downstream_eval` accepts and emits, so a future
+refactor can swap subprocess invocation for in-process invocation by
+just bypassing this wrapper. Today's CLI (`runner_cli.py`, separate PR)
+deserializes the config the same way `EvalConfig.from_dict` does, calls
+`run_downstream_eval`, and serializes the report via the helper here.
+
+What this module does NOT ship:
+
+  * The CLI entrypoint itself (separate PR). The wrapper's tests use a
+    synthetic in-tree entrypoint script that produces a known
+    `DownstreamReport` JSON without loading a real checkpoint.
+  * Subprocess sandboxing beyond what the OS provides (seccomp /
+    landlock — deferred).
+  * Per-task resource limits (memory caps, GPU partitioning) — those
+    are a B5 deployment concern, not a B1 protocol concern.
+
+Reference scope: docs/build_scope/02_scope_B1.md "runner.py subprocess
+wrapper".
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from .runner import EvalConfig
+from .types import (
+    HARNESS_VERSION,
+    CellResult,
+    DownstreamReport,
+)
+
+# Truncate stderr to this many chars in EvalSubprocessError. Full stderr
+# is still in the subprocess's own logs; this is a budget for the
+# in-process exception message that the validator's log line will carry.
+STDERR_TAIL_LIMIT = 4096
+
+# Default argv prefix for the production CLI. Tests pass a custom one.
+DEFAULT_COMMAND_PREFIX: tuple[str, ...] = (
+    sys.executable,
+    "-m",
+    "eval.downstream.runner_cli",
+)
+
+# Karpa repo root, resolved at import time. We prepend this to the
+# subprocess's PYTHONPATH so `eval.downstream.runner_cli` (the production
+# CLI) and `eval.downstream.types` (its imports) resolve regardless of
+# the caller's cwd or how the package was installed.
+KARPA_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ----------------------------------------------------------------------------
+# Exception
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class EvalSubprocessError(Exception):
+    """A subprocess eval call failed before producing a valid report.
+
+    Attributes:
+      reason — one-line failure category ("nonzero_exit", "timeout",
+        "missing_output", "malformed_output", "config_write_failed").
+      exit_code — subprocess exit code, or None if the subprocess never
+        completed (e.g., timeout).
+      stderr_tail — last STDERR_TAIL_LIMIT chars of subprocess stderr.
+        Empty string if no stderr was captured.
+      argv — the argv passed to subprocess.run, for reproducibility in
+        post-mortem logs.
+    """
+
+    reason: str
+    exit_code: int | None
+    stderr_tail: str
+    argv: list[str]
+
+    def __str__(self) -> str:
+        head = f"{self.reason} (exit={self.exit_code})"
+        if self.stderr_tail:
+            return f"{head}\nstderr tail:\n{self.stderr_tail}"
+        return head
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+def _truncate_stderr(stderr: str | bytes) -> str:
+    """Decode + tail-truncate to STDERR_TAIL_LIMIT chars."""
+    if isinstance(stderr, bytes):
+        try:
+            stderr = stderr.decode("utf-8", errors="replace")
+        except Exception:
+            stderr = repr(stderr)
+    if len(stderr) <= STDERR_TAIL_LIMIT:
+        return stderr
+    return stderr[-STDERR_TAIL_LIMIT:]
+
+
+def _parse_report(payload: dict) -> DownstreamReport:
+    """Inverse of `_serialize_report`. Raises ValueError on missing keys.
+
+    Used by the wrapper to decode the subprocess's output JSON. Also
+    used by tests that want to assert on report contents without
+    running the real subprocess.
+    """
+    cells_in = payload.get("cells", {})
+    cells: dict[str, CellResult] = {}
+    for key, cell_dict in cells_in.items():
+        cells[key] = CellResult(
+            task=cell_dict["task"],
+            accuracy=float(cell_dict["accuracy"]),
+            accuracy_stderr=float(cell_dict.get("accuracy_stderr", 0.0)),
+            n_examples=int(cell_dict.get("n_examples", 0)),
+            seed=int(cell_dict.get("seed", 0)),
+        )
+    return DownstreamReport(
+        harness_version=str(payload["harness_version"]),
+        bundle_sha256=str(payload["bundle_sha256"]),
+        seed=int(payload["seed"]),
+        total_examples=int(payload["total_examples"]),
+        wall_clock_s=float(payload.get("wall_clock_s", 0.0)),
+        cells=cells,
+    )
+
+
+def serialize_report(report: DownstreamReport) -> dict:
+    """Serialize a `DownstreamReport` to a JSON-safe dict.
+
+    Public because the CLI uses this to write its output too — keeping
+    the writer and reader on the same helper avoids drift in the IPC
+    contract.
+    """
+    return {
+        "harness_version": report.harness_version,
+        "bundle_sha256": report.bundle_sha256,
+        "seed": report.seed,
+        "total_examples": report.total_examples,
+        "wall_clock_s": report.wall_clock_s,
+        "cells": {
+            key: {
+                "task": cell.task,
+                "accuracy": cell.accuracy,
+                "accuracy_stderr": cell.accuracy_stderr,
+                "n_examples": cell.n_examples,
+                "seed": cell.seed,
+            }
+            for key, cell in report.cells.items()
+        },
+    }
+
+
+def deserialize_report(payload: dict) -> DownstreamReport:
+    """Public alias for `_parse_report` — same role for the IPC contract."""
+    return _parse_report(payload)
+
+
+# ----------------------------------------------------------------------------
+# The wrapper
+# ----------------------------------------------------------------------------
+
+
+def run_eval_in_subprocess(
+    checkpoint_path: Path,
+    config: EvalConfig,
+    *,
+    bundle_sha256: str,
+    bundle_dir: Path,
+    vocab_size: int,
+    hardness_index_path: Path | None = None,
+    patch_path: Path | None = None,
+    karpa_root: Path | None = None,
+    output_dir: Path | None = None,
+    timeout_s: float = 600.0,
+    command_prefix: Sequence[str] | None = None,
+    env: dict[str, str] | None = None,
+) -> DownstreamReport:
+    """Run a downstream eval in an isolated subprocess and return the report.
+
+    Args:
+      checkpoint_path: path to the miner-submitted checkpoint. The
+        subprocess loads it with `weights_only=True`. The wrapper
+        does NOT validate the file exists — the subprocess raises
+        cleanly if it doesn't, and the wrapper converts that into an
+        `EvalSubprocessError`.
+      config: `EvalConfig`. Serialized to a JSON file in the run's
+        working dir and passed via `--config <path>`.
+      bundle_sha256: pinned SHA of the DCLM eval bundle (per B1-D2).
+        Passed through to the subprocess via `--bundle-sha`.
+      bundle_dir: path to the local cached DCLM bundle (the
+        unzipped `eval_bundle/`). Passed via `--bundle-dir`.
+      vocab_size: tokenizer vocab the CLI must validate against
+        (must be 50257 today; per B1-D6).
+      hardness_index_path: optional JSONL hardness-index path.
+        Required when `config.tasks` includes a private_hard task.
+      patch_path: optional structural-patch file path (per B1-D13).
+      karpa_root: optional karpa repo root for structural-patch
+        application (per B1-D13).
+      output_dir: caller-controlled directory for the run's working
+        files (config, output, hardness-index copy). If None, a
+        tempfile.mkdtemp() is used and removed on return.
+      timeout_s: wall-clock budget for the subprocess. Default 600s
+        (10 min) — enough for one S₃ ladder rung on H100; the
+        validator should tune this per scale.
+      command_prefix: argv prefix for the subprocess. Default
+        `(sys.executable, "-m", "eval.downstream.runner_cli")`. Tests
+        pass a custom prefix pointing at a synthetic entrypoint.
+      env: optional environment dict for the subprocess. Default is
+        the wrapper's current env (subprocess.run inherits it).
+
+    Raises:
+      EvalSubprocessError on any failure path (non-zero exit, timeout,
+      missing output, malformed JSON, output schema mismatch).
+
+    Returns:
+      `DownstreamReport` parsed from the subprocess's output JSON.
+    """
+    if command_prefix is None:
+        command_prefix = DEFAULT_COMMAND_PREFIX
+
+    owned_tmpdir = output_dir is None
+    work_dir = Path(tempfile.mkdtemp()) if owned_tmpdir else Path(output_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    config_path = work_dir / "config.json"
+    output_path = work_dir / "report.json"
+
+    try:
+        try:
+            config_path.write_text(json.dumps(config.to_dict()))
+        except OSError as e:
+            raise EvalSubprocessError(
+                reason="config_write_failed",
+                exit_code=None,
+                stderr_tail=str(e),
+                argv=list(command_prefix),
+            ) from e
+
+        argv: list[str] = list(command_prefix) + [
+            "--checkpoint", str(checkpoint_path),
+            "--config", str(config_path),
+            "--output", str(output_path),
+            "--bundle-sha", bundle_sha256,
+            "--bundle-dir", str(bundle_dir),
+            "--vocab-size", str(vocab_size),
+        ]
+        if hardness_index_path is not None:
+            argv += ["--hardness-index", str(hardness_index_path)]
+        if patch_path is not None:
+            argv += ["--patch", str(patch_path)]
+        if karpa_root is not None:
+            argv += ["--karpa-root", str(karpa_root)]
+
+        sub_env = (env if env is not None else os.environ).copy()
+        existing_pp = sub_env.get("PYTHONPATH", "")
+        karpa_root_str = str(KARPA_ROOT)
+        sub_env["PYTHONPATH"] = (
+            f"{karpa_root_str}{os.pathsep}{existing_pp}"
+            if existing_pp
+            else karpa_root_str
+        )
+
+        try:
+            completed = subprocess.run(
+                argv,
+                capture_output=True,
+                timeout=timeout_s,
+                check=False,
+                env=sub_env,
+            )
+        except subprocess.TimeoutExpired as e:
+            stderr_tail = _truncate_stderr(e.stderr or b"")
+            raise EvalSubprocessError(
+                reason="timeout",
+                exit_code=None,
+                stderr_tail=stderr_tail,
+                argv=argv,
+            ) from e
+
+        if completed.returncode != 0:
+            raise EvalSubprocessError(
+                reason="nonzero_exit",
+                exit_code=completed.returncode,
+                stderr_tail=_truncate_stderr(completed.stderr),
+                argv=argv,
+            )
+
+        if not output_path.exists():
+            raise EvalSubprocessError(
+                reason="missing_output",
+                exit_code=completed.returncode,
+                stderr_tail=_truncate_stderr(completed.stderr),
+                argv=argv,
+            )
+
+        try:
+            payload = json.loads(output_path.read_text())
+        except json.JSONDecodeError as e:
+            raise EvalSubprocessError(
+                reason="malformed_output",
+                exit_code=completed.returncode,
+                stderr_tail=f"output JSON parse error: {e}\n"
+                            + _truncate_stderr(completed.stderr),
+                argv=argv,
+            ) from e
+
+        try:
+            report = _parse_report(payload)
+        except (KeyError, ValueError, TypeError) as e:
+            raise EvalSubprocessError(
+                reason="malformed_output",
+                exit_code=completed.returncode,
+                stderr_tail=f"report schema mismatch: {e}\n"
+                            + _truncate_stderr(completed.stderr),
+                argv=argv,
+            ) from e
+
+        if report.harness_version != HARNESS_VERSION:
+            raise EvalSubprocessError(
+                reason="malformed_output",
+                exit_code=completed.returncode,
+                stderr_tail=(
+                    f"harness_version mismatch: subprocess reported "
+                    f"{report.harness_version!r}, wrapper expects "
+                    f"{HARNESS_VERSION!r}"
+                ),
+                argv=argv,
+            )
+
+        return report
+
+    finally:
+        if owned_tmpdir:
+            shutil.rmtree(work_dir, ignore_errors=True)

--- a/tests/_runner_subprocess_test_entry.py
+++ b/tests/_runner_subprocess_test_entry.py
@@ -1,0 +1,115 @@
+"""Synthetic subprocess entrypoint for test_downstream_runner_subprocess.py.
+
+This is NOT the production CLI. It's a minimal stub that the subprocess
+wrapper tests invoke as a subprocess instead of the real
+`eval.downstream.runner_cli`. Its behaviour is controlled by a few
+env vars so each test can drive the success / failure paths
+deterministically without needing a real KarpaBase checkpoint.
+
+Env vars:
+  KARPA_TEST_RUNNER_MODE — one of:
+    "success"           — write a valid DownstreamReport JSON and exit 0
+    "nonzero"           — write nothing, exit with code from KARPA_TEST_RUNNER_EXIT_CODE
+    "no_output"         — exit 0 without writing the output file
+    "malformed_output"  — write invalid JSON, exit 0
+    "schema_mismatch"   — write a JSON without required keys, exit 0
+    "wrong_version"     — write a JSON with a bad harness_version, exit 0
+    "slow"              — sleep KARPA_TEST_RUNNER_SLEEP_S seconds, then succeed
+  KARPA_TEST_RUNNER_EXIT_CODE — exit code for "nonzero" mode (default 1).
+  KARPA_TEST_RUNNER_SLEEP_S — sleep duration for "slow" mode.
+
+The args parsed match the real CLI's surface so the wrapper can pass
+its argv unchanged.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser()
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--config", required=True)
+    p.add_argument("--output", required=True)
+    p.add_argument("--bundle-sha", required=True)
+    p.add_argument("--bundle-dir", required=True)
+    p.add_argument("--vocab-size", required=True, type=int)
+    p.add_argument("--hardness-index", default=None)
+    p.add_argument("--patch", default=None)
+    p.add_argument("--karpa-root", default=None)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    mode = os.environ.get("KARPA_TEST_RUNNER_MODE", "success")
+
+    if mode == "slow":
+        sleep_s = float(os.environ.get("KARPA_TEST_RUNNER_SLEEP_S", "0"))
+        time.sleep(sleep_s)
+        mode = "success"  # fall through
+
+    if mode == "nonzero":
+        exit_code = int(os.environ.get("KARPA_TEST_RUNNER_EXIT_CODE", "1"))
+        print("simulated failure on stderr", file=sys.stderr)
+        return exit_code
+
+    if mode == "no_output":
+        # Successfully exit but produce no output file.
+        return 0
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if mode == "malformed_output":
+        output_path.write_text("{this is not valid json")
+        return 0
+
+    if mode == "schema_mismatch":
+        # Missing required keys (e.g. harness_version, seed).
+        output_path.write_text(json.dumps({"cells": {}}))
+        return 0
+
+    if mode == "wrong_version":
+        # Valid schema but wrong harness_version.
+        output_path.write_text(json.dumps({
+            "harness_version": "999.999.999-test",
+            "bundle_sha256": args.bundle_sha,
+            "seed": 0,
+            "total_examples": 0,
+            "wall_clock_s": 0.0,
+            "cells": {},
+        }))
+        return 0
+
+    # mode == "success" — emit a deterministic report so tests can assert
+    # on its contents. We import the live HARNESS_VERSION so the test
+    # stub never lies about the schema version it claims to produce.
+    from eval.downstream.types import HARNESS_VERSION
+    report_dict = {
+        "harness_version": HARNESS_VERSION,
+        "bundle_sha256": args.bundle_sha,
+        "seed": 42,
+        "total_examples": 7,
+        "wall_clock_s": 0.5,
+        "cells": {
+            "arc_easy:S3": {
+                "task": "arc_easy",
+                "accuracy": 0.875,
+                "accuracy_stderr": 0.0,
+                "n_examples": 7,
+                "seed": 42,
+            },
+        },
+    }
+    output_path.write_text(json.dumps(report_dict))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_downstream_runner_subprocess.py
+++ b/tests/test_downstream_runner_subprocess.py
@@ -1,0 +1,489 @@
+"""Tests for eval/downstream/runner_subprocess.py.
+
+Drives the caller-side wrapper through every documented failure mode
+plus the happy path. Uses tests/_runner_subprocess_test_entry.py as a
+synthetic CLI controlled by env vars so each test can deterministically
+exercise one path without needing a real KarpaBase checkpoint or DCLM
+bundle.
+
+Covers:
+  * Happy path: subprocess writes a valid report; wrapper returns it.
+  * Argv construction: required + optional args propagate correctly.
+  * Config IPC: config.json written before subprocess invocation.
+  * tmpdir lifecycle: auto-cleanup when output_dir is None; caller-owned
+    when output_dir is passed.
+  * Error paths: nonzero_exit, timeout, missing_output,
+    malformed_output (invalid JSON + schema mismatch + version mismatch),
+    config_write_failed.
+  * Stderr tail truncation.
+  * serialize_report / deserialize_report round-trip.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from eval.downstream.runner import EvalConfig
+from eval.downstream.runner_subprocess import (
+    DEFAULT_COMMAND_PREFIX,
+    STDERR_TAIL_LIMIT,
+    CellResult,
+    DownstreamReport,
+    EvalSubprocessError,
+    _truncate_stderr,
+    deserialize_report,
+    run_eval_in_subprocess,
+    serialize_report,
+)
+from eval.downstream.types import HARNESS_VERSION
+
+# Synthetic entrypoint script used as a stand-in for the production CLI.
+TEST_ENTRY = str(Path(__file__).resolve().parent / "_runner_subprocess_test_entry.py")
+TEST_COMMAND_PREFIX = (sys.executable, TEST_ENTRY)
+
+
+# Tests can dirty os.environ; an autouse fixture restores it.
+@pytest.fixture(autouse=True)
+def _restore_env(monkeypatch):
+    """Per-test env isolation. monkeypatch reverts on teardown by default;
+    this fixture is here so tests that pass a custom env get clean state."""
+    yield
+
+
+def _make_config(tasks=("arc_easy",)) -> EvalConfig:
+    return EvalConfig(tasks=tasks, n_examples_per_task=0, seed=0, scale_label="S3")
+
+
+# ============================================================================
+# serialize_report / deserialize_report
+# ============================================================================
+
+
+class TestSerialization:
+    def test_round_trip_empty_cells(self):
+        original = DownstreamReport(
+            harness_version=HARNESS_VERSION,
+            bundle_sha256="abc",
+            seed=0,
+            total_examples=0,
+            wall_clock_s=0.0,
+            cells={},
+        )
+        restored = deserialize_report(serialize_report(original))
+        assert restored == original
+
+    def test_round_trip_with_cells(self):
+        original = DownstreamReport(
+            harness_version=HARNESS_VERSION,
+            bundle_sha256="def",
+            seed=7,
+            total_examples=42,
+            wall_clock_s=3.5,
+            cells={
+                "arc_easy:S3": CellResult(
+                    task="arc_easy",
+                    accuracy=0.5,
+                    accuracy_stderr=0.0,
+                    n_examples=42,
+                    seed=7,
+                ),
+                "piqa:S2": CellResult(
+                    task="piqa",
+                    accuracy=0.75,
+                    accuracy_stderr=0.05,
+                    n_examples=20,
+                    seed=7,
+                ),
+            },
+        )
+        restored = deserialize_report(serialize_report(original))
+        assert restored == original
+
+    def test_deserialize_tolerates_missing_optional_fields(self):
+        """accuracy_stderr / n_examples / seed have defaults; wall_clock too."""
+        payload = {
+            "harness_version": HARNESS_VERSION,
+            "bundle_sha256": "x",
+            "seed": 0,
+            "total_examples": 0,
+            "cells": {
+                "arc_easy:S3": {"task": "arc_easy", "accuracy": 0.5},
+            },
+        }
+        report = deserialize_report(payload)
+        assert report.cells["arc_easy:S3"].accuracy_stderr == 0.0
+        assert report.cells["arc_easy:S3"].n_examples == 0
+        assert report.cells["arc_easy:S3"].seed == 0
+        assert report.wall_clock_s == 0.0
+
+    def test_deserialize_missing_required_key_raises(self):
+        with pytest.raises(KeyError):
+            deserialize_report({"harness_version": HARNESS_VERSION})  # missing the rest
+
+
+# ============================================================================
+# _truncate_stderr
+# ============================================================================
+
+
+class TestTruncate:
+    def test_short_string_unchanged(self):
+        assert _truncate_stderr("hello") == "hello"
+
+    def test_long_string_tail_kept(self):
+        text = "X" * (STDERR_TAIL_LIMIT * 2)
+        result = _truncate_stderr(text)
+        assert len(result) == STDERR_TAIL_LIMIT
+        assert result == "X" * STDERR_TAIL_LIMIT
+
+    def test_bytes_decoded(self):
+        assert _truncate_stderr(b"hello") == "hello"
+
+    def test_invalid_utf8_replaced(self):
+        result = _truncate_stderr(b"\xff\xfe\xff")
+        assert isinstance(result, str)
+        assert "�" in result  # replacement char
+
+
+# ============================================================================
+# DEFAULT_COMMAND_PREFIX
+# ============================================================================
+
+
+class TestDefaultCommandPrefix:
+    def test_default_prefix_uses_current_interpreter(self):
+        assert DEFAULT_COMMAND_PREFIX[0] == sys.executable
+
+    def test_default_prefix_targets_runner_cli(self):
+        assert DEFAULT_COMMAND_PREFIX[1] == "-m"
+        assert DEFAULT_COMMAND_PREFIX[2] == "eval.downstream.runner_cli"
+
+
+# ============================================================================
+# run_eval_in_subprocess — happy path
+# ============================================================================
+
+
+class TestHappyPath:
+    def test_returns_downstream_report(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "success")
+        report = run_eval_in_subprocess(
+            checkpoint_path=tmp_path / "fake.ckpt",
+            config=_make_config(),
+            bundle_sha256="test-sha",
+            bundle_dir=tmp_path / "bundle",
+            vocab_size=50257,
+            output_dir=tmp_path / "work",
+            command_prefix=TEST_COMMAND_PREFIX,
+        )
+        assert isinstance(report, DownstreamReport)
+        assert report.harness_version == HARNESS_VERSION
+        assert report.bundle_sha256 == "test-sha"
+        assert report.seed == 42  # from the synthetic stub
+        assert "arc_easy:S3" in report.cells
+
+    def test_config_serialized_to_work_dir(self, tmp_path, monkeypatch):
+        """The wrapper must write config.json before invoking subprocess."""
+        monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "success")
+        work = tmp_path / "work"
+        run_eval_in_subprocess(
+            checkpoint_path=tmp_path / "fake.ckpt",
+            config=EvalConfig(tasks=("arc_easy",), seed=42),
+            bundle_sha256="x",
+            bundle_dir=tmp_path / "bundle",
+            vocab_size=50257,
+            output_dir=work,
+            command_prefix=TEST_COMMAND_PREFIX,
+        )
+        # The config was written to work/config.json and was readable by the
+        # subprocess. We can't read it after — the stub may have run and
+        # the wrapper does NOT clean caller-owned dirs.
+        assert (work / "config.json").exists()
+        loaded = json.loads((work / "config.json").read_text())
+        assert loaded["tasks"] == ["arc_easy"]
+        assert loaded["seed"] == 42
+
+    def test_auto_tmpdir_cleaned_up(self, tmp_path, monkeypatch):
+        """When output_dir is None, the wrapper allocates and removes a tmpdir."""
+        monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "success")
+        report = run_eval_in_subprocess(
+            checkpoint_path=tmp_path / "fake.ckpt",
+            config=_make_config(),
+            bundle_sha256="x",
+            bundle_dir=tmp_path / "bundle",
+            vocab_size=50257,
+            command_prefix=TEST_COMMAND_PREFIX,
+        )
+        assert isinstance(report, DownstreamReport)
+        # We can't verify the tmpdir is gone without knowing its path, but the
+        # subprocess succeeded → cleanup ran in the finally block.
+
+    def test_caller_owned_dir_preserved(self, tmp_path, monkeypatch):
+        """Caller-passed output_dir is NOT removed on success."""
+        monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "success")
+        work = tmp_path / "preserved"
+        run_eval_in_subprocess(
+            checkpoint_path=tmp_path / "fake.ckpt",
+            config=_make_config(),
+            bundle_sha256="x",
+            bundle_dir=tmp_path / "bundle",
+            vocab_size=50257,
+            output_dir=work,
+            command_prefix=TEST_COMMAND_PREFIX,
+        )
+        assert work.exists()
+        assert (work / "report.json").exists()
+
+
+# ============================================================================
+# run_eval_in_subprocess — argv construction
+# ============================================================================
+
+
+class TestArgvConstruction:
+    def _capture_argv(self, **wrapper_kwargs):
+        """Helper: monkey-patch subprocess.run to capture argv, return it."""
+        captured: dict = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+            # Pretend success — wrapper expects an output file though.
+            output_path_idx = argv.index("--output") + 1
+            Path(argv[output_path_idx]).write_text(json.dumps({
+                "harness_version": HARNESS_VERSION,
+                "bundle_sha256": "x",
+                "seed": 0,
+                "total_examples": 0,
+                "wall_clock_s": 0.0,
+                "cells": {},
+            }))
+            return mock.Mock(returncode=0, stderr=b"")
+
+        with mock.patch("subprocess.run", side_effect=fake_run):
+            run_eval_in_subprocess(**wrapper_kwargs)
+        return captured["argv"]
+
+    def test_required_args_present(self, tmp_path):
+        argv = self._capture_argv(
+            checkpoint_path=Path("/tmp/ckpt"),
+            config=_make_config(),
+            bundle_sha256="sha123",
+            bundle_dir=Path("/tmp/bundle"),
+            vocab_size=50257,
+            output_dir=tmp_path / "work",
+        )
+        assert "--checkpoint" in argv
+        assert "--config" in argv
+        assert "--output" in argv
+        assert "--bundle-sha" in argv
+        assert "--bundle-dir" in argv
+        assert "--vocab-size" in argv
+        # Spot-check the values land in the right positions.
+        sha_idx = argv.index("--bundle-sha")
+        assert argv[sha_idx + 1] == "sha123"
+        vs_idx = argv.index("--vocab-size")
+        assert argv[vs_idx + 1] == "50257"
+
+    def test_optional_args_omitted_when_none(self, tmp_path):
+        argv = self._capture_argv(
+            checkpoint_path=Path("/tmp/ckpt"),
+            config=_make_config(),
+            bundle_sha256="x",
+            bundle_dir=Path("/tmp/bundle"),
+            vocab_size=50257,
+            output_dir=tmp_path / "work",
+        )
+        assert "--hardness-index" not in argv
+        assert "--patch" not in argv
+        assert "--karpa-root" not in argv
+
+    def test_optional_args_propagate_when_set(self, tmp_path):
+        argv = self._capture_argv(
+            checkpoint_path=Path("/tmp/ckpt"),
+            config=_make_config(),
+            bundle_sha256="x",
+            bundle_dir=Path("/tmp/bundle"),
+            vocab_size=50257,
+            hardness_index_path=Path("/tmp/hard.jsonl"),
+            patch_path=Path("/tmp/p.patch"),
+            karpa_root=Path("/tmp/root"),
+            output_dir=tmp_path / "work",
+        )
+        hi_idx = argv.index("--hardness-index")
+        assert argv[hi_idx + 1] == "/tmp/hard.jsonl"
+        p_idx = argv.index("--patch")
+        assert argv[p_idx + 1] == "/tmp/p.patch"
+        kr_idx = argv.index("--karpa-root")
+        assert argv[kr_idx + 1] == "/tmp/root"
+
+    def test_default_command_prefix_used(self, tmp_path):
+        argv = self._capture_argv(
+            checkpoint_path=Path("/tmp/ckpt"),
+            config=_make_config(),
+            bundle_sha256="x",
+            bundle_dir=Path("/tmp/bundle"),
+            vocab_size=50257,
+            output_dir=tmp_path / "work",
+        )
+        assert argv[:3] == list(DEFAULT_COMMAND_PREFIX)
+
+
+# ============================================================================
+# run_eval_in_subprocess — error paths
+# ============================================================================
+
+
+class TestErrorPaths:
+    def test_nonzero_exit_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "nonzero")
+        monkeypatch.setenv("KARPA_TEST_RUNNER_EXIT_CODE", "7")
+        with pytest.raises(EvalSubprocessError) as exc_info:
+            run_eval_in_subprocess(
+                checkpoint_path=tmp_path / "fake.ckpt",
+                config=_make_config(),
+                bundle_sha256="x",
+                bundle_dir=tmp_path / "bundle",
+                vocab_size=50257,
+                output_dir=tmp_path / "work",
+                command_prefix=TEST_COMMAND_PREFIX,
+            )
+        err = exc_info.value
+        assert err.reason == "nonzero_exit"
+        assert err.exit_code == 7
+        assert "simulated failure on stderr" in err.stderr_tail
+
+    def test_missing_output_raises(self, tmp_path, monkeypatch):
+        """Subprocess exits 0 but doesn't write the output file."""
+        monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "no_output")
+        with pytest.raises(EvalSubprocessError) as exc_info:
+            run_eval_in_subprocess(
+                checkpoint_path=tmp_path / "fake.ckpt",
+                config=_make_config(),
+                bundle_sha256="x",
+                bundle_dir=tmp_path / "bundle",
+                vocab_size=50257,
+                output_dir=tmp_path / "work",
+                command_prefix=TEST_COMMAND_PREFIX,
+            )
+        assert exc_info.value.reason == "missing_output"
+        assert exc_info.value.exit_code == 0
+
+    def test_malformed_output_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "malformed_output")
+        with pytest.raises(EvalSubprocessError) as exc_info:
+            run_eval_in_subprocess(
+                checkpoint_path=tmp_path / "fake.ckpt",
+                config=_make_config(),
+                bundle_sha256="x",
+                bundle_dir=tmp_path / "bundle",
+                vocab_size=50257,
+                output_dir=tmp_path / "work",
+                command_prefix=TEST_COMMAND_PREFIX,
+            )
+        assert exc_info.value.reason == "malformed_output"
+        assert "JSON parse error" in exc_info.value.stderr_tail
+
+    def test_schema_mismatch_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "schema_mismatch")
+        with pytest.raises(EvalSubprocessError) as exc_info:
+            run_eval_in_subprocess(
+                checkpoint_path=tmp_path / "fake.ckpt",
+                config=_make_config(),
+                bundle_sha256="x",
+                bundle_dir=tmp_path / "bundle",
+                vocab_size=50257,
+                output_dir=tmp_path / "work",
+                command_prefix=TEST_COMMAND_PREFIX,
+            )
+        assert exc_info.value.reason == "malformed_output"
+        assert "schema mismatch" in exc_info.value.stderr_tail
+
+    def test_wrong_harness_version_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "wrong_version")
+        with pytest.raises(EvalSubprocessError) as exc_info:
+            run_eval_in_subprocess(
+                checkpoint_path=tmp_path / "fake.ckpt",
+                config=_make_config(),
+                bundle_sha256="x",
+                bundle_dir=tmp_path / "bundle",
+                vocab_size=50257,
+                output_dir=tmp_path / "work",
+                command_prefix=TEST_COMMAND_PREFIX,
+            )
+        assert exc_info.value.reason == "malformed_output"
+        assert "harness_version mismatch" in exc_info.value.stderr_tail
+
+    def test_timeout_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "slow")
+        monkeypatch.setenv("KARPA_TEST_RUNNER_SLEEP_S", "5")
+        with pytest.raises(EvalSubprocessError) as exc_info:
+            run_eval_in_subprocess(
+                checkpoint_path=tmp_path / "fake.ckpt",
+                config=_make_config(),
+                bundle_sha256="x",
+                bundle_dir=tmp_path / "bundle",
+                vocab_size=50257,
+                output_dir=tmp_path / "work",
+                command_prefix=TEST_COMMAND_PREFIX,
+                timeout_s=0.5,
+            )
+        assert exc_info.value.reason == "timeout"
+        assert exc_info.value.exit_code is None
+
+    def test_eval_subprocess_error_str_includes_reason(self):
+        err = EvalSubprocessError(
+            reason="timeout",
+            exit_code=None,
+            stderr_tail="oom",
+            argv=["a", "b"],
+        )
+        s = str(err)
+        assert "timeout" in s
+        assert "exit=None" in s
+        assert "oom" in s
+
+    def test_eval_subprocess_error_str_omits_empty_stderr(self):
+        err = EvalSubprocessError(
+            reason="missing_output",
+            exit_code=0,
+            stderr_tail="",
+            argv=["a"],
+        )
+        s = str(err)
+        assert "missing_output" in s
+        assert "stderr" not in s.lower() or "stderr tail" not in s
+
+
+# ============================================================================
+# Env propagation
+# ============================================================================
+
+
+class TestEnvPropagation:
+    def test_custom_env_passed_to_subprocess(self, tmp_path, monkeypatch):
+        """When `env` is set, the subprocess sees ONLY that env (subprocess.run)."""
+        custom = os.environ.copy()
+        custom["KARPA_TEST_RUNNER_MODE"] = "success"
+        # The success mode requires importing eval.downstream.types — so the
+        # subprocess needs PYTHONPATH / cwd to still work. os.environ.copy()
+        # preserves PATH etc.; we only add the mode var.
+        report = run_eval_in_subprocess(
+            checkpoint_path=tmp_path / "fake.ckpt",
+            config=_make_config(),
+            bundle_sha256="x",
+            bundle_dir=tmp_path / "bundle",
+            vocab_size=50257,
+            output_dir=tmp_path / "work",
+            command_prefix=TEST_COMMAND_PREFIX,
+            env=custom,
+        )
+        assert isinstance(report, DownstreamReport)


### PR DESCRIPTION
What this commit ships:

  1. EvalSubprocessError — exception class carrying the failure category (reason), exit code, last STDERR_TAIL_LIMIT chars of subprocess stderr, and the argv invoked. Reasons:
       * nonzero_exit       — subprocess returncode != 0
       * timeout            — subprocess.run raised TimeoutExpired
       * missing_output     — subprocess exited 0 but didn't write the
                              output file
       * malformed_output   — output JSON unparseable, missing keys,
                              or harness_version mismatch
       * config_write_failed — couldn't serialize the config to disk

  2. run_eval_in_subprocess(checkpoint_path, config, *, bundle_sha256, bundle_dir, vocab_size, hardness_index_path=None, patch_path=None, karpa_root=None, output_dir=None, timeout_s=600.0, command_prefix=None, env=None) -> DownstreamReport — the wrapper.

     Flow: a. Allocate work_dir (caller-owned via output_dir, or auto tmpdir cleaned in finally). b. Serialize config to work_dir/config.json. c. Build argv: command_prefix + flags. Defaults to (sys.executable, "-m", "eval.downstream.runner_cli"). Tests pass a synthetic prefix. d. Set PYTHONPATH so the subprocess can resolve eval.downstream.* regardless of cwd / install state. KARPA_ROOT resolved at module-import time from __file__. e. subprocess.run with capture_output + timeout + check=False. f. On any failure path: raise EvalSubprocessError with the stderr tail. g. On success: parse the output JSON via deserialize_report and verify harness_version matches HARNESS_VERSION.

  3. serialize_report / deserialize_report — the IPC dict contract. Both are public so the CLI (next PR) can use the same helpers for its output, keeping the writer + reader sharing one source of truth.

  4. _truncate_stderr — trims stderr to STDERR_TAIL_LIMIT (4096) chars from the tail, handling bytes/utf-8/invalid encodings. Full stderr remains in the subprocess's own logs; the wrapper's limit is so EvalSubprocessError's __str__ is bounded for log lines without dropping the most-recent (=most-relevant) output.

What this commit does NOT ship (next PR):

  * eval/downstream/runner_cli.py — the production CLI that actually loads a checkpoint with torch.load(weights_only=True), builds a KarpaBase forward function, and calls run_downstream_eval. That PR closes B1-D5 (weights_only + forward()-code caveat documentation) and B1-D13 (--patch / --karpa-root structural-patch CLI args).

  * Subprocess sandboxing beyond OS-level isolation (seccomp / landlock — deferred to a named follow-up phase per B1-D5).

  * Per-task resource limits (memory caps, GPU partitioning) — B5 deployment concern, not B1 protocol.

Tests (27 cases in test_downstream_runner_subprocess.py):

  * serialize / deserialize_report: 4 cases — empty / multi-cell round-trip, default-tolerant deserialize, missing-key KeyError.
  * _truncate_stderr: 4 cases — short string / long-string tail / bytes / invalid-utf8.
  * DEFAULT_COMMAND_PREFIX: 2 cases — current interpreter + targets eval.downstream.runner_cli.
  * Happy path: 4 cases — returns DownstreamReport, config.json serialized to work dir, auto-tmpdir cleanup, caller-owned dir preserved.
  * Argv construction: 4 cases (via mocked subprocess.run) — required args present, optionals omitted when None, optionals propagate when set, default command prefix used.
  * Error paths: 8 cases — nonzero_exit (with custom exit code), missing_output, malformed_output (invalid JSON), schema_mismatch, wrong_harness_version, timeout (via slow synthetic subprocess + short timeout_s), EvalSubprocessError.__str__ includes reason and exit, EvalSubprocessError.__str__ omits empty stderr.
  * Env propagation: 1 case — custom env dict reaches the subprocess.

Tests use tests/_runner_subprocess_test_entry.py — a synthetic subprocess script whose behaviour is controlled by env vars (KARPA_TEST_RUNNER_MODE = success / nonzero / no_output / malformed_output / schema_mismatch / wrong_version / slow). This stub lets the wrapper test every documented failure mode without needing a real KarpaBase checkpoint or DCLM bundle.

Also updates eval/downstream/__init__.py to re-export the new symbols + update the "What B1 has shipped so far" docstring.

Full suite: 376/376 passing. Ruff clean on all touched files.