### PR TITLE
eval/sealed_streams.py: B2 foundation — sampler + manifest + np.memmap loader

### DIFF
--- a/eval/__init__.py
+++ b/eval/__init__.py
@@ -5,11 +5,33 @@ restricted-file diff scanner enforces this in validator/.
 
 from .benchmark import compute_benchmark_score
 from .hidden_eval import HiddenEvalResult, run_hidden_eval
+from .sealed_streams import (
+    MANIFEST_VERSION,
+    SealedStreamBatch,
+    SealedStreamManifest,
+    SealedStreamSpec,
+    bytes_per_token_for,
+    compute_streams_root_hash,
+    load_stream,
+    read_manifest,
+    select_active_streams,
+    write_manifest,
+)
 from .val_bpb import compute_val_bpb
 
 __all__ = [
-    "compute_val_bpb",
-    "compute_benchmark_score",
     "HiddenEvalResult",
+    "MANIFEST_VERSION",
+    "SealedStreamBatch",
+    "SealedStreamManifest",
+    "SealedStreamSpec",
+    "bytes_per_token_for",
+    "compute_benchmark_score",
+    "compute_streams_root_hash",
+    "compute_val_bpb",
+    "load_stream",
+    "read_manifest",
     "run_hidden_eval",
+    "select_active_streams",
+    "write_manifest",
 ]

--- a/eval/sealed_streams.py
+++ b/eval/sealed_streams.py
@@ -1,0 +1,444 @@
+"""Sealed-stream pool sampler + manifest + loader (B2 foundation).
+
+The validator owns a 10-stream sealed pool (200k uint16 tokens each) and
+selects 2 active streams per epoch from an on-chain beacon. This module
+ships the sampling + loading half of B2 (B2 scope §4); the build script
+(`eval/build_sealed_pool.py`) that constructs the actual stream bytes
+from HF corpora is a separate follow-up. CPU-testable end-to-end via
+synthetic stream fixtures.
+
+What this module ships:
+
+  * `SealedStreamSpec` — per-stream metadata (id, corpus, sub_genre,
+    n_tokens, bytes_per_token, sha256). Frozen dataclass.
+  * `SealedStreamManifest` — list of specs + manifest version +
+    streams_root_hash. `streams_root_hash` is `sha256(sorted_sha256s)`
+    — a single fingerprint the on-chain `LadderCommitted` event will
+    record, so any drift in the sealed pool is detectable from chain
+    state alone.
+  * `select_active_streams(beacon, *, n_in_pool=10, n_active=2)` —
+    deterministic selection. For each stream index, derive a ranking
+    key `sha256(beacon || index_big_endian_4byte)`, sort ascending by
+    key, take the first `n_active` indices. Same beacon → same output;
+    uniform-random beacons → uniform-random outputs; output indices
+    are distinct by sort-uniqueness.
+  * `load_stream(stream_id, pool_dir, manifest, *, verify_sha=True)` —
+    np.memmap loader. Optionally hashes the file on open and rejects
+    if SHA doesn't match the manifest.
+  * `bytes_per_token_for(stream_id, manifest)` — per-stream
+    bytes-per-token lookup so `compute_val_bpb` can stop hardcoding
+    4.0 (B2 scope §"Files to MODIFY" — eval/val_bpb.py:74-77).
+  * `read_manifest(path)` / `write_manifest(manifest, path)` — JSON I/O
+    with `_meta` marker validation, atomic-write via .tmp + rename.
+
+What this module does NOT ship (next B2 PRs):
+
+  * The actual stream byte construction from HF corpora
+    (`eval/build_sealed_pool.py`).
+  * The public synthetic dev-stream pool + statistical-match verifier.
+  * The on-chain commit helper (`scripts/commit_pool_v1.py`).
+  * The TDX / LUKS / tmpfs deployment runbook.
+  * `compute_val_bpb_on_stream` shim (depends on
+    eval/val_bpb.py threading the per-stream bytes_per_token in;
+    separate change).
+
+Restricted-files note: this file lives under `eval/sealed_streams.py`
+which is covered by the `eval/**` glob in `restricted_files.yaml` (and
+explicitly via the `eval/private/streams/**` glob added in B1-D10 for
+the runtime stream files themselves).
+
+Reference scope: docs/build_scope/02_scope_B2.md §"Files to CREATE".
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+# JSON header marker; bump on any schema change to the manifest.
+_MANIFEST_META = "karpa-sealed-pool-manifest"
+MANIFEST_VERSION = "v1"
+
+
+# ----------------------------------------------------------------------------
+# Dataclasses
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SealedStreamSpec:
+    """Per-stream metadata. One entry per file in the sealed pool.
+
+    Fields:
+      * id — stable identifier, e.g. "stream_00". The file name
+        convention is `{id}.bin` under the pool dir.
+      * corpus — top-level corpus tag, e.g. "fineweb-edu", "starcoderdata",
+        "open-web-math", "oasst2", "fineweb-2".
+      * sub_genre — within-corpus tag for the composition table, e.g.
+        "english_prose", "python", "math", "dialogue", "de_fr_es_ru".
+        Empty string is allowed when the corpus has no sub-genre.
+      * n_tokens — pinned token count. The validator asserts the
+        memmap's element count equals this on load.
+      * bytes_per_token — empirical ratio (decoded UTF-8 bytes /
+        tokens) computed at construction time. Used by
+        `compute_val_bpb` to convert NLL-per-token to NLL-per-byte.
+      * sha256 — sha256 hex digest of the on-disk file bytes.
+    """
+
+    id: str
+    corpus: str
+    sub_genre: str
+    n_tokens: int
+    bytes_per_token: float
+    sha256: str
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("SealedStreamSpec.id must be non-empty")
+        if self.n_tokens <= 0:
+            raise ValueError(
+                f"SealedStreamSpec.n_tokens must be > 0; got {self.n_tokens}"
+            )
+        if self.bytes_per_token <= 0:
+            raise ValueError(
+                f"SealedStreamSpec.bytes_per_token must be > 0; "
+                f"got {self.bytes_per_token}"
+            )
+        if not self.sha256 or len(self.sha256) != 64:
+            raise ValueError(
+                f"SealedStreamSpec.sha256 must be a 64-char hex digest; "
+                f"got {self.sha256!r}"
+            )
+
+
+@dataclass
+class SealedStreamManifest:
+    """The pool's full manifest: list of specs + version + root hash.
+
+    `streams_root_hash` is `sha256(b"".join(sorted(s.sha256.encode() for s
+    in streams)))` — a single fingerprint that summarizes the pool.
+    Comparing two manifests' root hashes is equivalent to comparing the
+    sorted multi-set of per-stream SHAs. The `LadderCommitted` chain
+    event records this single hash so any drift in the sealed pool is
+    catchable from chain state alone.
+    """
+
+    streams: list[SealedStreamSpec]
+    streams_root_hash: str = ""
+    version: str = MANIFEST_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.streams:
+            raise ValueError("SealedStreamManifest.streams must be non-empty")
+        # Reject duplicate IDs immediately — every spec must have a
+        # distinct id so the loader's id → spec map is unambiguous.
+        ids = [s.id for s in self.streams]
+        if len(set(ids)) != len(ids):
+            raise ValueError(
+                f"duplicate stream ids in manifest: {sorted(ids)}"
+            )
+        # Auto-compute the root hash if the caller didn't supply one.
+        # The computed hash is deterministic from the streams list.
+        if not self.streams_root_hash:
+            object.__setattr__(
+                self, "streams_root_hash", self._compute_root_hash(),
+            )
+
+    def _compute_root_hash(self) -> str:
+        return compute_streams_root_hash(self.streams)
+
+    def spec_for(self, stream_id: str) -> SealedStreamSpec:
+        """Lookup a spec by id. Raises KeyError if not present."""
+        for s in self.streams:
+            if s.id == stream_id:
+                return s
+        raise KeyError(
+            f"stream id {stream_id!r} not in manifest "
+            f"(have {sorted(s.id for s in self.streams)})"
+        )
+
+
+@dataclass(frozen=True)
+class SealedStreamBatch:
+    """One loaded stream + its metadata, ready for compute_val_bpb.
+
+    Wraps the np.memmap + the spec so callers don't have to thread
+    bytes_per_token + n_tokens separately. Frozen so the batch is
+    hashable / safe to cache.
+    """
+
+    spec: SealedStreamSpec
+    tokens: np.ndarray = field(hash=False, compare=False)
+
+
+# ----------------------------------------------------------------------------
+# Streams root hash
+# ----------------------------------------------------------------------------
+
+
+def compute_streams_root_hash(streams: list[SealedStreamSpec]) -> str:
+    """`sha256(b"".join(sorted(spec.sha256.encode() for spec in streams)))`.
+
+    Sorting before concatenation makes the root hash invariant to stream
+    ordering inside the manifest — what matters is the multi-set of
+    per-stream SHAs, not the order they were listed.
+    """
+    sorted_shas = sorted(s.sha256.encode("ascii") for s in streams)
+    h = hashlib.sha256()
+    for sha in sorted_shas:
+        h.update(sha)
+    return h.hexdigest()
+
+
+# ----------------------------------------------------------------------------
+# Stream selection (deterministic from beacon)
+# ----------------------------------------------------------------------------
+
+
+def select_active_streams(
+    beacon: bytes,
+    *,
+    n_in_pool: int = 10,
+    n_active: int = 2,
+) -> tuple[int, ...]:
+    """Deterministically select `n_active` distinct stream indices.
+
+    Algorithm (constant-time, no PRNG state):
+      For each stream index `i ∈ [0, n_in_pool)`, compute a ranking key
+      `sha256(beacon || i_big_endian_uint32)`. Sort all indices by key
+      ascending, return the first `n_active`. The 256-bit key space
+      makes collisions astronomically unlikely, so the output is always
+      `n_active` distinct indices.
+
+    Properties:
+      * Determinism: same beacon → same output across all callers.
+      * Uniform fairness: for uniform-random beacons, each stream has
+        equal probability of being in the active set (over the
+        symmetry group of sha256).
+      * Distinctness: sort-by-key is one-to-one in the absence of
+        sha256 collisions, so the top `n_active` indices are distinct
+        by construction.
+
+    Args:
+      beacon: arbitrary bytes that vary per epoch (typically the block
+        hash from `chain_layer.ChainInterface.get_block_hash`).
+      n_in_pool: total streams in the sealed pool. Default 10 matches
+        the B2 spec; tests may pass smaller values.
+      n_active: how many streams the epoch evaluates against. Default 2.
+
+    Raises:
+      ValueError if n_active > n_in_pool, n_active < 1, or beacon is
+      empty (an empty beacon would make selection a constant across
+      epochs, which defeats the purpose).
+    """
+    if n_active < 1:
+        raise ValueError(f"n_active must be >= 1; got {n_active}")
+    if n_active > n_in_pool:
+        raise ValueError(
+            f"n_active ({n_active}) > n_in_pool ({n_in_pool}); "
+            "cannot select more streams than the pool contains"
+        )
+    if not beacon:
+        raise ValueError(
+            "beacon must be non-empty; an empty beacon makes selection "
+            "constant across epochs"
+        )
+
+    ranked: list[tuple[bytes, int]] = []
+    for i in range(n_in_pool):
+        key = hashlib.sha256(beacon + i.to_bytes(4, "big")).digest()
+        ranked.append((key, i))
+    ranked.sort()
+    return tuple(idx for _, idx in ranked[:n_active])
+
+
+# ----------------------------------------------------------------------------
+# Loader
+# ----------------------------------------------------------------------------
+
+
+def _sha256_file(path: Path) -> str:
+    """sha256 of a file's contents, chunked to keep memory bounded."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_stream(
+    stream_id: str,
+    pool_dir: Path,
+    manifest: SealedStreamManifest,
+    *,
+    verify_sha: bool = True,
+) -> SealedStreamBatch:
+    """Load a sealed stream via `np.memmap` and return a `SealedStreamBatch`.
+
+    Args:
+      stream_id: identifier matching one of `manifest.streams[*].id`.
+      pool_dir: directory containing `{id}.bin` files.
+      manifest: the manifest the validator received via the out-of-band
+        signed tarball; used to look up the spec and (when
+        `verify_sha=True`) to validate the file bytes.
+      verify_sha: if True (default), sha256 the file on open and raise
+        ValueError on mismatch. Set False ONLY for tests that
+        deliberately corrupt files to exercise other failure modes.
+
+    Raises:
+      KeyError if `stream_id` is not in the manifest.
+      FileNotFoundError if `{pool_dir}/{stream_id}.bin` doesn't exist.
+      ValueError if `verify_sha=True` and the file's sha256 doesn't
+        match the manifest, OR if the loaded element count doesn't
+        match the spec's `n_tokens`.
+    """
+    spec = manifest.spec_for(stream_id)
+    path = Path(pool_dir) / f"{stream_id}.bin"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"sealed stream file not found: {path}"
+        )
+
+    if verify_sha:
+        actual_sha = _sha256_file(path)
+        if actual_sha != spec.sha256:
+            raise ValueError(
+                f"sealed stream {stream_id!r} sha mismatch:\n"
+                f"  expected (from manifest): {spec.sha256}\n"
+                f"  actual (from {path}):     {actual_sha}\n"
+                "Either the file is corrupted or the manifest is out of date."
+            )
+
+    tokens = np.memmap(path, dtype=np.uint16, mode="r")
+    if len(tokens) != spec.n_tokens:
+        raise ValueError(
+            f"sealed stream {stream_id!r} length mismatch: "
+            f"manifest says n_tokens={spec.n_tokens}, file has "
+            f"{len(tokens)} uint16 elements"
+        )
+    return SealedStreamBatch(spec=spec, tokens=tokens)
+
+
+def bytes_per_token_for(
+    stream_id: str,
+    manifest: SealedStreamManifest,
+) -> float:
+    """Per-stream bytes-per-token lookup.
+
+    Replaces the hardcoded `bytes_per_token = 4.0` in
+    `eval/val_bpb.py:76`. The actual ratio varies by stream because
+    non-English / code / math text tokenizes to different bytes-per-
+    token under GPT-2 BPE.
+    """
+    return manifest.spec_for(stream_id).bytes_per_token
+
+
+# ----------------------------------------------------------------------------
+# Manifest JSON I/O
+# ----------------------------------------------------------------------------
+
+
+def write_manifest(manifest: SealedStreamManifest, path: Path) -> None:
+    """Write a manifest to JSON via atomic .tmp + rename.
+
+    Output schema (with `_meta` marker for the reader to validate):
+      {
+        "_meta": "karpa-sealed-pool-manifest",
+        "version": "v1",
+        "streams_root_hash": "<sha256 hex>",
+        "streams": [
+          {"id": "stream_00", "corpus": "...", "sub_genre": "...",
+           "n_tokens": 200000, "bytes_per_token": 4.05,
+           "sha256": "<hex>"},
+          ...
+        ]
+      }
+
+    Atomic-write so a crashed write never leaves a half-written manifest
+    the validator consumes.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "_meta": _MANIFEST_META,
+        "version": manifest.version,
+        "streams_root_hash": manifest.streams_root_hash,
+        "streams": [asdict(s) for s in manifest.streams],
+    }
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True, indent=2))
+    tmp.replace(path)
+
+
+def read_manifest(path: Path) -> SealedStreamManifest:
+    """Inverse of `write_manifest`.
+
+    Validates the `_meta` marker, the `version` matches MANIFEST_VERSION,
+    and the streams list is present + non-empty. After loading, re-computes
+    `streams_root_hash` from the streams list and asserts it matches the
+    on-disk value — catches manifests that were hand-edited without
+    updating the root hash.
+
+    Raises ValueError on any validation failure, with a message naming
+    the specific issue.
+    """
+    path = Path(path)
+    try:
+        payload = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"sealed-pool manifest at {path} is not valid JSON: {e}"
+        ) from e
+
+    meta = payload.get("_meta")
+    if meta != _MANIFEST_META:
+        raise ValueError(
+            f"unexpected _meta marker {meta!r} in {path}; "
+            f"expected {_MANIFEST_META!r}"
+        )
+    version = payload.get("version")
+    if version != MANIFEST_VERSION:
+        raise ValueError(
+            f"manifest version mismatch in {path}: file says {version!r}, "
+            f"this reader expects {MANIFEST_VERSION!r}"
+        )
+
+    streams_in = payload.get("streams")
+    if not isinstance(streams_in, list):
+        raise ValueError(
+            f"manifest {path} missing 'streams' list "
+            f"(got {type(streams_in).__name__})"
+        )
+
+    specs: list[SealedStreamSpec] = []
+    for entry in streams_in:
+        specs.append(SealedStreamSpec(
+            id=str(entry["id"]),
+            corpus=str(entry["corpus"]),
+            sub_genre=str(entry.get("sub_genre", "")),
+            n_tokens=int(entry["n_tokens"]),
+            bytes_per_token=float(entry["bytes_per_token"]),
+            sha256=str(entry["sha256"]),
+        ))
+
+    expected_root = compute_streams_root_hash(specs)
+    on_disk_root = str(payload.get("streams_root_hash", ""))
+    if on_disk_root and on_disk_root != expected_root:
+        raise ValueError(
+            f"manifest {path} streams_root_hash mismatch:\n"
+            f"  expected (recomputed): {expected_root}\n"
+            f"  on disk:               {on_disk_root}\n"
+            "Either the manifest was hand-edited or a stream sha was "
+            "changed without updating the root hash."
+        )
+
+    # Pass the expected root explicitly so __post_init__ doesn't re-compute
+    # (the value is the same, just skipping the work).
+    return SealedStreamManifest(
+        streams=specs,
+        streams_root_hash=expected_root,
+        version=version,
+    )

--- a/tests/test_sealed_streams.py
+++ b/tests/test_sealed_streams.py
@@ -1,0 +1,473 @@
+"""Tests for eval/sealed_streams.py — sampler + manifest + loader.
+
+Covers:
+  * SealedStreamSpec field validation
+  * SealedStreamManifest construction + auto root-hash + duplicate-id
+    rejection
+  * compute_streams_root_hash determinism + order-invariance
+  * select_active_streams determinism + distinctness + fairness +
+    error paths
+  * load_stream happy path + SHA mismatch + length mismatch + missing
+    file + KeyError on unknown id
+  * bytes_per_token_for lookup
+  * read/write manifest JSON round-trip + atomicity + validation
+"""
+from __future__ import annotations
+
+import collections
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from eval.sealed_streams import (
+    MANIFEST_VERSION,
+    SealedStreamBatch,
+    SealedStreamManifest,
+    SealedStreamSpec,
+    bytes_per_token_for,
+    compute_streams_root_hash,
+    load_stream,
+    read_manifest,
+    select_active_streams,
+    write_manifest,
+)
+
+# ----------------------------------------------------------------------------
+# Test fixtures
+# ----------------------------------------------------------------------------
+
+VALID_SHA = "a" * 64
+
+
+def _spec(
+    stream_id: str = "stream_00",
+    corpus: str = "fineweb-edu",
+    sub_genre: str = "english_prose",
+    n_tokens: int = 1024,
+    bytes_per_token: float = 4.0,
+    sha256: str = VALID_SHA,
+) -> SealedStreamSpec:
+    return SealedStreamSpec(
+        id=stream_id,
+        corpus=corpus,
+        sub_genre=sub_genre,
+        n_tokens=n_tokens,
+        bytes_per_token=bytes_per_token,
+        sha256=sha256,
+    )
+
+
+def _write_stream_file(
+    pool_dir: Path,
+    stream_id: str,
+    n_tokens: int,
+    fill_value: int = 0,
+) -> Path:
+    """Write a synthetic stream file. Returns the path."""
+    pool_dir.mkdir(parents=True, exist_ok=True)
+    arr = np.full(n_tokens, fill_value, dtype=np.uint16)
+    path = pool_dir / f"{stream_id}.bin"
+    arr.tofile(path)
+    return path
+
+
+def _real_sha_for_file(path: Path) -> str:
+    import hashlib
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# ============================================================================
+# SealedStreamSpec
+# ============================================================================
+
+
+class TestSealedStreamSpec:
+    def test_minimum_valid(self):
+        s = _spec()
+        assert s.id == "stream_00"
+
+    def test_frozen(self):
+        s = _spec()
+        with pytest.raises(Exception):
+            s.id = "stream_99"  # type: ignore[misc]
+
+    def test_empty_id_rejected(self):
+        with pytest.raises(ValueError, match=r"id must be non-empty"):
+            _spec(stream_id="")
+
+    def test_zero_n_tokens_rejected(self):
+        with pytest.raises(ValueError, match=r"n_tokens must be > 0"):
+            _spec(n_tokens=0)
+
+    def test_negative_bytes_per_token_rejected(self):
+        with pytest.raises(ValueError, match=r"bytes_per_token must be > 0"):
+            _spec(bytes_per_token=-1.0)
+
+    def test_bad_sha256_length_rejected(self):
+        with pytest.raises(ValueError, match=r"64-char hex digest"):
+            _spec(sha256="short")
+
+    def test_empty_sha256_rejected(self):
+        with pytest.raises(ValueError, match=r"64-char hex digest"):
+            _spec(sha256="")
+
+
+# ============================================================================
+# SealedStreamManifest + root hash
+# ============================================================================
+
+
+class TestSealedStreamManifest:
+    def test_empty_streams_rejected(self):
+        with pytest.raises(ValueError, match=r"streams must be non-empty"):
+            SealedStreamManifest(streams=[])
+
+    def test_duplicate_ids_rejected(self):
+        with pytest.raises(ValueError, match=r"duplicate stream ids"):
+            SealedStreamManifest(streams=[_spec("a"), _spec("a")])
+
+    def test_auto_root_hash_computed(self):
+        m = SealedStreamManifest(streams=[_spec("a"), _spec("b")])
+        assert m.streams_root_hash != ""
+        assert len(m.streams_root_hash) == 64
+
+    def test_supplied_root_hash_preserved(self):
+        explicit = "f" * 64
+        m = SealedStreamManifest(
+            streams=[_spec("a")],
+            streams_root_hash=explicit,
+        )
+        # Note: __post_init__ uses the supplied value if non-empty; the
+        # read_manifest path explicitly re-computes and asserts match.
+        assert m.streams_root_hash == explicit
+
+    def test_default_version(self):
+        m = SealedStreamManifest(streams=[_spec()])
+        assert m.version == MANIFEST_VERSION
+
+    def test_spec_for_returns_match(self):
+        m = SealedStreamManifest(streams=[_spec("a"), _spec("b")])
+        s = m.spec_for("a")
+        assert s.id == "a"
+
+    def test_spec_for_unknown_raises(self):
+        m = SealedStreamManifest(streams=[_spec("a")])
+        with pytest.raises(KeyError):
+            m.spec_for("not_a_real_id")
+
+
+class TestComputeRootHash:
+    def test_deterministic_same_streams(self):
+        a = compute_streams_root_hash([_spec("a", sha256="b" * 64)])
+        b = compute_streams_root_hash([_spec("a", sha256="b" * 64)])
+        assert a == b
+
+    def test_order_invariant(self):
+        """Same streams in different order → same root hash."""
+        s1, s2 = _spec("s1", sha256="b" * 64), _spec("s2", sha256="c" * 64)
+        assert compute_streams_root_hash([s1, s2]) == compute_streams_root_hash([s2, s1])
+
+    def test_different_streams_different_hash(self):
+        a = compute_streams_root_hash([_spec("a", sha256="b" * 64)])
+        b = compute_streams_root_hash([_spec("a", sha256="c" * 64)])
+        assert a != b
+
+    def test_returns_hex_digest(self):
+        h = compute_streams_root_hash([_spec()])
+        assert len(h) == 64
+        int(h, 16)  # valid hex
+
+
+# ============================================================================
+# select_active_streams
+# ============================================================================
+
+
+class TestSelectActiveStreams:
+    def test_deterministic(self):
+        beacon = b"deadbeef"
+        a = select_active_streams(beacon, n_in_pool=10, n_active=2)
+        b = select_active_streams(beacon, n_in_pool=10, n_active=2)
+        assert a == b
+
+    def test_different_beacons_can_differ(self):
+        """Across many beacons, selections vary (basic sanity)."""
+        a = select_active_streams(b"beacon1", n_in_pool=10, n_active=2)
+        # Not guaranteed for any TWO specific beacons; this asserts
+        # at least one of N random pairs differs from `a`.
+        all_same = all(
+            select_active_streams(
+                f"beacon{i}".encode(), n_in_pool=10, n_active=2,
+            ) == a
+            for i in range(20)
+        )
+        assert not all_same
+
+    def test_distinct_indices(self):
+        """The output indices are pairwise distinct."""
+        for i in range(50):
+            indices = select_active_streams(
+                f"beacon{i}".encode(), n_in_pool=10, n_active=5,
+            )
+            assert len(set(indices)) == len(indices)
+
+    def test_indices_in_range(self):
+        for i in range(50):
+            indices = select_active_streams(
+                f"beacon{i}".encode(), n_in_pool=10, n_active=3,
+            )
+            for idx in indices:
+                assert 0 <= idx < 10
+
+    def test_all_streams_selectable(self):
+        """Across 500 epochs, every stream appears at least once in
+        the active set."""
+        seen: set[int] = set()
+        for i in range(500):
+            indices = select_active_streams(
+                f"epoch{i}".encode(), n_in_pool=10, n_active=2,
+            )
+            seen.update(indices)
+        assert seen == set(range(10))
+
+    def test_fair_distribution(self):
+        """Across many beacons, selection frequency is approximately
+        uniform — each stream appears in ~20% of epochs when n_active=2
+        out of n_in_pool=10."""
+        counter: collections.Counter = collections.Counter()
+        n_trials = 1000
+        for i in range(n_trials):
+            indices = select_active_streams(
+                f"beacon{i}".encode(), n_in_pool=10, n_active=2,
+            )
+            counter.update(indices)
+        # Each stream should be active in roughly n_trials * 2 / 10 = 200 trials.
+        # Tolerance ±20% (loose so it doesn't flake; actual variance is ~5%).
+        expected = n_trials * 2 / 10
+        for stream_id in range(10):
+            count = counter[stream_id]
+            assert 0.8 * expected <= count <= 1.2 * expected, (
+                f"stream {stream_id} active {count}/{n_trials} ({count/n_trials:.1%}); "
+                f"expected ~{expected/n_trials:.1%}"
+            )
+
+    def test_n_active_one(self):
+        indices = select_active_streams(b"x", n_in_pool=10, n_active=1)
+        assert len(indices) == 1
+
+    def test_n_active_equals_pool(self):
+        """When n_active == n_in_pool, the output is a permutation."""
+        indices = select_active_streams(b"x", n_in_pool=5, n_active=5)
+        assert set(indices) == set(range(5))
+
+    def test_n_active_zero_rejected(self):
+        with pytest.raises(ValueError, match=r"n_active must be >= 1"):
+            select_active_streams(b"x", n_in_pool=10, n_active=0)
+
+    def test_n_active_exceeds_pool_rejected(self):
+        with pytest.raises(ValueError, match=r"n_active.*> n_in_pool"):
+            select_active_streams(b"x", n_in_pool=5, n_active=10)
+
+    def test_empty_beacon_rejected(self):
+        with pytest.raises(ValueError, match=r"beacon must be non-empty"):
+            select_active_streams(b"", n_in_pool=10, n_active=2)
+
+
+# ============================================================================
+# load_stream
+# ============================================================================
+
+
+class TestLoadStream:
+    def test_happy_path(self, tmp_path):
+        path = _write_stream_file(tmp_path, "stream_00", n_tokens=128)
+        sha = _real_sha_for_file(path)
+        manifest = SealedStreamManifest(streams=[
+            _spec("stream_00", n_tokens=128, sha256=sha),
+        ])
+        batch = load_stream("stream_00", tmp_path, manifest)
+        assert isinstance(batch, SealedStreamBatch)
+        assert batch.spec.id == "stream_00"
+        assert len(batch.tokens) == 128
+
+    def test_missing_file_raises(self, tmp_path):
+        manifest = SealedStreamManifest(streams=[
+            _spec("stream_00", n_tokens=128, sha256=VALID_SHA),
+        ])
+        with pytest.raises(FileNotFoundError, match=r"sealed stream file"):
+            load_stream("stream_00", tmp_path, manifest)
+
+    def test_unknown_stream_id_raises(self, tmp_path):
+        manifest = SealedStreamManifest(streams=[
+            _spec("stream_00", n_tokens=128, sha256=VALID_SHA),
+        ])
+        with pytest.raises(KeyError):
+            load_stream("stream_99", tmp_path, manifest)
+
+    def test_sha_mismatch_raises(self, tmp_path):
+        _write_stream_file(tmp_path, "stream_00", n_tokens=128)
+        # Manifest claims a different SHA than the file actually has.
+        manifest = SealedStreamManifest(streams=[
+            _spec("stream_00", n_tokens=128, sha256="b" * 64),
+        ])
+        with pytest.raises(ValueError, match=r"sha mismatch"):
+            load_stream("stream_00", tmp_path, manifest)
+
+    def test_skip_sha_check(self, tmp_path):
+        _write_stream_file(tmp_path, "stream_00", n_tokens=128)
+        manifest = SealedStreamManifest(streams=[
+            _spec("stream_00", n_tokens=128, sha256="b" * 64),
+        ])
+        # verify_sha=False bypasses the check.
+        batch = load_stream("stream_00", tmp_path, manifest, verify_sha=False)
+        assert len(batch.tokens) == 128
+
+    def test_length_mismatch_raises(self, tmp_path):
+        path = _write_stream_file(tmp_path, "stream_00", n_tokens=128)
+        sha = _real_sha_for_file(path)
+        # Manifest claims 256 tokens; file has 128.
+        manifest = SealedStreamManifest(streams=[
+            _spec("stream_00", n_tokens=256, sha256=sha),
+        ])
+        with pytest.raises(ValueError, match=r"length mismatch"):
+            load_stream("stream_00", tmp_path, manifest)
+
+    def test_returns_memmap_not_copy(self, tmp_path):
+        path = _write_stream_file(tmp_path, "stream_00", n_tokens=128)
+        sha = _real_sha_for_file(path)
+        manifest = SealedStreamManifest(streams=[
+            _spec("stream_00", n_tokens=128, sha256=sha),
+        ])
+        batch = load_stream("stream_00", tmp_path, manifest)
+        assert isinstance(batch.tokens, np.memmap)
+
+
+# ============================================================================
+# bytes_per_token_for
+# ============================================================================
+
+
+class TestBytesPerTokenFor:
+    def test_lookup_returns_spec_value(self):
+        manifest = SealedStreamManifest(streams=[
+            _spec("a", bytes_per_token=3.5),
+            _spec("b", bytes_per_token=2.1),
+        ])
+        assert bytes_per_token_for("a", manifest) == 3.5
+        assert bytes_per_token_for("b", manifest) == 2.1
+
+    def test_unknown_id_raises(self):
+        manifest = SealedStreamManifest(streams=[_spec("a")])
+        with pytest.raises(KeyError):
+            bytes_per_token_for("not_in_manifest", manifest)
+
+
+# ============================================================================
+# Manifest JSON I/O
+# ============================================================================
+
+
+class TestManifestJson:
+    def test_round_trip(self, tmp_path):
+        original = SealedStreamManifest(streams=[
+            _spec("stream_00", corpus="fineweb-edu",
+                  sub_genre="english_prose",
+                  n_tokens=200000, bytes_per_token=4.05, sha256="a" * 64),
+            _spec("stream_01", corpus="starcoderdata",
+                  sub_genre="python",
+                  n_tokens=200000, bytes_per_token=3.2, sha256="b" * 64),
+        ])
+        path = tmp_path / "manifest.json"
+        write_manifest(original, path)
+        restored = read_manifest(path)
+        assert restored.version == original.version
+        assert restored.streams_root_hash == original.streams_root_hash
+        assert len(restored.streams) == 2
+        assert restored.streams[0].id == "stream_00"
+        assert restored.streams[1].corpus == "starcoderdata"
+        assert restored.streams[0].bytes_per_token == 4.05
+
+    def test_creates_parent_dirs(self, tmp_path):
+        manifest = SealedStreamManifest(streams=[_spec()])
+        path = tmp_path / "nested" / "deep" / "manifest.json"
+        write_manifest(manifest, path)
+        assert path.exists()
+
+    def test_atomic_no_tmp_leftover(self, tmp_path):
+        manifest = SealedStreamManifest(streams=[_spec()])
+        path = tmp_path / "manifest.json"
+        write_manifest(manifest, path)
+        assert not (tmp_path / "manifest.json.tmp").exists()
+
+    def test_meta_marker_present(self, tmp_path):
+        manifest = SealedStreamManifest(streams=[_spec()])
+        path = tmp_path / "manifest.json"
+        write_manifest(manifest, path)
+        loaded = json.loads(path.read_text())
+        assert loaded["_meta"] == "karpa-sealed-pool-manifest"
+        assert loaded["version"] == MANIFEST_VERSION
+
+    def test_human_readable_output(self, tmp_path):
+        manifest = SealedStreamManifest(streams=[_spec()])
+        path = tmp_path / "manifest.json"
+        write_manifest(manifest, path)
+        text = path.read_text()
+        # indent=2 produces multi-line output.
+        assert "\n  " in text
+
+    def test_read_rejects_invalid_json(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("{not json")
+        with pytest.raises(ValueError, match=r"not valid JSON"):
+            read_manifest(path)
+
+    def test_read_rejects_missing_meta(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps({"version": "v1", "streams": []}))
+        with pytest.raises(ValueError, match=r"_meta marker"):
+            read_manifest(path)
+
+    def test_read_rejects_wrong_version(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps({
+            "_meta": "karpa-sealed-pool-manifest",
+            "version": "v999",
+            "streams": [],
+        }))
+        with pytest.raises(ValueError, match=r"version mismatch"):
+            read_manifest(path)
+
+    def test_read_rejects_missing_streams_key(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps({
+            "_meta": "karpa-sealed-pool-manifest",
+            "version": MANIFEST_VERSION,
+        }))
+        with pytest.raises(ValueError, match=r"missing 'streams'"):
+            read_manifest(path)
+
+    def test_read_detects_root_hash_tampering(self, tmp_path):
+        """A hand-edited manifest where a stream's sha was changed but
+        the streams_root_hash wasn't updated raises ValueError."""
+        path = tmp_path / "manifest.json"
+        path.write_text(json.dumps({
+            "_meta": "karpa-sealed-pool-manifest",
+            "version": MANIFEST_VERSION,
+            "streams_root_hash": "f" * 64,  # fake root hash
+            "streams": [{
+                "id": "stream_00",
+                "corpus": "x",
+                "sub_genre": "y",
+                "n_tokens": 1024,
+                "bytes_per_token": 4.0,
+                "sha256": "a" * 64,
+            }],
+        }))
+        with pytest.raises(ValueError, match=r"streams_root_hash mismatch"):
+            read_manifest(path)


### PR DESCRIPTION
What this commit ships:

  1. SealedStreamSpec — frozen per-stream metadata (id, corpus, sub_genre, n_tokens, bytes_per_token, sha256). Validates each field at construction; rejects empty id / zero n_tokens / non-positive bytes_per_token / non-64-char hex sha256.

  2. SealedStreamManifest — list of specs + version + streams_root_hash. Auto-computes the root hash if not supplied (so callers in tests don't have to). Rejects empty streams list + duplicate ids. `spec_for(stream_id)` resolves an id to its spec or raises KeyError.

  3. compute_streams_root_hash — sha256 of the concatenation of sorted per-stream SHAs. Order-invariant: same streams in any order → same root hash. The on-chain `LadderCommitted` event records this single fingerprint so any drift in the sealed pool is catchable from chain state alone.

  4. select_active_streams(beacon, *, n_in_pool=10, n_active=2) — deterministic stream-pair selection. For each stream index i, derive ranking key `sha256(beacon || i_uint32_be)`, sort ascending, take first n_active. Properties: * Determinism: same beacon → same output. * Uniform fairness: each stream has equal selection prob over uniform beacons (verified empirically at 1000 trials with ±20% tolerance). * Distinctness: sort-by-key is one-to-one absent sha256 collisions, so output indices are pairwise distinct by construction. Rejects n_active < 1, n_active > n_in_pool, empty beacon.

  5. load_stream(stream_id, pool_dir, manifest, *, verify_sha=True) — np.memmap loader with optional SHA verification. Reads `{pool_dir}/{stream_id}.bin`, hashes it on open (when verify_sha=True), and rejects if SHA doesn't match the manifest. Also asserts memmap element count == spec.n_tokens. Raises: * KeyError on unknown stream_id * FileNotFoundError on missing file * ValueError on SHA / length mismatch

  6. bytes_per_token_for(stream_id, manifest) — replaces the `bytes_per_token = 4.0` hardcode in eval/val_bpb.py:76 for callers that have a manifest. (eval/val_bpb.py itself stays unchanged in this commit; the threading is a separate change.)

  7. read_manifest / write_manifest — JSON I/O with the _meta marker "karpa-sealed-pool-manifest" and version "v1". Atomic write via .tmp + rename. Reader validates _meta, version, presence of streams list, AND re-computes the root hash and asserts it matches the on-disk value (catches manifests that were hand-edited without updating the root hash).

What this commit does NOT ship (next B2 PRs):

  * eval/build_sealed_pool.py — the build script that pulls FineWeb-Edu, starcoderdata, OpenWebMath, OASST2, FineWeb-2 from HF and constructs the actual stream bytes. Substantial work (~600-900 LOC realistic per the B2 critique).
  * Public synthetic dev-stream pool + statistical-match verifier.
  * scripts/commit_pool_v1.py — on-chain LadderCommitted + the actual pool deployment runbook.
  * Threading per-stream bytes_per_token through eval/val_bpb.py.
  * compute_val_bpb_on_stream shim.

Tests (48 cases in test_sealed_streams.py):

  * SealedStreamSpec: 7 cases — minimum valid / frozen / field validation for id / n_tokens / bytes_per_token / sha256 length / empty sha256.
  * SealedStreamManifest: 7 cases — empty list rejected / duplicate ids rejected / auto root-hash computed / supplied root hash preserved / default version / spec_for happy + KeyError.
  * compute_streams_root_hash: 4 cases — determinism / order-invariance / different streams → different hash / returns 64-char hex.
  * select_active_streams: 11 cases — deterministic / different beacons can differ / output indices distinct (50 trials) / indices in range (50 trials) / all streams selectable in 500 epochs / fair distribution (1000 trials, ±20% tolerance) / n_active=1 / n_active == n_in_pool yields permutation / n_active=0 rejected / n_active
    > pool rejected / empty beacon rejected.
  * load_stream: 7 cases — happy path / missing file / unknown id / SHA mismatch / verify_sha=False bypass / length mismatch / returns np.memmap (not in-memory copy).
  * bytes_per_token_for: 2 cases — lookup returns spec value / unknown id raises.
  * Manifest JSON: 10 cases — round-trip / creates parent dirs / atomic no-tmp-leftover / _meta marker present / human-readable indent / rejects invalid JSON / missing _meta / wrong version / missing streams key / detects root-hash tampering.

Restricted-files note: eval/sealed_streams.py is covered by the existing eval/** glob in restricted_files.yaml (plus the eval/private/streams/** explicit glob added in B1-D10 for the runtime stream files themselves). Miner patches that touch this file are rejected at op1.

Full suite: 510/510 passing. Ruff clean on all touched files.