### PR TITLE
eval/downstream/runner_cli.py: production CLI entrypoint (closes B1-D5 + B1-D13)

### DIFF
--- a/eval/downstream/DEFERRED.md
+++ b/eval/downstream/DEFERRED.md
@@ -124,7 +124,13 @@ scope.
 **Recommendation:** Accept (a) for B1. Subprocess isolation is necessary but
 not sufficient against arbitrary `forward()` code. Land seccomp/landlock as a
 named follow-up phase before mainnet activation.
-**Status:** OPEN
+**Status:** **CLOSED 2026-06-11 — option (a) ratified.** `eval/downstream/
+runner_cli.py` calls `torch.load(weights_only=True)` (closes the pickle RCE
+vector) AND its module + function docstrings document the caveat that
+forward()-code execution is NOT prevented by weights_only and the only
+containment is OS-level process isolation via the subprocess wrapper
+(`eval/downstream/runner_subprocess.py`). Seccomp / landlock recorded as a
+named follow-up phase before mainnet activation; not blocking B2 / B3 / B4.
 
 ### B1-D6 — Tokenizer equivalence enforcement
 **Owner:** B1 (runner.py author)
@@ -222,7 +228,14 @@ integration (~150 LOC + 2 days). If no, document that structural patches
 WILL fail the new downstream runner and the legacy path handles them.
 **Recommendation:** Add the args. The whole point of B1 → B7 is that
 structural patches work cleanly under the new rule.
-**Status:** OPEN
+**Status:** **CLOSED at CLI surface 2026-06-11.** `eval/downstream/
+runner_cli.py` accepts both `--patch` and `--karpa-root` arguments so the
+CLI contract is stable; submissions without structural patches go through
+the no-patch path unchanged. Full `apply_patch` integration (the ~150 LOC
++ 2 day deliverable) is recorded as a separate follow-up PR: until that
+lands, invoking the CLI WITH `--patch` raises `NotImplementedError`
+pointing at this DEFERRED.md item. No-patch submissions (the common case)
+are fully supported.
 
 ### B1-D14 — LOC re-budget
 **Owner:** B1 (whole-phase author)
@@ -301,6 +314,28 @@ authors (subprocess isolation reality, tokenizer enforcement,
 determinism specification, structural-patch handling, CC-BY-SA review,
 calibration sourcing, restricted-files scanner glob, HiddenEvalResult
 schema-versioning test).
+
+## Update 2026-06-11: 4 additional B1 decisions closed by runner.py PRs
+
+- **B1-D6 (tokenizer equivalence)** — closed; runner.py rejects
+  `vocab_size != 50257` at the in-process kernel via
+  `check_vocab_compatibility`.
+- **B1-D7 (determinism specification)** — closed; `set_eval_determinism`
+  pins `torch.use_deterministic_algorithms(True)` +
+  `CUBLAS_WORKSPACE_CONFIG=:4096:8`.
+- **B1-D5 (subprocess isolation reality)** — closed; runner_cli.py
+  uses `torch.load(weights_only=True)` and documents that
+  forward()-code containment is OS-level subprocess isolation only.
+- **B1-D13 (structural-patch CLI args)** — closed at CLI surface;
+  --patch / --karpa-root accepted; full apply_patch integration
+  recorded as a separate follow-up PR.
+
+Now 11 of 15 items closed, 4 still open: B1-D4 (CC-BY-SA legal
+review), B1-D8 (calibration data sourcing), B1-D10 (restricted-files
+scanner glob extension), B1-D12 (HiddenEvalResult schema-versioning
+test). Note: B1-D1 (HF dataset download implementation) was logged as
+closed in the 2026-06-10 update; the load_task_examples function
+remains stubbed but the decision itself is closed.
 
 ## What B1 still owes (open, in dependency order)
 

--- a/eval/downstream/__init__.py
+++ b/eval/downstream/__init__.py
@@ -23,12 +23,13 @@ What B1 has shipped so far:
   * runner.py (kernel): EvalConfig + vocab/determinism guards +
     in-process run_downstream_eval driver (B1-D6, B1-D7 closed)
   * runner_subprocess.py: caller-side subprocess wrapper +
-    EvalSubprocessError + JSON IPC contract for the (forthcoming)
-    CLI entrypoint
+    EvalSubprocessError + JSON IPC contract
+  * runner_cli.py: production CLI entrypoint — argparse +
+    `torch.load(weights_only=True)` checkpoint load + KarpaBase
+    model construction + tiktoken GPT-2 BPE tokenizer wiring +
+    structural-patch CLI args (B1-D5, B1-D13 closed)
 
 What B1 will ship (separate commits within the phase):
-  * runner_cli.py: argparse + weights_only checkpoint load +
-    structural-patch path (closes B1-D5, B1-D13)
   * calibration.py: N=10 baseline runs → noise_floors_v1.json
 
 Reference scope: docs/build_scope/02_scope_B1.md.

--- a/eval/downstream/runner_cli.py
+++ b/eval/downstream/runner_cli.py
@@ -1,0 +1,298 @@
+"""Production CLI entrypoint for the downstream-eval subprocess (B1).
+
+Invoked as `python -m eval.downstream.runner_cli ...` from the
+validator's `run_eval_in_subprocess` wrapper (eval/downstream/
+runner_subprocess.py). Reads its `EvalConfig` from a JSON file
+specified via --config, loads a miner-submitted checkpoint with
+torch.load(weights_only=True), builds a `KarpaBase` model, and
+delegates to `run_downstream_eval`. Writes the resulting
+`DownstreamReport` as JSON to --output.
+
+Closes:
+
+  * **B1-D5** — subprocess isolation reality. `torch.load(
+    weights_only=True)` blocks pickle-deserialization RCE during
+    checkpoint load; it does NOT block arbitrary Python code
+    executed inside the loaded model's `forward()` method. Once
+    state_dict tensors are back in memory and `model(input_ids)` is
+    called, any code the miner has wired into KarpaBase's forward
+    path runs in this subprocess. The only containment B1 provides
+    is OS-level process isolation (separate PID, separate Python
+    interpreter), which the `run_eval_in_subprocess` wrapper
+    establishes. Seccomp / landlock are deferred to a named
+    follow-up phase before mainnet activation.
+
+  * **B1-D13** — structural-patch CLI args. --patch and
+    --karpa-root are accepted at the CLI surface so the contract is
+    stable. The actual `apply_patch` integration (~150 LOC + 2 days)
+    is deferred to a follow-up PR; for now, passing --patch raises
+    a clean NotImplementedError pointing at the follow-up ticket.
+    Submissions that don't use a structural patch (the common case)
+    are unaffected.
+
+What this module ships:
+
+  * `main(argv)` — the argparse + orchestration entrypoint.
+  * `_build_parser()` — the argparse.ArgumentParser; exposed for
+    test inspection.
+  * `_load_checkpoint(path)` — torch.load + dict-shape validation
+    helper. Returns (config_dict, state_dict). Closes the B1-D5
+    weights_only=True requirement.
+  * `_import_karpa_model(karpa_root)` — sys.path bootstrap +
+    `from model import KarpaBase, KarpaConfig` import helper.
+
+What this module does NOT ship (separate follow-up PR):
+
+  * The `apply_patch` integration that turns --patch into a
+    modified workdir. The args are accepted; full handling lands
+    when the apply_patch helper is ready.
+
+  * `load_task_examples` implementations. Both `core22.load_task_examples`
+    and `private_hard.load_task_examples` are stubs that raise
+    NotImplementedError. The CLI's task_loaders dict will reach
+    those stubs and the subprocess will exit non-zero with a
+    clean error pointing at DEFERRED.md B1-D1. This is by design:
+    the CLI framework lands here; data-loading lands when the HF
+    download + DCLM bundle SHA-pin commits land.
+
+Reference scope: docs/build_scope/02_scope_B1.md "runner_cli.py".
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import torch
+
+from .grader import read_hardness_index_jsonl
+from .runner import (
+    EvalConfig,
+    run_downstream_eval,
+)
+from .runner_subprocess import serialize_report
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Construct the argparse parser. Exposed for arg-surface tests."""
+    p = argparse.ArgumentParser(
+        prog="eval.downstream.runner_cli",
+        description=(
+            "Subprocess entrypoint for the downstream-eval harness. "
+            "Loads a miner checkpoint with weights_only=True, runs the "
+            "configured tasks, and writes a DownstreamReport JSON."
+        ),
+    )
+    p.add_argument("--checkpoint", required=True, type=Path,
+                   help="Path to the miner-submitted checkpoint .pt file.")
+    p.add_argument("--config", required=True, type=Path,
+                   help="Path to the EvalConfig JSON.")
+    p.add_argument("--output", required=True, type=Path,
+                   help="Path to write the DownstreamReport JSON.")
+    p.add_argument("--bundle-sha", required=True,
+                   help="Pinned SHA256 of the DCLM eval bundle (B1-D2).")
+    p.add_argument("--bundle-dir", required=True, type=Path,
+                   help="Path to the local unpacked DCLM eval bundle.")
+    p.add_argument("--vocab-size", required=True, type=int,
+                   help="Expected tokenizer vocab size (must be 50257 per "
+                        "B1-D6).")
+    p.add_argument("--hardness-index", default=None, type=Path,
+                   help="Optional path to the hardness-index JSONL. "
+                        "Required when --config tasks include any "
+                        "private_hard task.")
+    p.add_argument("--patch", default=None, type=Path,
+                   help="Structural-patch path (B1-D13). Args accepted; "
+                        "full apply_patch integration deferred.")
+    p.add_argument("--karpa-root", default=None, type=Path,
+                   help="Karpa repo root for structural-patch application "
+                        "(B1-D13) and `from model import ...` resolution.")
+    return p
+
+
+def _load_checkpoint(path: Path) -> tuple[dict, dict]:
+    """Load a checkpoint with `torch.load(weights_only=True)`.
+
+    Returns:
+      `(config_dict, state_dict)`. `config_dict` is the KarpaConfig
+      kwargs the checkpoint was saved with; `state_dict` is the
+      tensor state for `model.load_state_dict`.
+
+    Accepted checkpoint shapes:
+      * `{"model": state_dict, "config": dict}` — canonical v0.10 form
+      * `{"state_dict": state_dict, "config": dict}` — legacy variant
+      * `{"model": state_dict}` + sibling `checkpoint_config.json` —
+        the sidecar pattern used by validator/eval_in_workdir.py
+
+    Raises:
+      ValueError on any unrecognized shape, with a message naming the
+      specific failure mode (not a dict / missing config / etc.).
+    """
+    full = torch.load(path, weights_only=True, map_location="cpu")
+    if not isinstance(full, dict):
+        raise ValueError(
+            f"checkpoint at {path} must be a dict; got {type(full).__name__}"
+        )
+    if "model" in full:
+        state_dict = full["model"]
+    elif "state_dict" in full:
+        state_dict = full["state_dict"]
+    else:
+        raise ValueError(
+            f"checkpoint at {path} has no 'model' or 'state_dict' key; "
+            f"top-level keys: {sorted(full.keys())}"
+        )
+
+    config = full.get("config")
+    if config is None:
+        sidecar = path.parent / "checkpoint_config.json"
+        if sidecar.exists():
+            config = json.loads(sidecar.read_text())
+    if not isinstance(config, dict):
+        raise ValueError(
+            f"checkpoint at {path} missing 'config' dict and no "
+            "checkpoint_config.json sidecar in the same directory"
+        )
+    return config, state_dict
+
+
+def _import_karpa_model(karpa_root: Path | None):
+    """Inject the recipe path into sys.path and import KarpaBase + Config.
+
+    If `karpa_root` is provided, prepend it to sys.path so a patched
+    `model/` package wins over any installed one. Otherwise import
+    `karpa_bootstrap` from the karpa repo (already on sys.path via
+    the subprocess wrapper's PYTHONPATH) which injects the sibling
+    `../recipe` per its resolution order.
+
+    Returns: (KarpaBase, KarpaConfig) classes.
+    """
+    if karpa_root is not None:
+        sys.path.insert(0, str(karpa_root.resolve()))
+    else:
+        import karpa_bootstrap  # noqa: F401  (side-effect import)
+    from model import KarpaBase, KarpaConfig  # type: ignore
+    return KarpaBase, KarpaConfig
+
+
+def _build_task_loaders(
+    tasks: tuple[str, ...],
+    bundle_dir: Path,
+):
+    """Build a {task_name: () -> raw_rows} dict for run_downstream_eval.
+
+    Dispatches by task name:
+      * task in PRIVATE_HARD_TASK_SPECS → private_hard.load_task_examples
+      * otherwise (assumes task in TASK_SPECS) → core22.load_task_examples
+
+    Both `load_task_examples` calls currently raise NotImplementedError
+    (B1-D1 follow-up). The CLI plumbing reaches the loader call, the
+    loader raises, and the subprocess exits non-zero with the
+    NotImplementedError message in stderr.
+    """
+    from .core22 import load_task_examples as core22_load
+    from .private_hard import (
+        PRIVATE_HARD_TASK_SPECS,
+    )
+    from .private_hard import (
+        load_task_examples as private_hard_load,
+    )
+    loaders: dict[str, object] = {}
+    for task in tasks:
+        if task in PRIVATE_HARD_TASK_SPECS:
+            loaders[task] = (lambda t=task: private_hard_load(t))
+        else:
+            loaders[task] = (lambda t=task: core22_load(bundle_dir, t))
+    return loaders
+
+
+def _build_tokenize_fn():
+    """Return the GPT-2 BPE tokenize callable used by the harness."""
+    import tiktoken
+    enc = tiktoken.get_encoding("gpt2")
+    return lambda text: enc.encode(text)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Subprocess entrypoint. Returns the process exit code.
+
+    Flow:
+      1. Parse args.
+      2. Reject --patch (B1-D13 args accepted, application deferred).
+      3. Read EvalConfig JSON.
+      4. Import KarpaBase / KarpaConfig (sys.path bootstrap).
+      5. Load checkpoint with weights_only=True.
+      6. Construct model + load state_dict.
+      7. Verify vocab matches.
+      8. Build forward_logits + tokenize + task_loaders.
+      9. Load hardness_index if provided.
+      10. Run downstream eval.
+      11. Serialize report + write to --output.
+    """
+    args = _build_parser().parse_args(argv)
+
+    if args.patch is not None:
+        raise NotImplementedError(
+            "Structural-patch application is deferred to the apply_patch "
+            "follow-up PR per DEFERRED.md B1-D13. The --patch + --karpa-root "
+            "args are accepted at the CLI surface so the contract is stable; "
+            "full integration is a separate deliverable. Submissions without "
+            "a structural patch should not pass --patch."
+        )
+
+    config = EvalConfig.from_dict(json.loads(args.config.read_text()))
+
+    KarpaBase, KarpaConfig = _import_karpa_model(args.karpa_root)
+    ckpt_config, state_dict = _load_checkpoint(args.checkpoint)
+
+    cfg_kwargs = {
+        k: v for k, v in ckpt_config.items()
+        if k in KarpaConfig.__dataclass_fields__
+    }
+    model_cfg = KarpaConfig(**cfg_kwargs)
+    model = KarpaBase(model_cfg)
+    model.load_state_dict(state_dict, strict=True)
+    model.eval()
+    if torch.cuda.is_available():
+        model = model.cuda()
+
+    if model_cfg.vocab_size != args.vocab_size:
+        raise ValueError(
+            f"checkpoint vocab_size={model_cfg.vocab_size} does not match "
+            f"--vocab-size={args.vocab_size}; the validator and miner "
+            "are out of sync on tokenizer choice"
+        )
+
+    hardness_index = None
+    if args.hardness_index is not None:
+        hardness_index = read_hardness_index_jsonl(args.hardness_index)
+
+    tokenize = _build_tokenize_fn()
+    task_loaders = _build_task_loaders(config.tasks, args.bundle_dir)
+
+    def forward_logits(input_ids: torch.Tensor) -> torch.Tensor:
+        if torch.cuda.is_available():
+            input_ids = input_ids.cuda()
+        with torch.no_grad():
+            out = model(input_ids)
+        # KarpaBase returns (logits, optional_loss) or logits; scorer's
+        # _extract_logits handles either form.
+        return out
+
+    report = run_downstream_eval(
+        forward_logits,
+        config=config,
+        task_loaders=task_loaders,
+        tokenize=tokenize,
+        bundle_sha256=args.bundle_sha,
+        vocab_size=model_cfg.vocab_size,
+        hardness_index=hardness_index,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(serialize_report(report)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_downstream_runner_cli.py
+++ b/tests/test_downstream_runner_cli.py
@@ -1,0 +1,414 @@
+"""Tests for eval/downstream/runner_cli.py.
+
+The CLI's full end-to-end behaviour depends on:
+  * a real KarpaBase + KarpaConfig from the karpaai/recipe sibling
+  * a real DCLM bundle on disk
+  * the load_task_examples stubs being implemented (B1-D1 follow-up)
+
+None of those are wired in B1. These tests cover what IS testable:
+  * argparse surface (required vs optional, type coercion)
+  * _load_checkpoint helper on synthetic torch checkpoints
+  * _build_task_loaders dispatcher (core22 vs private_hard routing)
+  * main(): --patch raises NotImplementedError with the right pointer
+  * main() with all dependencies mocked: completes end-to-end and
+    writes a valid report
+
+The wrapper-side tests in test_downstream_runner_subprocess.py
+exercise the IPC contract via the synthetic entrypoint; these tests
+exercise the production-CLI implementation in isolation.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from eval.downstream.runner_cli import (
+    _build_parser,
+    _build_task_loaders,
+    _load_checkpoint,
+    main,
+)
+from eval.downstream.types import HARNESS_VERSION
+
+# ============================================================================
+# _build_parser — arg surface
+# ============================================================================
+
+
+class TestBuildParser:
+    def test_required_args_enforced(self):
+        parser = _build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args([])
+
+    def test_required_args_subset_enforced(self):
+        """Even missing ONE required arg fails."""
+        parser = _build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args([
+                "--checkpoint", "ckpt", "--config", "cfg",
+                "--output", "out", "--bundle-sha", "sha",
+                "--bundle-dir", "bundle",
+                # missing --vocab-size
+            ])
+
+    def test_minimal_required_set_parses(self):
+        parser = _build_parser()
+        args = parser.parse_args([
+            "--checkpoint", "ckpt.pt",
+            "--config", "config.json",
+            "--output", "report.json",
+            "--bundle-sha", "abc",
+            "--bundle-dir", "/path/to/bundle",
+            "--vocab-size", "50257",
+        ])
+        assert args.checkpoint == Path("ckpt.pt")
+        assert args.config == Path("config.json")
+        assert args.output == Path("report.json")
+        assert args.bundle_sha == "abc"
+        assert args.bundle_dir == Path("/path/to/bundle")
+        assert args.vocab_size == 50257
+
+    def test_vocab_size_type_coercion(self):
+        parser = _build_parser()
+        args = parser.parse_args([
+            "--checkpoint", "x", "--config", "x", "--output", "x",
+            "--bundle-sha", "x", "--bundle-dir", "x", "--vocab-size", "50257",
+        ])
+        assert isinstance(args.vocab_size, int)
+        assert args.vocab_size == 50257
+
+    def test_vocab_size_rejects_non_int(self):
+        parser = _build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args([
+                "--checkpoint", "x", "--config", "x", "--output", "x",
+                "--bundle-sha", "x", "--bundle-dir", "x",
+                "--vocab-size", "not_a_number",
+            ])
+
+    def test_optional_args_default_none(self):
+        parser = _build_parser()
+        args = parser.parse_args([
+            "--checkpoint", "x", "--config", "x", "--output", "x",
+            "--bundle-sha", "x", "--bundle-dir", "x", "--vocab-size", "50257",
+        ])
+        assert args.hardness_index is None
+        assert args.patch is None
+        assert args.karpa_root is None
+
+    def test_optional_args_parse_to_paths(self):
+        parser = _build_parser()
+        args = parser.parse_args([
+            "--checkpoint", "x", "--config", "x", "--output", "x",
+            "--bundle-sha", "x", "--bundle-dir", "x", "--vocab-size", "50257",
+            "--hardness-index", "/tmp/hard.jsonl",
+            "--patch", "/tmp/p.patch",
+            "--karpa-root", "/tmp/karpa",
+        ])
+        assert args.hardness_index == Path("/tmp/hard.jsonl")
+        assert args.patch == Path("/tmp/p.patch")
+        assert args.karpa_root == Path("/tmp/karpa")
+
+
+# ============================================================================
+# _load_checkpoint — synthetic torch checkpoints
+# ============================================================================
+
+
+class TestLoadCheckpoint:
+    def test_canonical_v010_shape(self, tmp_path):
+        ckpt = tmp_path / "ckpt.pt"
+        state = {"w": torch.tensor([1.0, 2.0, 3.0])}
+        config = {"vocab_size": 50257, "dim": 64}
+        torch.save({"model": state, "config": config}, ckpt)
+
+        out_config, out_state = _load_checkpoint(ckpt)
+        assert out_config == config
+        assert torch.equal(out_state["w"], state["w"])
+
+    def test_state_dict_key_variant(self, tmp_path):
+        ckpt = tmp_path / "ckpt.pt"
+        state = {"w": torch.tensor([1.0])}
+        config = {"vocab_size": 50257}
+        torch.save({"state_dict": state, "config": config}, ckpt)
+
+        out_config, out_state = _load_checkpoint(ckpt)
+        assert out_config == config
+        assert torch.equal(out_state["w"], state["w"])
+
+    def test_sidecar_config(self, tmp_path):
+        ckpt = tmp_path / "ckpt.pt"
+        state = {"w": torch.tensor([1.0])}
+        torch.save({"model": state}, ckpt)
+        sidecar = tmp_path / "checkpoint_config.json"
+        sidecar.write_text(json.dumps({"vocab_size": 50257, "dim": 32}))
+
+        out_config, out_state = _load_checkpoint(ckpt)
+        assert out_config == {"vocab_size": 50257, "dim": 32}
+
+    def test_non_dict_checkpoint_raises(self, tmp_path):
+        ckpt = tmp_path / "ckpt.pt"
+        torch.save(torch.tensor([1.0]), ckpt)
+        with pytest.raises(ValueError, match=r"must be a dict"):
+            _load_checkpoint(ckpt)
+
+    def test_missing_model_and_state_dict_keys_raises(self, tmp_path):
+        ckpt = tmp_path / "ckpt.pt"
+        torch.save({"config": {"vocab_size": 50257}}, ckpt)
+        with pytest.raises(ValueError, match=r"no 'model' or 'state_dict' key"):
+            _load_checkpoint(ckpt)
+
+    def test_missing_config_and_no_sidecar_raises(self, tmp_path):
+        ckpt = tmp_path / "ckpt.pt"
+        torch.save({"model": {"w": torch.tensor([1.0])}}, ckpt)
+        with pytest.raises(ValueError, match=r"missing 'config' dict"):
+            _load_checkpoint(ckpt)
+
+
+# ============================================================================
+# _build_task_loaders — routing
+# ============================================================================
+
+
+class TestBuildTaskLoaders:
+    def test_returns_dict_keyed_by_task(self, tmp_path):
+        loaders = _build_task_loaders(("arc_easy",), tmp_path)
+        assert "arc_easy" in loaders
+        assert len(loaders) == 1
+
+    def test_routes_core22_vs_private_hard(self, tmp_path):
+        loaders = _build_task_loaders(
+            ("arc_easy", "tiny_mmlu"), tmp_path,
+        )
+        assert "arc_easy" in loaders
+        assert "tiny_mmlu" in loaders
+
+    def test_loaders_are_callable(self, tmp_path):
+        loaders = _build_task_loaders(("arc_easy",), tmp_path)
+        assert callable(loaders["arc_easy"])
+
+    def test_core22_loader_calls_core22_load(self, tmp_path):
+        """The bound loader reaches core22.load_task_examples, which is
+        a stub today and raises NotImplementedError."""
+        loaders = _build_task_loaders(("arc_easy",), tmp_path)
+        with pytest.raises(NotImplementedError):
+            loaders["arc_easy"]()
+
+    def test_private_hard_loader_calls_private_hard_load(self, tmp_path):
+        loaders = _build_task_loaders(("tiny_mmlu",), tmp_path)
+        with pytest.raises(NotImplementedError) as exc_info:
+            loaders["tiny_mmlu"]()
+        # private_hard.load_task_examples mentions DEFERRED.md B1-D1.
+        assert "DEFERRED" in str(exc_info.value) or "B1-D1" in str(exc_info.value)
+
+    def test_closure_binds_task_name(self, tmp_path):
+        """Each loader must capture its own task name, not the loop's last."""
+        loaders = _build_task_loaders(
+            ("arc_easy", "tiny_mmlu", "piqa"), tmp_path,
+        )
+        # If closure binding is wrong, all loaders would call the same task.
+        # We can detect this by checking that distinct tasks have distinct
+        # loaders (each loader's id is unique).
+        ids = {id(loaders[t]) for t in loaders}
+        assert len(ids) == 3
+
+
+# ============================================================================
+# main() — --patch handling (B1-D13)
+# ============================================================================
+
+
+class TestMainPatchHandling:
+    def test_patch_arg_raises_not_implemented(self, tmp_path):
+        cfg_path = tmp_path / "cfg.json"
+        cfg_path.write_text(json.dumps({"tasks": ["arc_easy"]}))
+        with pytest.raises(NotImplementedError) as exc_info:
+            main([
+                "--checkpoint", "x",
+                "--config", str(cfg_path),
+                "--output", "x",
+                "--bundle-sha", "x",
+                "--bundle-dir", "x",
+                "--vocab-size", "50257",
+                "--patch", "/tmp/p.patch",
+                "--karpa-root", "/tmp/root",
+            ])
+        msg = str(exc_info.value)
+        assert "Structural-patch" in msg or "structural-patch" in msg.lower()
+        assert "B1-D13" in msg
+
+    def test_no_patch_passes_through(self, tmp_path):
+        """Without --patch, main() proceeds past the gate (fails later for
+        unrelated reasons in this stripped-down test)."""
+        cfg_path = tmp_path / "cfg.json"
+        cfg_path.write_text(json.dumps({"tasks": ["arc_easy"]}))
+        # Without --patch, main() will try to load the checkpoint at "x"
+        # which doesn't exist → FileNotFoundError. That's a different
+        # error than NotImplementedError, which proves the patch gate
+        # didn't fire.
+        with pytest.raises(Exception) as exc_info:
+            main([
+                "--checkpoint", "/nonexistent/ckpt.pt",
+                "--config", str(cfg_path),
+                "--output", "x",
+                "--bundle-sha", "x",
+                "--bundle-dir", "x",
+                "--vocab-size", "50257",
+            ])
+        # Should NOT be NotImplementedError mentioning B1-D13.
+        assert not (
+            isinstance(exc_info.value, NotImplementedError)
+            and "B1-D13" in str(exc_info.value)
+        )
+
+
+# ============================================================================
+# main() — end-to-end with mocked dependencies
+# ============================================================================
+
+
+class _FakeKarpaConfig:
+    """Stand-in for KarpaConfig with a __dataclass_fields__ surface."""
+    __dataclass_fields__ = {"vocab_size": None, "dim": None}
+
+    def __init__(self, *, vocab_size: int, dim: int = 32):
+        self.vocab_size = vocab_size
+        self.dim = dim
+
+
+class _FakeKarpaBase(torch.nn.Module):
+    """Stand-in for KarpaBase that returns uniform logits."""
+    def __init__(self, cfg):
+        super().__init__()
+        self.cfg = cfg
+        self._w = torch.nn.Parameter(torch.zeros(1))  # one parameter so state_dict is non-empty
+
+    def load_state_dict(self, state, strict=True):  # noqa: ARG002 — match torch sig
+        # Tolerate any state_dict shape — we only need the model to forward.
+        pass
+
+    def forward(self, input_ids):
+        # Return uniform logits over the configured vocab.
+        b, t = input_ids.shape
+        return torch.zeros((b, t, self.cfg.vocab_size))
+
+
+def _fake_loader_factory():
+    """Returns task_loaders that produce zero examples (trivially succeeds)."""
+    return {
+        "arc_easy": lambda: [],
+    }
+
+
+class TestMainHappyPath:
+    def test_full_flow_with_mocks(self, tmp_path):
+        """Mock out the heavy dependencies and verify main() writes a report."""
+        # Synthetic checkpoint
+        ckpt = tmp_path / "ckpt.pt"
+        torch.save({
+            "model": {"_w": torch.zeros(1)},
+            "config": {"vocab_size": 50257, "dim": 32},
+        }, ckpt)
+
+        # Synthetic config
+        cfg_path = tmp_path / "cfg.json"
+        cfg_path.write_text(json.dumps({"tasks": ["arc_easy"]}))
+
+        output_path = tmp_path / "report.json"
+
+        # Mock _import_karpa_model + _build_task_loaders + _build_tokenize_fn
+        with mock.patch(
+            "eval.downstream.runner_cli._import_karpa_model",
+            return_value=(_FakeKarpaBase, _FakeKarpaConfig),
+        ), mock.patch(
+            "eval.downstream.runner_cli._build_task_loaders",
+            return_value=_fake_loader_factory(),
+        ), mock.patch(
+            "eval.downstream.runner_cli._build_tokenize_fn",
+            return_value=lambda text: [ord(c) for c in text],
+        ):
+            rc = main([
+                "--checkpoint", str(ckpt),
+                "--config", str(cfg_path),
+                "--output", str(output_path),
+                "--bundle-sha", "test-sha",
+                "--bundle-dir", str(tmp_path),
+                "--vocab-size", "50257",
+            ])
+
+        assert rc == 0
+        assert output_path.exists()
+        report = json.loads(output_path.read_text())
+        assert report["harness_version"] == HARNESS_VERSION
+        assert report["bundle_sha256"] == "test-sha"
+        assert "arc_easy:S3" in report["cells"]
+        # Empty loader → 0 examples → accuracy=0.0 (the documented empty-cell
+        # sentinel for downstream tasks).
+        assert report["cells"]["arc_easy:S3"]["n_examples"] == 0
+
+    def test_vocab_mismatch_aborts(self, tmp_path):
+        """Checkpoint vocab differs from --vocab-size → ValueError."""
+        ckpt = tmp_path / "ckpt.pt"
+        torch.save({
+            "model": {"_w": torch.zeros(1)},
+            "config": {"vocab_size": 50257, "dim": 32},
+        }, ckpt)
+        cfg_path = tmp_path / "cfg.json"
+        cfg_path.write_text(json.dumps({"tasks": ["arc_easy"]}))
+
+        with mock.patch(
+            "eval.downstream.runner_cli._import_karpa_model",
+            return_value=(_FakeKarpaBase, _FakeKarpaConfig),
+        ):
+            with pytest.raises(ValueError, match=r"vocab_size"):
+                main([
+                    "--checkpoint", str(ckpt),
+                    "--config", str(cfg_path),
+                    "--output", str(tmp_path / "out.json"),
+                    "--bundle-sha", "x",
+                    "--bundle-dir", str(tmp_path),
+                    "--vocab-size", "40000",  # mismatch
+                ])
+
+    def test_output_parent_dir_created(self, tmp_path):
+        """main() must mkdir -p the output's parent before writing."""
+        ckpt = tmp_path / "ckpt.pt"
+        torch.save({
+            "model": {"_w": torch.zeros(1)},
+            "config": {"vocab_size": 50257, "dim": 32},
+        }, ckpt)
+        cfg_path = tmp_path / "cfg.json"
+        cfg_path.write_text(json.dumps({"tasks": ["arc_easy"]}))
+
+        output = tmp_path / "nested" / "deep" / "report.json"
+        assert not output.parent.exists()
+
+        with mock.patch(
+            "eval.downstream.runner_cli._import_karpa_model",
+            return_value=(_FakeKarpaBase, _FakeKarpaConfig),
+        ), mock.patch(
+            "eval.downstream.runner_cli._build_task_loaders",
+            return_value=_fake_loader_factory(),
+        ), mock.patch(
+            "eval.downstream.runner_cli._build_tokenize_fn",
+            return_value=lambda text: [],
+        ):
+            rc = main([
+                "--checkpoint", str(ckpt),
+                "--config", str(cfg_path),
+                "--output", str(output),
+                "--bundle-sha", "x",
+                "--bundle-dir", str(tmp_path),
+                "--vocab-size", "50257",
+            ])
+        assert rc == 0
+        assert output.exists()


### PR DESCRIPTION
What this commit ships:

  1. `main(argv) -> int` — the argparse + orchestration entrypoint. Invoked as `python -m eval.downstream.runner_cli ...` by the subprocess wrapper (eval/downstream/runner_subprocess.py).

     Flow: a. Parse args. b. If --patch is set, raise NotImplementedError pointing at DEFERRED.md B1-D13 (args accepted; full apply_patch integration deferred to a follow-up PR). c. Read EvalConfig JSON. d. Import KarpaBase + KarpaConfig via the recipe path (--karpa-root + sys.path bootstrap or karpa_bootstrap fallback). e. Load checkpoint with torch.load(weights_only=True). f. Build model + load_state_dict(strict=True), move to CUDA if available, model.eval(). g. Verify checkpoint vocab matches --vocab-size. h. Build forward_logits closure, GPT-2 BPE tokenize, and task_loaders dict. i. Read hardness_index JSONL if --hardness-index provided. j. run_downstream_eval. k. Serialize the report via serialize_report and write to --output (mkdir -p on the parent).

  2. `_build_parser()` — argparse with all the args the run_eval_in_subprocess wrapper passes: --checkpoint, --config, --output, --bundle-sha, --bundle-dir, --vocab-size (all required) + --hardness-index, --patch, --karpa-root (optional).

  3. `_load_checkpoint(path)` — the weights_only=True load helper. Accepts three checkpoint shapes: * `{"model": state_dict, "config": dict}` (canonical v0.10) * `{"state_dict": state_dict, "config": dict}` (legacy) * `{"model": state_dict}` + sibling `checkpoint_config.json` Raises ValueError naming the specific failure mode on any other shape. **Closes B1-D5** (weights_only-doesn't-block- forward()-code documented in the module docstring; OS-level subprocess isolation is the only containment B1 provides).

  4. `_import_karpa_model(karpa_root)` — sys.path bootstrap + `from model import KarpaBase, KarpaConfig`. Patched workdirs are picked up via karpa_root prepending; the no-patch path falls through to karpa_bootstrap's resolution.

  5. `_build_task_loaders(tasks, bundle_dir)` — dispatch by task name to core22.load_task_examples or private_hard.load_task_examples. Both stubs raise NotImplementedError today; the CLI plumbing reaches them and the subprocess exits non-zero with a clear pointer (B1-D1 follow-up). The closure captures `task` per-iteration so loaders don't all bind to the loop's last value.

  6. `_build_tokenize_fn()` — `tiktoken.get_encoding("gpt2").encode` wrapper. Lazy-imported so arg-parsing tests don't trigger the tiktoken bundle download.

What this commit does NOT ship (separate follow-up PRs):

  * `apply_patch` integration for --patch. The args land here so the CLI contract is stable; the actual ~150 LOC + 2 day integration is recorded as a separate deliverable per DEFERRED.md B1-D13. Submissions without structural patches go through the no-patch path unchanged.

  * `load_task_examples` implementations (B1-D1 follow-up). The CLI calls into the existing stubs; the data-loading rewrite lands when the HF download + DCLM bundle SHA-pin commits land.

  * Seccomp / landlock sandboxing inside the subprocess. Recorded as a named follow-up phase before mainnet activation per DEFERRED.md B1-D5.

Tests (24 cases in test_downstream_runner_cli.py):

  * _build_parser: 7 cases — required args enforced, subset enforcement, minimal-required-set parses, type coercion on --vocab-size, optional defaults, optional → Path coercion.
  * _load_checkpoint: 6 cases — canonical / state_dict variant / sidecar config / non-dict / missing model+state_dict keys / missing config and no sidecar.
  * _build_task_loaders: 6 cases — dict shape / routing / callable / reaches core22 stub / reaches private_hard stub / closure per-iteration binding.
  * main() --patch: 2 cases — raises NotImplementedError with "B1-D13" in the message; without --patch, the gate is bypassed (reaches a different failure).
  * main() happy path with mocked dependencies: 3 cases — full flow writes a valid report with HARNESS_VERSION + bundle_sha; vocab mismatch raises ValueError; output parent dir is mkdir -p'd on write.

DEFERRED.md updated: B1-D5 and B1-D13 marked CLOSED with short references to the runner_cli.py + runner_subprocess.py docstrings. 11 of 15 B1 decisions now closed; 4 remain (B1-D4 legal, B1-D8 calibration sourcing, B1-D10 restricted-files scanner glob, B1-D12 HiddenEvalResult schema versioning).

eval/downstream/__init__.py docstring updated. No new public symbols re-exported (the CLI is invoked via `python -m`, not imported).

Full suite: 400/400 passing. Ruff clean on all touched files.