### PR TITLE
eval/val_bpb.py: per-stream bytes_per_token threading (B2 follow-up)

### DIFF
--- a/eval/__init__.py
+++ b/eval/__init__.py
@@ -17,9 +17,10 @@ from .sealed_streams import (
     select_active_streams,
     write_manifest,
 )
-from .val_bpb import compute_val_bpb
+from .val_bpb import DEFAULT_BYTES_PER_TOKEN, compute_val_bpb, compute_val_bpb_on_stream
 
 __all__ = [
+    "DEFAULT_BYTES_PER_TOKEN",
     "HiddenEvalResult",
     "MANIFEST_VERSION",
     "SealedStreamBatch",
@@ -29,6 +30,7 @@ __all__ = [
     "compute_benchmark_score",
     "compute_streams_root_hash",
     "compute_val_bpb",
+    "compute_val_bpb_on_stream",
     "load_stream",
     "read_manifest",
     "run_hidden_eval",

--- a/eval/val_bpb.py
+++ b/eval/val_bpb.py
@@ -8,16 +8,36 @@ It is vocabulary-independent (unlike perplexity), so architectural changes
 that change tokenization are scored fairly. This is what autoresearch
 optimizes by default; Karpa inherits the metric for the LLM
 pretraining launch track.
+
+Per-stream bytes_per_token (B2):
+  The token-to-byte ratio varies across the sealed pool: English prose
+  hits ~4.0 under GPT-2 BPE, but code/math/multilingual streams have
+  meaningfully different ratios (Python ~3.2, OpenWebMath ~3.5, FineWeb-2
+  non-European ~2.0). `compute_val_bpb` now accepts the ratio as a
+  parameter; `compute_val_bpb_on_stream` is a convenience wrapper for
+  callers holding a `SealedStreamBatch` that reads the per-stream value
+  from the manifest spec. Backward-compat: when `bytes_per_token=None`,
+  the 4.0 default fires — preserves the pre-B2 behaviour for
+  eval/hidden_eval.py and existing single-stream callers.
 """
 
 from __future__ import annotations
 
 import math
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
 import torch.nn.functional as F
+
+if TYPE_CHECKING:
+    from .sealed_streams import SealedStreamBatch
+
+# Default token-to-byte ratio when caller passes bytes_per_token=None.
+# Matches the pre-B2 hardcoded value; preserved for single-stream callers
+# and for Phase 0 smoke tests that don't construct a sealed pool.
+DEFAULT_BYTES_PER_TOKEN = 4.0
 
 
 def compute_val_bpb(
@@ -26,17 +46,30 @@ def compute_val_bpb(
     seq_len: int,
     batch_size: int = 8,
     device: torch.device | None = None,
+    *,
+    bytes_per_token: float | None = None,
 ) -> dict:
     """
     Compute val_bpb over a held-out token stream.
 
+    Args:
+      bytes_per_token: empirical token-to-byte ratio for this stream. When
+        None (default), uses `DEFAULT_BYTES_PER_TOKEN = 4.0` matching the
+        pre-B2 behaviour. When set (typically by `compute_val_bpb_on_stream`
+        reading from the SealedStreamManifest), uses that value. Must be
+        > 0 or ValueError.
+
     The token-to-byte ratio is recovered from the tokenizer: GPT-2 BPE
-    averages roughly 4.0 bytes per token on English text. For reproducibility
-    across runs we use the empirical ratio from the eval token stream's
-    decoded byte length, computed once at eval-set-construction time and
-    passed in here. For Phase 0 smoke tests we approximate with the typical
-    GPT-2 ratio.
+    averages roughly 4.0 bytes per token on English text. The sealed
+    pool's manifest carries per-stream ratios computed at
+    construction time from each stream's decoded byte length.
     """
+    if bytes_per_token is None:
+        bytes_per_token = DEFAULT_BYTES_PER_TOKEN
+    if bytes_per_token <= 0:
+        raise ValueError(
+            f"bytes_per_token must be > 0; got {bytes_per_token}"
+        )
     if device is None:
         device = next(model.parameters()).device
     model.eval()
@@ -71,9 +104,6 @@ def compute_val_bpb(
                 batch_inp.clear()
                 batch_tgt.clear()
 
-    # bytes per token: use a fixed ratio for Phase 0; in production this is
-    # computed from the eval set's decoded byte length at construction time.
-    bytes_per_token = 4.0  # typical for GPT-2 BPE on English
     total_bytes = total_tokens * bytes_per_token
     bpb = total_nats / (math.log(2) * total_bytes) if total_bytes > 0 else float("inf")
     nll_per_token = total_nats / max(total_tokens, 1)
@@ -83,6 +113,38 @@ def compute_val_bpb(
         "tokens_evaluated": total_tokens,
         "bytes_per_token": bytes_per_token,
     }
+
+
+def compute_val_bpb_on_stream(
+    model: torch.nn.Module,
+    batch: SealedStreamBatch,
+    seq_len: int,
+    batch_size: int = 8,
+    device: torch.device | None = None,
+) -> dict:
+    """Convenience wrapper: compute val_bpb on a `SealedStreamBatch`.
+
+    Reads `batch.spec.bytes_per_token` and passes it through to
+    `compute_val_bpb`. The result dict includes a `stream_id` field so
+    the validator's ladder code can route per-stream results into the
+    right Pareto cell.
+
+    Behaviour-equivalent to:
+        compute_val_bpb(model, np.asarray(batch.tokens), seq_len,
+                        batch_size, device,
+                        bytes_per_token=batch.spec.bytes_per_token)
+    plus the `stream_id` annotation.
+    """
+    result = compute_val_bpb(
+        model,
+        np.asarray(batch.tokens),
+        seq_len,
+        batch_size,
+        device,
+        bytes_per_token=batch.spec.bytes_per_token,
+    )
+    result["stream_id"] = batch.spec.id
+    return result
 
 
 def load_eval_tokens(path: Path | str) -> np.ndarray:

--- a/tests/test_val_bpb_per_stream.py
+++ b/tests/test_val_bpb_per_stream.py
@@ -1,0 +1,227 @@
+"""Tests for the B2 val_bpb per-stream bytes_per_token threading.
+
+Covers:
+  * compute_val_bpb default behaviour (no bytes_per_token) matches
+    pre-B2 fixed 4.0 — backward compat for eval/hidden_eval.py and any
+    other single-stream callers.
+  * compute_val_bpb honors an explicit bytes_per_token override.
+  * compute_val_bpb rejects bytes_per_token <= 0.
+  * compute_val_bpb_on_stream reads bytes_per_token from
+    batch.spec and stamps stream_id into the result dict.
+  * The math is exact: doubling bytes_per_token halves val_bpb (level
+    shift, not a sign error).
+
+These tests use a tiny synthetic torch model so they run on CPU; they
+do NOT exercise KarpaBase. The actual transformer correctness is tested
+elsewhere (tests/test_model.py).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from eval.sealed_streams import SealedStreamBatch, SealedStreamSpec
+from eval.val_bpb import (
+    DEFAULT_BYTES_PER_TOKEN,
+    compute_val_bpb,
+    compute_val_bpb_on_stream,
+)
+
+# ----------------------------------------------------------------------------
+# Synthetic model
+# ----------------------------------------------------------------------------
+
+VOCAB = 50  # small enough that CPU tests run fast
+
+
+class _TinyModel(torch.nn.Module):
+    """Returns (logits, None) — matches KarpaBase's forward signature."""
+
+    def __init__(self, vocab_size: int = VOCAB, dim: int = 8):
+        super().__init__()
+        self.embed = torch.nn.Embedding(vocab_size, dim)
+        self.out = torch.nn.Linear(dim, vocab_size)
+
+    def forward(self, x):
+        h = self.embed(x)
+        return self.out(h), None
+
+
+def _make_tokens(n: int) -> np.ndarray:
+    """Deterministic token stream small enough to evaluate quickly."""
+    rng = np.random.default_rng(seed=42)
+    return rng.integers(0, VOCAB, size=n, dtype=np.uint16)
+
+
+# ============================================================================
+# compute_val_bpb — bytes_per_token parameter
+# ============================================================================
+
+
+class TestComputeValBpbBackwardCompat:
+    def test_default_bytes_per_token_is_4(self):
+        """Without the kwarg, the helper uses DEFAULT_BYTES_PER_TOKEN=4.0."""
+        assert DEFAULT_BYTES_PER_TOKEN == 4.0
+
+    def test_no_arg_matches_explicit_default(self):
+        """compute_val_bpb() with default vs explicit 4.0 → identical results."""
+        torch.manual_seed(0)
+        model = _TinyModel()
+        tokens = _make_tokens(128)
+        result_default = compute_val_bpb(model, tokens, seq_len=16)
+        result_explicit = compute_val_bpb(
+            model, tokens, seq_len=16, bytes_per_token=4.0,
+        )
+        assert result_default["val_bpb"] == result_explicit["val_bpb"]
+        assert result_default["bytes_per_token"] == 4.0
+
+    def test_returns_expected_keys(self):
+        torch.manual_seed(0)
+        model = _TinyModel()
+        tokens = _make_tokens(64)
+        result = compute_val_bpb(model, tokens, seq_len=8)
+        assert "val_bpb" in result
+        assert "nll_per_token" in result
+        assert "tokens_evaluated" in result
+        assert "bytes_per_token" in result
+
+
+class TestComputeValBpbExplicitBytesPerToken:
+    def test_explicit_override(self):
+        torch.manual_seed(0)
+        model = _TinyModel()
+        tokens = _make_tokens(128)
+        result = compute_val_bpb(
+            model, tokens, seq_len=16, bytes_per_token=2.5,
+        )
+        assert result["bytes_per_token"] == 2.5
+
+    def test_halved_bytes_per_token_doubles_bpb(self):
+        """val_bpb = nats / (log(2) * total_bytes). Halving bytes_per_token
+        halves total_bytes and therefore doubles val_bpb. Math sanity check."""
+        torch.manual_seed(0)
+        model = _TinyModel()
+        tokens = _make_tokens(128)
+        baseline = compute_val_bpb(
+            model, tokens, seq_len=16, bytes_per_token=4.0,
+        )
+        halved = compute_val_bpb(
+            model, tokens, seq_len=16, bytes_per_token=2.0,
+        )
+        assert halved["val_bpb"] == pytest.approx(2 * baseline["val_bpb"])
+
+    def test_zero_bytes_per_token_rejected(self):
+        torch.manual_seed(0)
+        model = _TinyModel()
+        tokens = _make_tokens(64)
+        with pytest.raises(ValueError, match=r"bytes_per_token must be > 0"):
+            compute_val_bpb(model, tokens, seq_len=8, bytes_per_token=0)
+
+    def test_negative_bytes_per_token_rejected(self):
+        torch.manual_seed(0)
+        model = _TinyModel()
+        tokens = _make_tokens(64)
+        with pytest.raises(ValueError, match=r"bytes_per_token must be > 0"):
+            compute_val_bpb(model, tokens, seq_len=8, bytes_per_token=-1.0)
+
+    def test_nll_per_token_invariant_to_bytes_per_token(self):
+        """Changing bytes_per_token must NOT change nll_per_token — that's
+        a pure model+data property, no byte conversion involved."""
+        torch.manual_seed(0)
+        model = _TinyModel()
+        tokens = _make_tokens(128)
+        a = compute_val_bpb(model, tokens, seq_len=16, bytes_per_token=4.0)
+        b = compute_val_bpb(model, tokens, seq_len=16, bytes_per_token=2.0)
+        assert a["nll_per_token"] == b["nll_per_token"]
+        assert a["tokens_evaluated"] == b["tokens_evaluated"]
+
+
+# ============================================================================
+# compute_val_bpb_on_stream
+# ============================================================================
+
+
+def _make_batch(
+    bytes_per_token: float = 3.5,
+    n_tokens: int = 128,
+    stream_id: str = "stream_00",
+) -> SealedStreamBatch:
+    tokens = _make_tokens(n_tokens)
+    spec = SealedStreamSpec(
+        id=stream_id,
+        corpus="fineweb-edu",
+        sub_genre="english_prose",
+        n_tokens=n_tokens,
+        bytes_per_token=bytes_per_token,
+        sha256="a" * 64,
+    )
+    return SealedStreamBatch(spec=spec, tokens=tokens)
+
+
+class TestComputeValBpbOnStream:
+    def test_uses_per_stream_bytes_per_token(self):
+        """The wrapper threads bytes_per_token from the spec, not the
+        default 4.0."""
+        torch.manual_seed(0)
+        model = _TinyModel()
+        batch = _make_batch(bytes_per_token=3.2)
+        result = compute_val_bpb_on_stream(model, batch, seq_len=16)
+        assert result["bytes_per_token"] == 3.2
+
+    def test_stamps_stream_id(self):
+        torch.manual_seed(0)
+        model = _TinyModel()
+        batch = _make_batch(stream_id="stream_07")
+        result = compute_val_bpb_on_stream(model, batch, seq_len=16)
+        assert result["stream_id"] == "stream_07"
+
+    def test_carries_all_keys(self):
+        torch.manual_seed(0)
+        model = _TinyModel()
+        batch = _make_batch()
+        result = compute_val_bpb_on_stream(model, batch, seq_len=16)
+        # The base compute_val_bpb keys are preserved.
+        for key in ("val_bpb", "nll_per_token", "tokens_evaluated",
+                    "bytes_per_token"):
+            assert key in result
+        # Plus the stream annotation.
+        assert "stream_id" in result
+
+    def test_matches_compute_val_bpb_directly(self):
+        """compute_val_bpb_on_stream(model, batch) ==
+        compute_val_bpb(model, np.asarray(batch.tokens),
+                        bytes_per_token=batch.spec.bytes_per_token)
+        modulo the stream_id annotation."""
+        torch.manual_seed(0)
+        model = _TinyModel()
+        batch = _make_batch(bytes_per_token=2.7)
+        direct = compute_val_bpb(
+            model, np.asarray(batch.tokens), seq_len=16,
+            bytes_per_token=2.7,
+        )
+        wrapped = compute_val_bpb_on_stream(model, batch, seq_len=16)
+        # Same numerical results.
+        assert wrapped["val_bpb"] == direct["val_bpb"]
+        assert wrapped["nll_per_token"] == direct["nll_per_token"]
+        assert wrapped["tokens_evaluated"] == direct["tokens_evaluated"]
+
+    def test_two_streams_with_different_ratios_diverge(self):
+        """Two streams with the same tokens but different bytes_per_token
+        produce different val_bpb (the level shift is real, not a
+        formatting bug)."""
+        torch.manual_seed(0)
+        model = _TinyModel()
+        batch_a = _make_batch(bytes_per_token=4.0)
+        batch_b = _make_batch(bytes_per_token=2.0)
+        # Same token sequence in both batches (same seed inside _make_tokens).
+        result_a = compute_val_bpb_on_stream(model, batch_a, seq_len=16)
+        result_b = compute_val_bpb_on_stream(model, batch_b, seq_len=16)
+        # Halved bytes_per_token → doubled val_bpb.
+        assert result_b["val_bpb"] == pytest.approx(2 * result_a["val_bpb"])


### PR DESCRIPTION
What this commit ships:

  1. compute_val_bpb gains an optional bytes_per_token keyword arg. When None (default), uses DEFAULT_BYTES_PER_TOKEN = 4.0, matching the pre-B2 hardcoded value — eval/hidden_eval.py and any other single-stream callers continue to work unchanged. When set, the helper uses the provided ratio. Rejects values <= 0 with a clear ValueError.

  2. compute_val_bpb_on_stream(model, batch, seq_len, ...) — thin wrapper around compute_val_bpb that: * Reads batch.spec.bytes_per_token (from the SealedStreamManifest) * Reads batch.tokens (the memmap) * Delegates to compute_val_bpb with the right ratio * Stamps batch.spec.id into the result dict as `stream_id` so the validator's ladder code can route per-stream results into the right Pareto cell.

  3. DEFAULT_BYTES_PER_TOKEN module-level constant + re-export from eval/__init__.py so calibration tooling can read the legacy value without re-deriving it.

Motivation (B2 scope §"Files to MODIFY" eval/val_bpb.py:74-77):
  bytes-per-token varies meaningfully across the sealed pool. GPT-2
  BPE compresses English prose at ~4.0 bytes/token but achieves
  significantly different ratios on code (Python ~3.2), math
  (OpenWebMath ~3.5), and non-European multilingual streams (~2.0).
  Without per-stream ratios, the val_bpb comparison across streams
  would be biased by tokenization rather than by model quality.

Backward-compat:
  * eval/hidden_eval.py:93 calls compute_val_bpb without bytes_per_token → falls through to the 4.0 default. Unchanged.
  * Any other in-tree caller using the previous signature works unchanged because bytes_per_token is a keyword-only param.

Tests (13 cases in test_val_bpb_per_stream.py):

  * Backward compat: 3 cases — DEFAULT_BYTES_PER_TOKEN is 4.0 / no-arg call matches explicit 4.0 / returns expected keys.
  * Explicit override: 5 cases — explicit value lands in result / halved bytes doubles val_bpb (math sanity) / zero rejected / negative rejected / nll_per_token invariant to bytes_per_token (pure model+data property).
  * compute_val_bpb_on_stream: 5 cases — uses per-stream ratio / stamps stream_id / preserves all base keys / numerical equivalence to compute_val_bpb call with the same args / two streams with different ratios diverge by the right factor.

Tests use a tiny synthetic torch model (Embedding + Linear, returns (logits, None) to match KarpaBase's signature). Runs CPU-only in under a second.

Full suite: 523/523 passing. Ruff clean on touched files.