### PR TITLE
HiddenEvalResult schema versioning: add `downstream` field + to_legacy_dict (closes B1-D12)

### DIFF
--- a/eval/downstream/DEFERRED.md
+++ b/eval/downstream/DEFERRED.md
@@ -234,7 +234,18 @@ miner-side modification vector before the harness goes live.
 with `downstream=None` is byte-equivalent to a legacy serialization.
 **Recommendation:** Land. Prevents source-compat surprises during the
 v0.10 → v0.11 transition.
-**Status:** OPEN
+**Status:** **CLOSED 2026-06-11.** `eval/hidden_eval.py::HiddenEvalResult`
+extended with `downstream: DownstreamReport | None = None` + a
+`to_legacy_dict()` method that omits the `downstream` key when it's None
+(byte-equivalent to the pre-v0.11 `asdict()` shape). `validator/
+validator.py`'s chain serialization switched from raw `asdict()` to
+`to_legacy_dict()` so chain payloads stay byte-stable across the
+transition. 13 tests in `tests/test_hidden_eval_schema_versioning.py`
+pin: old-dict deserialization with the default firing, extra-key
+rejection (forward-compat asymmetry), missing-required-field rejection,
+to_legacy_dict byte equivalence (None and default cases), no
+`downstream` key when None, kwargs round-trip, populated-downstream
+inclusion, nested-cells shape via asdict, dataclass equality semantics.
 
 ## Decisions blocking the runner CLI contract
 

--- a/eval/hidden_eval.py
+++ b/eval/hidden_eval.py
@@ -13,23 +13,59 @@ active subset for repeatable tests.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import numpy as np
 import torch
 
 from .benchmark import compute_benchmark_score, make_placeholder_examples
+from .downstream.types import DownstreamReport
 from .val_bpb import compute_val_bpb, load_eval_tokens
 
 
 @dataclass
 class HiddenEvalResult:
+    """Validator-side scoring result for one checkpoint.
+
+    Schema versioning (B1-D12):
+      The `downstream` field is the v0.11 forward-compat extension
+      carrying the Cross-Scale Downstream Pareto report from the
+      v0.10 downstream-eval harness. Default `None` preserves the
+      pre-v0.11 contract — when `downstream is None`,
+      `to_legacy_dict()` produces a dict byte-equivalent to the
+      pre-v0.11 `dataclasses.asdict(...)` output, so old chain
+      consumers reading the legacy dict shape continue to work
+      against new validators that haven't filled in downstream yet.
+
+      Old serialized dicts (no `downstream` key) deserialize
+      cleanly via `HiddenEvalResult(**old_dict)` because the field
+      has a default. This is the asymmetric forward-compat property
+      B1-D12 calls out.
+    """
+
     val_bpb: float
     benchmark_accuracy: float
     tokens_evaluated: int
     benchmark_examples: int
     eval_set_hash: str
+    # B1-D12 forward-compat slot. When set, the v0.11+ chain consumer
+    # reads the Cross-Scale Downstream Pareto verdict via this field.
+    downstream: DownstreamReport | None = None
+
+    def to_legacy_dict(self) -> dict:
+        """Serialize, omitting `downstream` when it's None.
+
+        When `downstream is None` (the common case during the v0.10 →
+        v0.11 transition), the output is byte-identical to the
+        pre-v0.11 `dataclasses.asdict(self)` shape. When `downstream`
+        is populated, it's included as a nested dict (consumers that
+        don't know about it simply ignore the extra key).
+        """
+        d = asdict(self)
+        if d.get("downstream") is None:
+            d.pop("downstream", None)
+        return d
 
 
 def _stable_hash(obj) -> str:

--- a/tests/test_hidden_eval_schema_versioning.py
+++ b/tests/test_hidden_eval_schema_versioning.py
@@ -1,0 +1,311 @@
+"""Schema-versioning tests for HiddenEvalResult (closes B1-D12).
+
+The v0.10 → v0.11 transition extends HiddenEvalResult with an optional
+`downstream: DownstreamReport | None = None` field. These tests pin
+the forward-compat invariants:
+
+  1. An old serialized HiddenEvalResult dict (saved BEFORE the
+     downstream field was added, hence with NO `downstream` key)
+     deserializes cleanly via `HiddenEvalResult(**old_dict)` because
+     `downstream` has a default.
+
+  2. A new HiddenEvalResult with `downstream=None` serializes via
+     `to_legacy_dict()` to a dict byte-equivalent to the pre-v0.11
+     `dataclasses.asdict` shape — same keys, same values, no extra
+     `downstream` key. Chain consumers reading the legacy shape
+     continue to work against new validators that haven't filled in
+     downstream yet.
+
+  3. A new HiddenEvalResult with a populated downstream serializes via
+     `to_legacy_dict()` to a dict that INCLUDES the downstream nested
+     dict. Old consumers that don't know about `downstream` simply
+     ignore the extra key.
+
+Reference: docs/build_scope/02_scope_B1.md "DEFERRED.md B1-D12".
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from eval.downstream.types import (
+    HARNESS_VERSION,
+    CellResult,
+    DownstreamReport,
+)
+from eval.hidden_eval import HiddenEvalResult
+
+# ============================================================================
+# Forward-compat: old serialized dict deserializes cleanly
+# ============================================================================
+
+
+class TestOldDictDeserializes:
+    def test_old_format_dict_no_downstream_key(self):
+        """Pre-v0.11 dict (no downstream field) round-trips via kwargs."""
+        old_dict = {
+            "val_bpb": 1.234,
+            "benchmark_accuracy": 0.5,
+            "tokens_evaluated": 1000,
+            "benchmark_examples": 50,
+            "eval_set_hash": "abc123",
+        }
+        result = HiddenEvalResult(**old_dict)
+        assert result.val_bpb == 1.234
+        assert result.benchmark_accuracy == 0.5
+        assert result.tokens_evaluated == 1000
+        assert result.benchmark_examples == 50
+        assert result.eval_set_hash == "abc123"
+        # Default fires when key is absent.
+        assert result.downstream is None
+
+    def test_old_format_with_extra_keys_rejected(self):
+        """Extra keys still raise TypeError — dataclass kwargs are strict.
+
+        The forward-compat guarantee is "missing fields use defaults",
+        NOT "extra fields are silently dropped". If a future schema
+        change adds a field, a deserializer reading from a yet-newer
+        format would correctly fail loudly here.
+        """
+        old_dict = {
+            "val_bpb": 1.0,
+            "benchmark_accuracy": 0.5,
+            "tokens_evaluated": 1000,
+            "benchmark_examples": 50,
+            "eval_set_hash": "abc",
+            "unknown_future_field": "surprise",
+        }
+        with pytest.raises(TypeError, match=r"unknown_future_field"):
+            HiddenEvalResult(**old_dict)
+
+    def test_old_format_missing_required_field_raises(self):
+        """Pre-existing fields (without defaults) remain required."""
+        old_dict = {
+            "val_bpb": 1.0,
+            "benchmark_accuracy": 0.5,
+            # missing tokens_evaluated
+            "benchmark_examples": 50,
+            "eval_set_hash": "abc",
+        }
+        with pytest.raises(TypeError, match=r"tokens_evaluated"):
+            HiddenEvalResult(**old_dict)
+
+
+# ============================================================================
+# Backward-compat: new None-downstream → byte-equivalent to legacy serialization
+# ============================================================================
+
+
+class TestLegacyDictByteEquivalence:
+    def _legacy_serialization_target(
+        self, *, val_bpb=1.0, benchmark_accuracy=0.5,
+        tokens_evaluated=1000, benchmark_examples=50, eval_set_hash="abc",
+    ) -> dict:
+        """The exact dict shape the pre-v0.11 asdict() would produce.
+
+        This is what chain consumers reading the legacy format expect.
+        """
+        return {
+            "val_bpb": val_bpb,
+            "benchmark_accuracy": benchmark_accuracy,
+            "tokens_evaluated": tokens_evaluated,
+            "benchmark_examples": benchmark_examples,
+            "eval_set_hash": eval_set_hash,
+        }
+
+    def test_to_legacy_dict_with_none_downstream(self):
+        """downstream=None → output is byte-identical to legacy asdict."""
+        result = HiddenEvalResult(
+            val_bpb=1.234,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=1000,
+            benchmark_examples=50,
+            eval_set_hash="abc",
+            downstream=None,
+        )
+        expected = self._legacy_serialization_target(
+            val_bpb=1.234,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=1000,
+            benchmark_examples=50,
+            eval_set_hash="abc",
+        )
+        assert result.to_legacy_dict() == expected
+
+    def test_to_legacy_dict_default_downstream(self):
+        """Default downstream is also None → same byte-equivalence."""
+        result = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=1000,
+            benchmark_examples=50,
+            eval_set_hash="abc",
+        )
+        expected = self._legacy_serialization_target()
+        assert result.to_legacy_dict() == expected
+
+    def test_to_legacy_dict_no_downstream_key_when_none(self):
+        """downstream=None → output dict has NO downstream key at all."""
+        result = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=1000,
+            benchmark_examples=50,
+            eval_set_hash="abc",
+        )
+        d = result.to_legacy_dict()
+        assert "downstream" not in d
+
+    def test_legacy_dict_round_trip_via_kwargs(self):
+        """to_legacy_dict() → HiddenEvalResult(**) recovers the same object."""
+        original = HiddenEvalResult(
+            val_bpb=1.234,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=1000,
+            benchmark_examples=50,
+            eval_set_hash="abc",
+        )
+        restored = HiddenEvalResult(**original.to_legacy_dict())
+        assert restored == original
+
+
+# ============================================================================
+# Populated downstream — to_legacy_dict still includes it
+# ============================================================================
+
+
+class TestPopulatedDownstream:
+    def _sample_downstream(self) -> DownstreamReport:
+        return DownstreamReport(
+            harness_version=HARNESS_VERSION,
+            bundle_sha256="def456",
+            seed=7,
+            total_examples=10,
+            wall_clock_s=1.5,
+            cells={
+                "arc_easy:S3": CellResult(
+                    task="arc_easy",
+                    accuracy=0.6,
+                    accuracy_stderr=0.0,
+                    n_examples=10,
+                    seed=7,
+                ),
+            },
+        )
+
+    def test_downstream_included_when_set(self):
+        result = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=1000,
+            benchmark_examples=50,
+            eval_set_hash="abc",
+            downstream=self._sample_downstream(),
+        )
+        d = result.to_legacy_dict()
+        assert "downstream" in d
+        assert d["downstream"]["harness_version"] == HARNESS_VERSION
+        assert d["downstream"]["bundle_sha256"] == "def456"
+
+    def test_downstream_dict_shape_matches_asdict(self):
+        """Nested downstream uses dataclasses.asdict conversion — full
+        recursive dict; structure matches DownstreamReport's asdict."""
+        downstream = self._sample_downstream()
+        result = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=1000,
+            benchmark_examples=50,
+            eval_set_hash="abc",
+            downstream=downstream,
+        )
+        d = result.to_legacy_dict()
+        assert d["downstream"] == asdict(downstream)
+
+    def test_cells_nested_in_downstream_dict(self):
+        result = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=1000,
+            benchmark_examples=50,
+            eval_set_hash="abc",
+            downstream=self._sample_downstream(),
+        )
+        d = result.to_legacy_dict()
+        assert "arc_easy:S3" in d["downstream"]["cells"]
+        cell = d["downstream"]["cells"]["arc_easy:S3"]
+        assert cell["task"] == "arc_easy"
+        assert cell["accuracy"] == 0.6
+
+
+# ============================================================================
+# Cross-cutting: dataclass equality + asdict semantics
+# ============================================================================
+
+
+class TestDataclassSemantics:
+    def test_two_results_with_same_fields_equal(self):
+        a = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=100,
+            benchmark_examples=10,
+            eval_set_hash="x",
+        )
+        b = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=100,
+            benchmark_examples=10,
+            eval_set_hash="x",
+        )
+        assert a == b
+
+    def test_downstream_difference_breaks_equality(self):
+        a = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=100,
+            benchmark_examples=10,
+            eval_set_hash="x",
+        )
+        b = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=100,
+            benchmark_examples=10,
+            eval_set_hash="x",
+            downstream=DownstreamReport(
+                harness_version=HARNESS_VERSION,
+                bundle_sha256="any",
+                seed=0,
+                total_examples=0,
+                wall_clock_s=0.0,
+                cells={},
+            ),
+        )
+        assert a != b
+
+    def test_asdict_includes_downstream_none(self):
+        """Raw asdict (not to_legacy_dict) keeps the downstream: None key.
+
+        This is what legacy callers that hadn't migrated would see.
+        The to_legacy_dict helper is the explicit migration tool;
+        asdict() reflects the dataclass shape verbatim.
+        """
+        result = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=100,
+            benchmark_examples=10,
+            eval_set_hash="x",
+        )
+        d = asdict(result)
+        assert "downstream" in d
+        assert d["downstream"] is None

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -82,7 +82,9 @@ class ValidatorResult:
             "pr_url": self.pr_url,
             "bundle_hash": self.bundle_hash,
             "handshake_nonce": self.handshake_nonce,
-            "hidden_eval": asdict(self.hidden_eval) if self.hidden_eval else None,
+            # Use to_legacy_dict() so the chain payload stays byte-equivalent
+            # to pre-v0.11 form when downstream is None (B1-D12 contract).
+            "hidden_eval": self.hidden_eval.to_legacy_dict() if self.hidden_eval else None,
             "training_summary": self.training_summary,
             "calibration": self.calibration,
             "operations": self.operations,


### PR DESCRIPTION
What this commit ships:

  1. eval/hidden_eval.py — HiddenEvalResult extended with: * `downstream: DownstreamReport | None = None` field — the v0.11 forward-compat slot for the Cross-Scale Downstream Pareto report. Default None preserves the pre-v0.11 contract. * `to_legacy_dict()` method — serializes via dataclasses.asdict but POPS the `downstream` key when its value is None. Output is then byte-identical to the pre-v0.11 asdict() shape.

  2. validator/validator.py — switched the chain payload's `hidden_eval` field from raw `asdict(self.hidden_eval)` to `self.hidden_eval.to_legacy_dict()` so chain consumers reading the pre-v0.11 shape continue to work unchanged against new validators that haven't filled in downstream yet. The transition is byte-stable.

Schema versioning contract (B1-D12):

  Forward-compat (old dict → new struct):
    HiddenEvalResult(**old_dict) succeeds when old_dict has no
    `downstream` key because the field has a default. Asymmetry:
    extra keys still raise TypeError (dataclass kwargs are strict);
    this is the correct behaviour — we want forward-compat for
    MISSING fields with defaults, not for arbitrary EXTRA fields a
    yet-newer format might include.

  Backward-compat (new struct → old dict):
    to_legacy_dict() with downstream=None produces a dict identical
    to what the pre-v0.11 asdict() would produce. When downstream is
    set, the nested dict is included (asdict-recursive) and old
    consumers ignore the extra key.

Tests (13 cases in test_hidden_eval_schema_versioning.py):

  * TestOldDictDeserializes: 3 cases — old-format dict deserializes cleanly with default firing for downstream / extra-key rejection (forward-compat asymmetry) / missing-required-field rejection.
  * TestLegacyDictByteEquivalence: 4 cases — to_legacy_dict matches legacy shape (explicit None downstream + default downstream) / output dict has no `downstream` key when value is None / legacy-dict round-trip via kwargs recovers identical struct.
  * TestPopulatedDownstream: 3 cases — to_legacy_dict includes downstream when set / nested dict matches dataclasses.asdict on the DownstreamReport / cells structure preserved through the asdict-recursive conversion.
  * TestDataclassSemantics: 3 cases — dataclass equality on identical fields / downstream-difference breaks equality / raw asdict (NOT to_legacy_dict) keeps `downstream: None` for callers that need the verbatim dataclass shape.

DEFERRED.md updated: B1-D12 marked CLOSED. 14 of 15 items now closed; only B1-D4 (legal CC-BY-SA review — user-owned, not engineering) remains open.

Full suite: 462/462 passing. Ruff clean on touched files.