### PR TITLE
eval/downstream/calibration.py: noise-floor aggregator + JSON I/O (closes B1-D8)

### DIFF
--- a/eval/downstream/DEFERRED.md
+++ b/eval/downstream/DEFERRED.md
@@ -160,7 +160,18 @@ baselines (adds hard dependency on A2), (c) ship `noise_floors_v0.json` as
 null-filled placeholders for B1 ship and complete in B5.
 **Recommendation:** (a). The cost is trivial and option (c) leaves the
 aggregator without floors which is brittle.
-**Status:** OPEN
+**Status:** **CLOSED at aggregation surface 2026-06-11 — option (a)
+ratified.** `eval/downstream/calibration.py` ships the
+`aggregate_noise_floors` kernel that takes N DownstreamReports and
+produces a `NoiseFloorTable` via per-task `margin_multiplier *
+max(stddev across scales)`. JSON round-trip via
+`write_noise_floor_table_json` / `read_noise_floor_table_json`. The
+**operational** half (train 10 baselines on H100, run each through
+`run_eval_in_subprocess`, feed reports into the aggregator) is gated
+on (1) `load_task_examples` being implemented (B1-D1 follow-up) and
+(2) an H100 instance for the ~$15 baseline-training pass. Recorded as
+a separate operational step, not blocking B2 / B3 / B4 code paths
+that consume `NoiseFloorTable` via the same dataclass contract.
 
 ### B1-D9 — `validator/scoring.py::score_ladder` reference removed from aggregate.py
 **Owner:** B1 (aggregate.py author) — **CLOSED in this commit**
@@ -336,6 +347,19 @@ scanner glob extension), B1-D12 (HiddenEvalResult schema-versioning
 test). Note: B1-D1 (HF dataset download implementation) was logged as
 closed in the 2026-06-10 update; the load_task_examples function
 remains stubbed but the decision itself is closed.
+
+## Update 2026-06-11 (later) — B1-D8 closed at aggregation surface
+
+- **B1-D8 (calibration data sourcing)** — closed; `calibration.py`
+  ships `aggregate_noise_floors` + JSON round-trip. Operational
+  baseline-training run (H100 + ~$15) recorded as a separate step,
+  not blocking B2 / B3 / B4 code that depends on the
+  `NoiseFloorTable` dataclass.
+
+Now 12 of 15 items closed, 3 still open: B1-D4 (CC-BY-SA legal
+review), B1-D10 (restricted-files scanner glob extension), B1-D12
+(HiddenEvalResult schema-versioning test). Each is a small,
+focused PR independent of the remaining B1 module sweep.
 
 ## What B1 still owes (open, in dependency order)
 

--- a/eval/downstream/__init__.py
+++ b/eval/downstream/__init__.py
@@ -28,15 +28,26 @@ What B1 has shipped so far:
     `torch.load(weights_only=True)` checkpoint load + KarpaBase
     model construction + tiktoken GPT-2 BPE tokenizer wiring +
     structural-patch CLI args (B1-D5, B1-D13 closed)
+  * calibration.py: aggregate_noise_floors + per-cell stddev
+    diagnostic + noise_floors_v1.json round-trip (B1-D8 closed
+    at the aggregation surface; the H100 training-driver follow-up
+    will produce the actual file)
 
-What B1 will ship (separate commits within the phase):
-  * calibration.py: N=10 baseline runs → noise_floors_v1.json
+B1 module sweep complete — types, aggregate, scorer, core22,
+private_hard, grader, runner (kernel + subprocess + CLI),
+calibration.
 
 Reference scope: docs/build_scope/02_scope_B1.md.
 """
 from __future__ import annotations
 
 from .aggregate import aggregate_pareto
+from .calibration import (
+    aggregate_noise_floors,
+    compute_per_cell_stddev,
+    read_noise_floor_table_json,
+    write_noise_floor_table_json,
+)
 from .core22 import (
     DCLM_CORE_22_TASKS,
     DCLM_EVAL_BUNDLE_SHA256,
@@ -143,10 +154,12 @@ __all__ = [
     "SchemaRawRow",
     "TASK_SPECS",
     "TaskSpec",
+    "aggregate_noise_floors",
     "aggregate_pareto",
     "assemble_hardness_index",
     "check_vocab_compatibility",
     "compute_bottom_quintile",
+    "compute_per_cell_stddev",
     "deserialize_report",
     "evaluate_lm_task_lambada",
     "evaluate_mc_task",
@@ -159,6 +172,7 @@ __all__ = [
     "make_mc_example",
     "make_schema_example",
     "read_hardness_index_jsonl",
+    "read_noise_floor_table_json",
     "run_downstream_eval",
     "run_eval_in_subprocess",
     "score_lm",
@@ -172,4 +186,5 @@ __all__ = [
     "to_cell_result",
     "to_private_hard_cell_result",
     "write_hardness_index_jsonl",
+    "write_noise_floor_table_json",
 ]

--- a/eval/downstream/calibration.py
+++ b/eval/downstream/calibration.py
@@ -1,0 +1,281 @@
+"""Noise-floor calibration aggregator for the downstream-eval harness (B1).
+
+The Cross-Scale Downstream Pareto kernel (`aggregate_pareto`) uses a
+per-task noise floor `eta_task` as the minimum delta that counts as a
+significant win or loss in a cell. eta_task answers: "what's the
+typical spread in this task's accuracy across statistically equivalent
+baseline runs?" — i.e., the magnitude of noise we should attribute to
+randomness rather than to skill differences.
+
+This module ships:
+
+  * `aggregate_noise_floors(reports, *, margin_multiplier=2.0,
+    recipe_sha="")` — pure aggregation. Takes N `DownstreamReport`
+    objects from N statistically equivalent baseline runs and returns
+    a `NoiseFloorTable` mapping task name → eta_task.
+
+    eta_task is conservative across scales: for a given task, it is
+    `margin_multiplier * max(stddev(accs at scale)) for scale in
+    scales`. The "max across scales" choice means the per-task floor
+    is at least as wide as the noisiest scale's spread — a delta
+    smaller than the worst-scale noise is rejected for that task on
+    every scale, not just the noisy one.
+
+  * `compute_per_cell_stddev(reports)` — diagnostic helper that
+    returns the per-`(task:scale)` stddev BEFORE the per-task
+    aggregation. Useful for the calibration report ("how does noise
+    vary across scales for task X?"); the Pareto kernel itself uses
+    only the per-task aggregated value.
+
+  * `_sample_stddev(xs)` — Bessel-corrected (ddof=1) sample stddev
+    with two surgical short-circuits:
+      - n < 2 → 0.0 (no within-sample variance to estimate)
+      - all xs equal → 0.0 exactly (avoids the `sum/N != X` fp
+        rounding flake that bit
+        `test_multiseed_three_runs_produce_byte_identical_results`
+        before; matches `validator/multiseed.py::_mean_stderr`'s
+        same short-circuit).
+
+  * `write_noise_floor_table_json(table, path)` — atomic JSON output
+    via `.tmp` + rename, with parent-dir mkdir.
+
+  * `read_noise_floor_table_json(path)` — inverse, with explicit
+    schema validation on required keys.
+
+What this module does NOT ship (separate H100 PR):
+
+  * The driver that actually trains N baseline checkpoints, runs
+    them through `run_eval_in_subprocess`, and feeds the resulting
+    reports into `aggregate_noise_floors`. That driver is gated on
+    (a) `load_task_examples` being implemented (B1-D1 follow-up)
+    and (b) a real H100 instance for the baseline-training pass
+    (~$15 wall-clock per the master plan).
+
+  * Cross-scale eta variants (per-cell etas, per-rung-pair etas).
+    The single per-task eta is the v0.10 convention; multi-scale
+    variants are a B3 / aggregate-v2 concern.
+
+Closes B1-D8 at the aggregation surface: the CODE path is wired;
+the operational H100 run produces the actual `noise_floors_v1.json`
+file in a follow-up.
+
+Reference scope: docs/build_scope/02_scope_B1.md "calibration.py".
+"""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+from .types import (
+    HARNESS_VERSION,
+    DownstreamReport,
+    NoiseFloorTable,
+)
+
+# ----------------------------------------------------------------------------
+# Sample stddev
+# ----------------------------------------------------------------------------
+
+
+def _sample_stddev(xs: list[float]) -> float:
+    """Bessel-corrected (ddof=1) sample standard deviation.
+
+    Edge cases:
+      * n == 0 or n == 1 → 0.0 (no within-sample variance to estimate)
+      * all values equal → 0.0 (exact short-circuit; avoids the
+        `sum/N != X` floating-point flake)
+      * otherwise → sqrt(sum((x - mean)² for x in xs) / (n - 1))
+    """
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    first = xs[0]
+    if all(x == first for x in xs):
+        return 0.0
+    mean = sum(xs) / n
+    var = sum((x - mean) * (x - mean) for x in xs) / (n - 1)
+    return math.sqrt(var)
+
+
+# ----------------------------------------------------------------------------
+# Per-cell stddev (diagnostic)
+# ----------------------------------------------------------------------------
+
+
+def compute_per_cell_stddev(
+    reports: list[DownstreamReport],
+) -> dict[str, float]:
+    """Per-`(task:scale)` sample stddev across the N reports.
+
+    Returns dict `cell_key -> stddev`. Cells that don't appear in EVERY
+    report contribute the stddev of however many they appear in (the
+    aggregator's caller is responsible for ensuring report shapes line
+    up; this helper is tolerant).
+
+    Diagnostic only — the Pareto kernel reads per-TASK floors, not
+    per-cell. The per-cell breakdown is for the human-readable
+    calibration report ("does the task get noisier at smaller scale?").
+    """
+    if not reports:
+        return {}
+    per_cell: dict[str, list[float]] = {}
+    for report in reports:
+        for cell_key, cell in report.cells.items():
+            per_cell.setdefault(cell_key, []).append(cell.accuracy)
+    return {k: _sample_stddev(v) for k, v in per_cell.items()}
+
+
+# ----------------------------------------------------------------------------
+# Aggregator
+# ----------------------------------------------------------------------------
+
+
+def aggregate_noise_floors(
+    reports: list[DownstreamReport],
+    *,
+    margin_multiplier: float = 2.0,
+    recipe_sha: str = "",
+) -> NoiseFloorTable:
+    """Aggregate N baseline DownstreamReports into a NoiseFloorTable.
+
+    Algorithm:
+      1. Group accuracies by cell key (`task:scale`).
+      2. For each cell key, compute the across-baseline stddev.
+      3. For each TASK (cell_key.split(":", 1)[0]), take the MAX
+         stddev across all of its scales.
+      4. eta_task = margin_multiplier * max_stddev.
+
+    The "max across scales" choice ensures the per-task floor is
+    conservative — at least as wide as the noisiest scale's measured
+    noise. A delta smaller than that floor is rejected on every scale
+    for that task, not just the noisy one.
+
+    Args:
+      reports: at least one DownstreamReport. Empty → ValueError.
+      margin_multiplier: scalar applied to the stddev. Default 2.0
+        matches `scripts/noise_floor.py`'s "decisively beats the king"
+        margin. Must be >= 0; negative → ValueError.
+      recipe_sha: stamped into the returned NoiseFloorTable. The
+        validator emits this on chain so a future auditor can replay
+        the calibration run. Empty string is allowed (B1-D8 follow-up
+        will populate it when the H100 driver lands).
+
+    Returns:
+      `NoiseFloorTable` with floors keyed by task name, plus
+      `harness_version`, `recipe_sha`, `n_baselines` stamped.
+    """
+    if not reports:
+        raise ValueError(
+            "aggregate_noise_floors requires at least one report; got 0"
+        )
+    if margin_multiplier < 0:
+        raise ValueError(
+            f"margin_multiplier must be >= 0; got {margin_multiplier}"
+        )
+
+    per_cell_stddev = compute_per_cell_stddev(reports)
+
+    per_task_max_stddev: dict[str, float] = {}
+    for cell_key, stddev in per_cell_stddev.items():
+        task = cell_key.split(":", 1)[0]
+        if task not in per_task_max_stddev or stddev > per_task_max_stddev[task]:
+            per_task_max_stddev[task] = stddev
+
+    floors = {
+        task: margin_multiplier * stddev
+        for task, stddev in per_task_max_stddev.items()
+    }
+
+    return NoiseFloorTable(
+        floors=floors,
+        harness_version=HARNESS_VERSION,
+        recipe_sha=recipe_sha,
+        n_baselines=len(reports),
+    )
+
+
+# ----------------------------------------------------------------------------
+# JSON I/O
+# ----------------------------------------------------------------------------
+
+
+_META_MARKER = "karpa-noise-floor-table"
+
+
+def write_noise_floor_table_json(
+    table: NoiseFloorTable,
+    path: Path,
+) -> None:
+    """Write a NoiseFloorTable to disk as JSON.
+
+    Atomic-write via `<path>.tmp` + rename so a crashed write never
+    leaves a half-written file the validator consumes. Output is
+    human-readable (indent=2, sort_keys=True) — the file is small
+    (~one entry per task, ~26 tasks total) and the audit trail
+    benefits from a clean diff.
+
+    Schema:
+      {
+        "_meta": "karpa-noise-floor-table",
+        "harness_version": "...",
+        "recipe_sha": "...",
+        "n_baselines": <int>,
+        "floors": {"<task>": <eta>, ...}
+      }
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "_meta": _META_MARKER,
+        "harness_version": table.harness_version,
+        "recipe_sha": table.recipe_sha,
+        "n_baselines": table.n_baselines,
+        "floors": dict(table.floors),
+    }
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True, indent=2))
+    tmp.replace(path)
+
+
+def read_noise_floor_table_json(path: Path) -> NoiseFloorTable:
+    """Inverse of `write_noise_floor_table_json`.
+
+    Validates the `_meta` marker so a different JSON file accidentally
+    handed to this reader fails clean instead of producing a
+    NoiseFloorTable with arbitrary numbers. Missing optional fields
+    fall back to defaults; missing required keys raise ValueError.
+    """
+    path = Path(path)
+    try:
+        payload = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"noise-floor JSON at {path} is not valid JSON: {e}"
+        ) from e
+
+    meta = payload.get("_meta")
+    if meta != _META_MARKER:
+        raise ValueError(
+            f"unexpected _meta marker {meta!r} in {path}; "
+            f"expected {_META_MARKER!r}"
+        )
+
+    if "floors" not in payload:
+        raise ValueError(
+            f"noise-floor JSON at {path} missing required 'floors' key"
+        )
+
+    floors_raw = payload["floors"]
+    if not isinstance(floors_raw, dict):
+        raise ValueError(
+            f"'floors' must be a dict; got {type(floors_raw).__name__}"
+        )
+    floors = {str(k): float(v) for k, v in floors_raw.items()}
+
+    return NoiseFloorTable(
+        floors=floors,
+        harness_version=str(payload.get("harness_version", HARNESS_VERSION)),
+        recipe_sha=str(payload.get("recipe_sha", "")),
+        n_baselines=int(payload.get("n_baselines", 0)),
+    )

--- a/tests/test_downstream_calibration.py
+++ b/tests/test_downstream_calibration.py
@@ -1,0 +1,409 @@
+"""Tests for eval/downstream/calibration.py — noise-floor aggregator.
+
+Covers:
+  * _sample_stddev edge cases (empty / single / identical /
+    floating-point precision)
+  * compute_per_cell_stddev diagnostic helper
+  * aggregate_noise_floors: happy path, multi-scale max-across, single
+    report / identical reports → 0 floors, margin_multiplier scaling,
+    metadata propagation, empty-input + negative-multiplier rejection
+  * write/read JSON round-trip + atomicity + schema validation
+"""
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from eval.downstream.calibration import (
+    _META_MARKER,
+    _sample_stddev,
+    aggregate_noise_floors,
+    compute_per_cell_stddev,
+    read_noise_floor_table_json,
+    write_noise_floor_table_json,
+)
+from eval.downstream.types import (
+    HARNESS_VERSION,
+    CellResult,
+    DownstreamReport,
+    NoiseFloorTable,
+)
+
+# ----------------------------------------------------------------------------
+# Test fixtures
+# ----------------------------------------------------------------------------
+
+
+def _report(cells: dict[str, float], *, seed: int = 0) -> DownstreamReport:
+    """Build a DownstreamReport from a {cell_key: accuracy} dict."""
+    return DownstreamReport(
+        harness_version=HARNESS_VERSION,
+        bundle_sha256="test-sha",
+        seed=seed,
+        total_examples=sum(1 for _ in cells),
+        wall_clock_s=0.0,
+        cells={
+            key: CellResult(
+                task=key.split(":", 1)[0],
+                accuracy=acc,
+                accuracy_stderr=0.0,
+                n_examples=1,
+                seed=seed,
+            )
+            for key, acc in cells.items()
+        },
+    )
+
+
+# ============================================================================
+# _sample_stddev
+# ============================================================================
+
+
+class TestSampleStddev:
+    def test_empty(self):
+        assert _sample_stddev([]) == 0.0
+
+    def test_single(self):
+        assert _sample_stddev([0.5]) == 0.0
+
+    def test_all_identical(self):
+        """Short-circuit avoids the fp-rounding flake."""
+        x = 3.9048486872424535
+        assert _sample_stddev([x, x, x]) == 0.0
+
+    def test_two_distinct(self):
+        # ddof=1: var = ((0-0.5)² + (1-0.5)²) / 1 = 0.5
+        assert _sample_stddev([0.0, 1.0]) == pytest.approx(math.sqrt(0.5))
+
+    def test_three_distinct(self):
+        # xs = [1, 2, 3]; mean = 2; var = ((1-2)² + (2-2)² + (3-2)²) / 2 = 1.0
+        assert _sample_stddev([1.0, 2.0, 3.0]) == pytest.approx(1.0)
+
+    def test_ddof_one_not_population(self):
+        """Population stddev of [0, 1] is 0.5; sample (ddof=1) is sqrt(0.5)."""
+        result = _sample_stddev([0.0, 1.0])
+        assert result == pytest.approx(math.sqrt(0.5))
+        assert result != pytest.approx(0.5)
+
+    def test_negative_values(self):
+        # [-1, 1]; mean=0; var = (1+1)/1 = 2; stddev = sqrt(2)
+        assert _sample_stddev([-1.0, 1.0]) == pytest.approx(math.sqrt(2.0))
+
+    def test_floating_point_precision(self):
+        """Three near-identical values shouldn't blow up."""
+        x = 0.5
+        # Values that differ by a few ULPs.
+        result = _sample_stddev([x, x + 1e-15, x - 1e-15])
+        assert result < 1e-14
+
+
+# ============================================================================
+# compute_per_cell_stddev
+# ============================================================================
+
+
+class TestComputePerCellStddev:
+    def test_empty_reports(self):
+        assert compute_per_cell_stddev([]) == {}
+
+    def test_single_report(self):
+        rep = _report({"arc_easy:S3": 0.5})
+        result = compute_per_cell_stddev([rep])
+        # n=1 → stddev=0
+        assert result == {"arc_easy:S3": 0.0}
+
+    def test_multi_report_per_cell(self):
+        reps = [
+            _report({"arc_easy:S3": 0.5}),
+            _report({"arc_easy:S3": 0.7}),
+            _report({"arc_easy:S3": 0.9}),
+        ]
+        result = compute_per_cell_stddev(reps)
+        # [0.5, 0.7, 0.9] → mean=0.7, var = (0.04+0+0.04)/2 = 0.04
+        assert result["arc_easy:S3"] == pytest.approx(0.2)
+
+    def test_separates_cell_keys(self):
+        reps = [
+            _report({"arc_easy:S3": 0.5, "piqa:S3": 0.6}),
+            _report({"arc_easy:S3": 0.7, "piqa:S3": 0.8}),
+        ]
+        result = compute_per_cell_stddev(reps)
+        assert "arc_easy:S3" in result
+        assert "piqa:S3" in result
+        assert len(result) == 2
+
+    def test_tolerates_missing_cells(self):
+        """One report has fewer cells than others — that cell's stddev
+        is over the present subset."""
+        reps = [
+            _report({"arc_easy:S3": 0.5, "piqa:S3": 0.6}),
+            _report({"arc_easy:S3": 0.7}),  # missing piqa
+        ]
+        result = compute_per_cell_stddev(reps)
+        assert "arc_easy:S3" in result
+        # piqa appears only once → stddev=0 (single sample)
+        assert result["piqa:S3"] == 0.0
+
+
+# ============================================================================
+# aggregate_noise_floors — happy path + scaling
+# ============================================================================
+
+
+class TestAggregateHappyPath:
+    def test_returns_noise_floor_table(self):
+        reps = [_report({"arc_easy:S3": 0.5 + i * 0.1}) for i in range(3)]
+        table = aggregate_noise_floors(reps)
+        assert isinstance(table, NoiseFloorTable)
+
+    def test_single_task_single_scale(self):
+        reps = [_report({"arc_easy:S3": v}) for v in [0.5, 0.7, 0.9]]
+        # stddev([0.5, 0.7, 0.9]) = 0.2; eta = 2 * 0.2 = 0.4
+        table = aggregate_noise_floors(reps, margin_multiplier=2.0)
+        assert table.floors["arc_easy"] == pytest.approx(0.4)
+
+    def test_margin_multiplier_scales(self):
+        reps = [_report({"arc_easy:S3": v}) for v in [0.5, 0.7, 0.9]]
+        # stddev = 0.2; with 3.0 multiplier → 0.6
+        table = aggregate_noise_floors(reps, margin_multiplier=3.0)
+        assert table.floors["arc_easy"] == pytest.approx(0.6)
+
+    def test_zero_multiplier_yields_zero(self):
+        reps = [_report({"arc_easy:S3": v}) for v in [0.5, 0.7, 0.9]]
+        table = aggregate_noise_floors(reps, margin_multiplier=0.0)
+        assert table.floors["arc_easy"] == 0.0
+
+    def test_single_report_yields_zero_floors(self):
+        """n=1 → no within-sample variance → all floors = 0."""
+        rep = _report({"arc_easy:S3": 0.5, "piqa:S3": 0.7})
+        table = aggregate_noise_floors([rep])
+        assert table.floors["arc_easy"] == 0.0
+        assert table.floors["piqa"] == 0.0
+
+    def test_identical_reports_yield_zero_floors(self):
+        """N copies of the same report → all floors = 0."""
+        rep = _report({"arc_easy:S3": 0.5})
+        table = aggregate_noise_floors([rep, rep, rep, rep])
+        assert table.floors["arc_easy"] == 0.0
+
+
+# ============================================================================
+# aggregate_noise_floors — multi-scale per-task
+# ============================================================================
+
+
+class TestAggregateMultiScale:
+    def test_takes_max_across_scales(self):
+        """Per-task eta = max stddev across all scales for that task."""
+        reps = [
+            _report({"arc_easy:S1": 0.5, "arc_easy:S3": 0.5}),
+            _report({"arc_easy:S1": 0.7, "arc_easy:S3": 0.55}),
+            _report({"arc_easy:S1": 0.9, "arc_easy:S3": 0.6}),
+        ]
+        # S1 stddev = 0.2; S3 stddev ≈ 0.05; max = 0.2
+        # eta = 2 * 0.2 = 0.4
+        table = aggregate_noise_floors(reps, margin_multiplier=2.0)
+        assert table.floors["arc_easy"] == pytest.approx(0.4)
+
+    def test_max_across_scales_picks_noisier(self):
+        """Reversal: S3 noisier than S1 → eta picks S3's stddev."""
+        reps = [
+            _report({"arc_easy:S1": 0.5, "arc_easy:S3": 0.2}),
+            _report({"arc_easy:S1": 0.51, "arc_easy:S3": 0.5}),
+            _report({"arc_easy:S1": 0.52, "arc_easy:S3": 0.8}),
+        ]
+        # S1 stddev ≈ 0.01; S3 stddev = 0.3; max = 0.3
+        # eta = 2 * 0.3 = 0.6
+        table = aggregate_noise_floors(reps, margin_multiplier=2.0)
+        assert table.floors["arc_easy"] == pytest.approx(0.6)
+
+    def test_separate_tasks_independent(self):
+        reps = [
+            _report({"arc_easy:S3": v, "piqa:S3": w})
+            for v, w in [(0.5, 0.8), (0.7, 0.8), (0.9, 0.8)]
+        ]
+        # arc_easy stddev = 0.2; piqa stddev = 0 (all 0.8)
+        table = aggregate_noise_floors(reps, margin_multiplier=2.0)
+        assert table.floors["arc_easy"] == pytest.approx(0.4)
+        assert table.floors["piqa"] == 0.0
+
+
+# ============================================================================
+# aggregate_noise_floors — metadata
+# ============================================================================
+
+
+class TestAggregateMetadata:
+    def test_harness_version_stamped(self):
+        rep = _report({"arc_easy:S3": 0.5})
+        table = aggregate_noise_floors([rep])
+        assert table.harness_version == HARNESS_VERSION
+
+    def test_recipe_sha_threaded_through(self):
+        rep = _report({"arc_easy:S3": 0.5})
+        table = aggregate_noise_floors([rep], recipe_sha="abc123")
+        assert table.recipe_sha == "abc123"
+
+    def test_recipe_sha_default_empty(self):
+        rep = _report({"arc_easy:S3": 0.5})
+        table = aggregate_noise_floors([rep])
+        assert table.recipe_sha == ""
+
+    def test_n_baselines_count(self):
+        reps = [_report({"arc_easy:S3": v}) for v in [0.5, 0.7, 0.9]]
+        table = aggregate_noise_floors(reps)
+        assert table.n_baselines == 3
+
+    def test_eta_for_returns_zero_for_unknown_task(self):
+        rep = _report({"arc_easy:S3": 0.5})
+        table = aggregate_noise_floors([rep])
+        assert table.eta_for("not_a_real_task") == 0.0
+
+
+# ============================================================================
+# aggregate_noise_floors — error paths
+# ============================================================================
+
+
+class TestAggregateErrors:
+    def test_empty_reports_rejected(self):
+        with pytest.raises(ValueError, match=r"at least one report"):
+            aggregate_noise_floors([])
+
+    def test_negative_multiplier_rejected(self):
+        rep = _report({"arc_easy:S3": 0.5})
+        with pytest.raises(ValueError, match=r"margin_multiplier"):
+            aggregate_noise_floors([rep], margin_multiplier=-0.5)
+
+    def test_zero_multiplier_accepted(self):
+        rep = _report({"arc_easy:S3": 0.5})
+        aggregate_noise_floors([rep], margin_multiplier=0.0)  # no raise
+
+
+# ============================================================================
+# JSON I/O — write
+# ============================================================================
+
+
+class TestWriteJson:
+    def test_round_trip(self, tmp_path):
+        table = NoiseFloorTable(
+            floors={"arc_easy": 0.02, "piqa": 0.015},
+            harness_version=HARNESS_VERSION,
+            recipe_sha="sha-abc",
+            n_baselines=10,
+        )
+        path = tmp_path / "nf.json"
+        write_noise_floor_table_json(table, path)
+        restored = read_noise_floor_table_json(path)
+        assert restored.floors == table.floors
+        assert restored.harness_version == table.harness_version
+        assert restored.recipe_sha == table.recipe_sha
+        assert restored.n_baselines == table.n_baselines
+
+    def test_creates_parent_dirs(self, tmp_path):
+        path = tmp_path / "nested" / "deep" / "nf.json"
+        table = NoiseFloorTable(floors={"x": 0.1}, n_baselines=1)
+        write_noise_floor_table_json(table, path)
+        assert path.exists()
+
+    def test_atomic_via_tmp(self, tmp_path):
+        """Write succeeds → no leftover .tmp file."""
+        path = tmp_path / "nf.json"
+        table = NoiseFloorTable(floors={"x": 0.1}, n_baselines=1)
+        write_noise_floor_table_json(table, path)
+        assert not (tmp_path / "nf.json.tmp").exists()
+
+    def test_meta_marker_present(self, tmp_path):
+        path = tmp_path / "nf.json"
+        table = NoiseFloorTable(floors={"x": 0.1}, n_baselines=1)
+        write_noise_floor_table_json(table, path)
+        loaded = json.loads(path.read_text())
+        assert loaded["_meta"] == _META_MARKER
+
+    def test_human_readable_sorted(self, tmp_path):
+        """sort_keys=True + indent=2 produces an audit-friendly diff."""
+        path = tmp_path / "nf.json"
+        table = NoiseFloorTable(
+            floors={"zebra": 0.1, "alpha": 0.2},
+            n_baselines=1,
+        )
+        write_noise_floor_table_json(table, path)
+        text = path.read_text()
+        assert text.index("alpha") < text.index("zebra")
+        assert "\n  " in text  # indent=2
+
+
+# ============================================================================
+# JSON I/O — read
+# ============================================================================
+
+
+class TestReadJson:
+    def test_rejects_invalid_json(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("{not valid json")
+        with pytest.raises(ValueError, match=r"not valid JSON"):
+            read_noise_floor_table_json(path)
+
+    def test_rejects_missing_meta(self, tmp_path):
+        path = tmp_path / "no-meta.json"
+        path.write_text(json.dumps({"floors": {}, "n_baselines": 0}))
+        with pytest.raises(ValueError, match=r"_meta marker"):
+            read_noise_floor_table_json(path)
+
+    def test_rejects_wrong_meta(self, tmp_path):
+        path = tmp_path / "wrong-meta.json"
+        path.write_text(json.dumps({
+            "_meta": "some-other-format",
+            "floors": {},
+        }))
+        with pytest.raises(ValueError, match=r"_meta marker"):
+            read_noise_floor_table_json(path)
+
+    def test_rejects_missing_floors_key(self, tmp_path):
+        path = tmp_path / "no-floors.json"
+        path.write_text(json.dumps({"_meta": _META_MARKER}))
+        with pytest.raises(ValueError, match=r"'floors'"):
+            read_noise_floor_table_json(path)
+
+    def test_rejects_non_dict_floors(self, tmp_path):
+        path = tmp_path / "bad-floors.json"
+        path.write_text(json.dumps({
+            "_meta": _META_MARKER,
+            "floors": [0.1, 0.2],  # list, not dict
+        }))
+        with pytest.raises(ValueError, match=r"'floors' must be a dict"):
+            read_noise_floor_table_json(path)
+
+    def test_tolerates_missing_optional_fields(self, tmp_path):
+        """harness_version / recipe_sha / n_baselines all have defaults."""
+        path = tmp_path / "minimal.json"
+        path.write_text(json.dumps({
+            "_meta": _META_MARKER,
+            "floors": {"arc_easy": 0.05},
+        }))
+        table = read_noise_floor_table_json(path)
+        assert table.floors == {"arc_easy": 0.05}
+        assert table.harness_version == HARNESS_VERSION
+        assert table.recipe_sha == ""
+        assert table.n_baselines == 0
+
+    def test_coerces_floor_values_to_float(self, tmp_path):
+        """Even ints in the JSON come back as floats."""
+        path = tmp_path / "ints.json"
+        path.write_text(json.dumps({
+            "_meta": _META_MARKER,
+            "floors": {"arc_easy": 0, "piqa": 1},  # ints
+        }))
+        table = read_noise_floor_table_json(path)
+        assert table.floors["arc_easy"] == 0.0
+        assert isinstance(table.floors["arc_easy"], float)


### PR DESCRIPTION
What this commit ships:

  1. aggregate_noise_floors(reports, *, margin_multiplier=2.0, recipe_sha="") -> NoiseFloorTable — the pure aggregation kernel. Takes N DownstreamReports from N statistically equivalent baseline runs and emits the per-task noise floors the Pareto kernel consumes via NoiseFloorTable.eta_for(task).

     Algorithm: a. Group accuracies by cell key ("task:scale"). b. Per cell, compute across-baseline sample stddev. c. Per TASK, take the MAX stddev across all of its scales. d. eta_task = margin_multiplier * max_stddev.

     The "max across scales" choice is conservative — the per-task floor is at least as wide as the noisiest scale's spread. A delta smaller than the worst-scale noise is rejected on every scale, not just the noisy one. This matches the v0.10 design where aggregate_pareto's noise_floors.eta_for(task) is indexed by bare task name (not cell key).

  2. compute_per_cell_stddev(reports) -> dict[cell_key, stddev] — diagnostic helper exposing the per-`(task:scale)` stddev BEFORE the per-task aggregation. Useful for the calibration report ("does task X get noisier at smaller scales?"); the Pareto kernel itself only reads the per-task aggregated value.

  3. _sample_stddev(xs) — Bessel-corrected (ddof=1) stddev with two surgical short-circuits: - n < 2 → 0.0 (no within-sample variance to estimate) - all values equal → 0.0 exactly (matches the same fix in validator/multiseed.py::_mean_stderr — avoids the fp rounding flake where `sum(xs)/N != xs[0]` for N copies of the same float).

  4. write_noise_floor_table_json(table, path) — atomic JSON output via `.tmp` + rename + parent-dir mkdir. Output is human-readable (sort_keys=True, indent=2) so noise_floors_v1.json diffs cleanly under git.

  5. read_noise_floor_table_json(path) -> NoiseFloorTable — inverse, with explicit schema validation on the `_meta` marker ("karpa-noise-floor-table") and the required `floors` key. Missing optional fields (harness_version / recipe_sha / n_baselines) fall back to defaults; invalid JSON, wrong marker, missing required keys, and non-dict `floors` all raise ValueError with a clear message.

What this commit does NOT ship (separate H100 PR):

  * The driver that actually trains N=10 baseline checkpoints, runs each through run_eval_in_subprocess, and feeds the resulting reports into aggregate_noise_floors. That driver is gated on (a) load_task_examples being implemented (B1-D1 follow-up) and (b) an H100 instance for the ~$15 baseline training pass.

  * Cross-scale eta variants (per-cell etas, per-rung-pair etas). The single per-task eta is the v0.10 convention; multi-scale variants are a B3 / aggregate-v2 concern.

Tests (42 cases in test_downstream_calibration.py):

  * _sample_stddev: 8 cases — empty / single / all-identical (fp flake regression) / two-distinct / three-distinct / ddof=1 vs population / negative values / floating-point precision at ULP scale.
  * compute_per_cell_stddev: 5 cases — empty reports / single report / multi-report per cell / separates cell keys / tolerates missing cells across reports.
  * aggregate_noise_floors happy path: 6 cases — returns NoiseFloorTable / single task+scale stddev math / multiplier scales linearly / zero multiplier / single report → all floors=0 / N identical reports → all floors=0.
  * aggregate_noise_floors multi-scale: 3 cases — per-task max picks noisier S1 / per-task max picks noisier S3 / separate tasks have independent etas.
  * aggregate_noise_floors metadata: 5 cases — harness_version stamped / recipe_sha threaded through / recipe_sha default empty / n_baselines count / eta_for fallback to 0 for unknown task.
  * aggregate_noise_floors errors: 3 cases — empty input rejected / negative multiplier rejected / zero multiplier accepted.
  * write JSON: 5 cases — round-trip / creates parent dirs / atomic no-tmp-leftover / _meta marker present / human- readable sorted output.
  * read JSON: 7 cases — rejects invalid JSON / missing _meta / wrong _meta / missing floors key / non-dict floors / tolerates missing optional fields / coerces int floor values to float.

DEFERRED.md updated: B1-D8 marked CLOSED at the aggregation surface (option (a) ratified). Operational baseline-training run on H100 recorded as a separate step, not blocking B2 / B3 / B4 code paths that consume NoiseFloorTable. 12 of 15 B1 decisions now closed; 3 remain (B1-D4 legal, B1-D10 restricted-files scanner glob, B1-D12 HiddenEvalResult schema-versioning test).

eval/downstream/__init__.py — re-exports aggregate_noise_floors
+ compute_per_cell_stddev + read/write_noise_floor_table_json; docstring updated to note B1 module sweep is complete.

B1 module sweep complete: types, aggregate, scorer, core22, private_hard, grader, runner (kernel + subprocess + CLI), calibration.

Full suite: 442/442 passing. Ruff clean on all touched files.