### PR TITLE
eval/downstream/core22.py::load_task_examples: implement canonical-JSONL parser

### DIFF
--- a/eval/downstream/core22.py
+++ b/eval/downstream/core22.py
@@ -12,18 +12,21 @@ catalogued by:
     baseline as a fraction in [0, 1]
 
 The bundle URL + SHA pin are constants here so the runner can verify the
-on-disk mirror against the expected upstream version. The actual bundle
-fetch + jsonl parsing is deferred to a follow-up commit once the bundle
-is downloaded and its SHA is pinned (B1-D2 protocol). For now the
-loader stub raises a clear NotImplementedError that the runner.py
-author will resolve.
+on-disk mirror against the expected upstream version. `load_task_examples`
+parses per-task JSONLs from a local bundle copy and dispatches to the
+per-mode parser (mc / schema / lm) to produce typed raw rows. The
+actual bundle FETCH (download + SHA verification + local mirror) is a
+separate operational step — `load_task_examples` takes the bundle
+directory as an input and reads from there.
 
 Reference scope: docs/build_scope/02_scope_B1.md "core22.py".
 """
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 
 from .scorer import (
     LMExample,
@@ -298,26 +301,189 @@ def to_cell_result(
 # ----------------------------------------------------------------------------
 
 
-def load_task_examples(bundle_dir, task_name: str):
-    """Load raw rows for a task from the DCLM bundle.
+def _read_jsonl(path: Path) -> list[dict]:
+    """Iterate a JSONL file into a list of dicts. Skips blank lines.
 
-    NOT IMPLEMENTED in this commit. The bundle layout follows DCLM's
-    `eval_bundle/<task_name>.jsonl` convention with per-task schemas
-    that the runner.py author will parse.
-
-    Until the bundle SHA is pinned (B1-D2), this raises a clear error
-    pointing at the protocol the first downloader commit must follow.
-    Callers that test against fixture data can use
-    `make_mc_example` / `make_schema_example` / `make_lm_example`
-    directly without going through this loader.
+    Raises ValueError naming the offending line on the first invalid
+    JSON line, so a downloader / mirror that produced a corrupt file
+    fails clean rather than silently dropping examples.
     """
-    raise NotImplementedError(
-        f"load_task_examples({task_name!r}) is not implemented in B1 "
-        "foundation. The first commit that downloads the bundle from "
-        f"{DCLM_EVAL_BUNDLE_URL} must (1) compute its SHA256, (2) update "
-        "DCLM_EVAL_BUNDLE_SHA256 in this module, (3) implement this "
-        "loader to parse <bundle_dir>/<task_name>.jsonl, and (4) add "
-        "tests/test_downstream_core22_bundle.py with one task driven "
-        "end-to-end against the real bundle. See eval/downstream/DEFERRED.md "
-        "items B1-D2 / B1-D13 / B1-D8 for the protocol."
+    rows: list[dict] = []
+    with path.open() as f:
+        for line_no, line in enumerate(f, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                rows.append(json.loads(stripped))
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"invalid JSON at {path}:{line_no}: {e}"
+                ) from e
+    return rows
+
+
+def _parse_mc_row(row: dict, line_no: int) -> MCRawRow:
+    """Parse one canonical MC JSONL row.
+
+    Schema (canonical Karpa form):
+      {"id": str, "query": str, "choices": [str, ...], "gold": int}
+
+    `id` is consumed by callers that need item-level keying (e.g.
+    private-hard's HardnessIndex lookup). `_parse_mc_row` ignores it —
+    the loader returns plain MCRawRow / SchemaRawRow / LMRawRow without
+    the id; private-hard's `load_task_examples` (separate follow-up)
+    is the variant that preserves `(item_id, row)` pairs.
+    """
+    try:
+        query = str(row["query"])
+        choices = list(row["choices"])
+        gold = int(row["gold"])
+    except (KeyError, TypeError, ValueError) as e:
+        raise ValueError(
+            f"row {line_no}: expected canonical MC schema "
+            f"{{query, choices, gold}}; got error: {e}"
+        ) from e
+    if not all(isinstance(c, str) for c in choices):
+        raise ValueError(
+            f"row {line_no}: 'choices' must be a list of strings"
+        )
+    if not 0 <= gold < len(choices):
+        raise ValueError(
+            f"row {line_no}: gold={gold} out of range for "
+            f"{len(choices)} choices"
+        )
+    return MCRawRow(query=query, choices=choices, gold=gold)
+
+
+def _parse_schema_row(row: dict, line_no: int) -> SchemaRawRow:
+    """Parse one canonical schema JSONL row.
+
+    Schema: {"id": str, "contexts": [str, ...], "continuations": [str, ...],
+             "gold": int}
+
+    Each variant has its own (context, continuation) pair. `contexts` and
+    `continuations` must have the same length (one entry per variant).
+    """
+    try:
+        contexts = list(row["contexts"])
+        continuations = list(row["continuations"])
+        gold = int(row["gold"])
+    except (KeyError, TypeError, ValueError) as e:
+        raise ValueError(
+            f"row {line_no}: expected canonical schema "
+            f"{{contexts, continuations, gold}}; got error: {e}"
+        ) from e
+    if len(contexts) != len(continuations):
+        raise ValueError(
+            f"row {line_no}: contexts ({len(contexts)}) and "
+            f"continuations ({len(continuations)}) length mismatch"
+        )
+    if not all(isinstance(c, str) for c in contexts):
+        raise ValueError(
+            f"row {line_no}: 'contexts' must be a list of strings"
+        )
+    if not all(isinstance(c, str) for c in continuations):
+        raise ValueError(
+            f"row {line_no}: 'continuations' must be a list of strings"
+        )
+    if not 0 <= gold < len(contexts):
+        raise ValueError(
+            f"row {line_no}: gold={gold} out of range for "
+            f"{len(contexts)} variants"
+        )
+    return SchemaRawRow(
+        contexts=contexts, continuations=continuations, gold=gold,
     )
+
+
+def _parse_lm_row(row: dict, line_no: int) -> LMRawRow:
+    """Parse one canonical LM JSONL row.
+
+    Schema: {"id": str, "context": str, "target": str,
+             "accept_set": [str, ...] | optional}
+
+    `accept_set` is the set of accepted completions for LM tasks that
+    allow multiple gold answers (e.g., a question whose answer can be
+    phrased several ways). Optional — defaults to () for LAMBADA-style
+    tasks with a single target.
+    """
+    try:
+        context = str(row["context"])
+        target = str(row["target"])
+    except (KeyError, TypeError) as e:
+        raise ValueError(
+            f"row {line_no}: expected canonical LM schema "
+            f"{{context, target}}; got error: {e}"
+        ) from e
+    accept_raw = row.get("accept_set", [])
+    if not isinstance(accept_raw, list):
+        raise ValueError(
+            f"row {line_no}: 'accept_set' must be a list if provided"
+        )
+    if not all(isinstance(a, str) for a in accept_raw):
+        raise ValueError(
+            f"row {line_no}: 'accept_set' must be a list of strings"
+        )
+    return LMRawRow(
+        context=context, target=target, accept_set=tuple(accept_raw),
+    )
+
+
+def load_task_examples(
+    bundle_dir: Path | str,
+    task_name: str,
+) -> list[MCRawRow | SchemaRawRow | LMRawRow]:
+    """Load raw rows for a CORE-22 task from a local DCLM bundle copy.
+
+    Reads `{bundle_dir}/{task_name}.jsonl` and parses each line per
+    the task's mode (per `TASK_SPECS[task_name].mode`):
+      * mode == "mc"     → MCRawRow
+      * mode == "schema" → SchemaRawRow
+      * mode == "lm"     → LMRawRow
+
+    The JSONL schema is the canonical Karpa form documented in
+    `_parse_mc_row` / `_parse_schema_row` / `_parse_lm_row`. If the
+    DCLM bundle's per-task JSONLs use different keys, the
+    downloader / mirror script (separate follow-up) is responsible for
+    re-keying into this canonical schema during the bundle-prep step.
+
+    Args:
+      bundle_dir: directory containing per-task `<task>.jsonl` files.
+      task_name: one of `DCLM_CORE_22_TASKS`.
+
+    Raises:
+      ValueError if `task_name` is unknown.
+      FileNotFoundError if `{bundle_dir}/{task_name}.jsonl` doesn't exist.
+      ValueError if any row in the JSONL fails per-mode parsing, with a
+        message naming the line number and the missing/invalid field.
+    """
+    if task_name not in TASK_SPECS:
+        raise ValueError(
+            f"unknown task {task_name!r}; not in DCLM_CORE_22_TASKS"
+        )
+    bundle_dir = Path(bundle_dir)
+    path = bundle_dir / f"{task_name}.jsonl"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"CORE-22 task file not found: {path}. The bundle download "
+            f"(URL {DCLM_EVAL_BUNDLE_URL}) must place per-task JSONLs "
+            "under the supplied bundle_dir."
+        )
+
+    spec = TASK_SPECS[task_name]
+    raw_rows = _read_jsonl(path)
+    parsed: list[MCRawRow | SchemaRawRow | LMRawRow] = []
+    for i, row in enumerate(raw_rows, start=1):
+        if spec.mode == "mc":
+            parsed.append(_parse_mc_row(row, i))
+        elif spec.mode == "schema":
+            parsed.append(_parse_schema_row(row, i))
+        elif spec.mode == "lm":
+            parsed.append(_parse_lm_row(row, i))
+        else:
+            raise ValueError(
+                f"task {task_name!r} has unsupported mode "
+                f"{spec.mode!r}; expected mc/schema/lm"
+            )
+    return parsed

--- a/tests/test_downstream_core22.py
+++ b/tests/test_downstream_core22.py
@@ -349,16 +349,140 @@ def test_to_cell_result_rejects_unknown_task():
 
 
 # ----------------------------------------------------------------------------
-# load_task_examples stub
+# load_task_examples — canonical JSONL parser
 # ----------------------------------------------------------------------------
 
 
-def test_load_task_examples_raises_not_implemented(tmp_path):
-    """The stub must raise loudly with a clear pointer to the protocol
-    the first downloader commit must follow."""
-    with pytest.raises(NotImplementedError) as exc_info:
+def _write_jsonl(path, rows):
+    """Helper: write a list of dicts as a JSONL file."""
+    import json as _json
+    path.write_text("\n".join(_json.dumps(r) for r in rows) + "\n")
+
+
+def test_load_task_examples_unknown_task_rejected(tmp_path):
+    with pytest.raises(ValueError, match=r"unknown task"):
+        load_task_examples(tmp_path, "not_a_real_task")
+
+
+def test_load_task_examples_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError, match=r"CORE-22 task file"):
         load_task_examples(tmp_path, "arc_easy")
-    msg = str(exc_info.value)
-    assert "DEFERRED.md" in msg
-    assert "B1-D2" in msg
-    assert DCLM_EVAL_BUNDLE_URL in msg
+
+
+def test_load_task_examples_mc_happy_path(tmp_path):
+    """An MC task (arc_easy) parses to MCRawRow list."""
+    _write_jsonl(tmp_path / "arc_easy.jsonl", [
+        {"id": "a1", "query": "Q1?", "choices": ["A", "B", "C", "D"], "gold": 0},
+        {"id": "a2", "query": "Q2?", "choices": ["W", "X"], "gold": 1},
+    ])
+    rows = load_task_examples(tmp_path, "arc_easy")
+    assert len(rows) == 2
+    assert all(isinstance(r, MCRawRow) for r in rows)
+    assert rows[0].query == "Q1?"
+    assert rows[0].choices == ["A", "B", "C", "D"]
+    assert rows[0].gold == 0
+    assert rows[1].gold == 1
+
+
+def test_load_task_examples_schema_happy_path(tmp_path):
+    """A schema task (winogrande) parses to SchemaRawRow list."""
+    _write_jsonl(tmp_path / "winogrande.jsonl", [
+        {"id": "w1",
+         "contexts": ["The trophy didn't fit in the brown suitcase because it",
+                      "The trophy didn't fit in the brown suitcase because it"],
+         "continuations": ["was too big", "was too small"],
+         "gold": 0},
+    ])
+    rows = load_task_examples(tmp_path, "winogrande")
+    assert len(rows) == 1
+    assert isinstance(rows[0], SchemaRawRow)
+    assert len(rows[0].contexts) == 2
+    assert rows[0].gold == 0
+
+
+def test_load_task_examples_lm_happy_path(tmp_path):
+    """An LM task (lambada_openai) parses to LMRawRow list."""
+    _write_jsonl(tmp_path / "lambada_openai.jsonl", [
+        {"id": "l1", "context": "Once upon a", "target": " time"},
+        {"id": "l2", "context": "The quick brown", "target": " fox",
+         "accept_set": [" fox", " Fox"]},
+    ])
+    rows = load_task_examples(tmp_path, "lambada_openai")
+    assert len(rows) == 2
+    assert all(isinstance(r, LMRawRow) for r in rows)
+    assert rows[0].context == "Once upon a"
+    assert rows[0].target == " time"
+    assert rows[0].accept_set == ()
+    assert rows[1].accept_set == (" fox", " Fox")
+
+
+def test_load_task_examples_skips_blank_lines(tmp_path):
+    """Blank lines in the JSONL are skipped, not parsed as bad JSON."""
+    path = tmp_path / "arc_easy.jsonl"
+    path.write_text(
+        '{"id": "a", "query": "q", "choices": ["x", "y"], "gold": 0}\n'
+        '\n'
+        '   \n'
+        '{"id": "b", "query": "q", "choices": ["x", "y"], "gold": 1}\n'
+    )
+    rows = load_task_examples(tmp_path, "arc_easy")
+    assert len(rows) == 2
+
+
+def test_load_task_examples_invalid_json_raises(tmp_path):
+    """A bad line raises with the line number."""
+    path = tmp_path / "arc_easy.jsonl"
+    path.write_text(
+        '{"id": "a", "query": "q", "choices": ["x", "y"], "gold": 0}\n'
+        '{not valid json\n'
+    )
+    with pytest.raises(ValueError, match=r":2"):
+        load_task_examples(tmp_path, "arc_easy")
+
+
+def test_load_task_examples_mc_missing_field_raises(tmp_path):
+    _write_jsonl(tmp_path / "arc_easy.jsonl", [
+        {"id": "a", "query": "q", "choices": ["x", "y"]},  # no 'gold'
+    ])
+    with pytest.raises(ValueError, match=r"canonical MC schema"):
+        load_task_examples(tmp_path, "arc_easy")
+
+
+def test_load_task_examples_mc_out_of_range_gold_raises(tmp_path):
+    _write_jsonl(tmp_path / "arc_easy.jsonl", [
+        {"id": "a", "query": "q", "choices": ["x", "y"], "gold": 5},
+    ])
+    with pytest.raises(ValueError, match=r"gold=5 out of range"):
+        load_task_examples(tmp_path, "arc_easy")
+
+
+def test_load_task_examples_mc_non_string_choice_raises(tmp_path):
+    _write_jsonl(tmp_path / "arc_easy.jsonl", [
+        {"id": "a", "query": "q", "choices": ["x", 42], "gold": 0},
+    ])
+    with pytest.raises(ValueError, match=r"list of strings"):
+        load_task_examples(tmp_path, "arc_easy")
+
+
+def test_load_task_examples_schema_length_mismatch_raises(tmp_path):
+    _write_jsonl(tmp_path / "winogrande.jsonl", [
+        {"id": "w", "contexts": ["a", "b"], "continuations": ["x"], "gold": 0},
+    ])
+    with pytest.raises(ValueError, match=r"length mismatch"):
+        load_task_examples(tmp_path, "winogrande")
+
+
+def test_load_task_examples_lm_missing_context_raises(tmp_path):
+    _write_jsonl(tmp_path / "lambada_openai.jsonl", [
+        {"id": "l", "target": " time"},  # missing 'context'
+    ])
+    with pytest.raises(ValueError, match=r"canonical LM schema"):
+        load_task_examples(tmp_path, "lambada_openai")
+
+
+def test_load_task_examples_lm_bad_accept_set_type_raises(tmp_path):
+    _write_jsonl(tmp_path / "lambada_openai.jsonl", [
+        {"id": "l", "context": "x", "target": "y", "accept_set": "not a list"},
+    ])
+    with pytest.raises(ValueError, match=r"accept_set.*list"):
+        load_task_examples(tmp_path, "lambada_openai")

--- a/tests/test_downstream_runner_cli.py
+++ b/tests/test_downstream_runner_cli.py
@@ -197,10 +197,11 @@ class TestBuildTaskLoaders:
         assert callable(loaders["arc_easy"])
 
     def test_core22_loader_calls_core22_load(self, tmp_path):
-        """The bound loader reaches core22.load_task_examples, which is
-        a stub today and raises NotImplementedError."""
+        """The bound loader reaches core22.load_task_examples, which now
+        looks for {bundle_dir}/arc_easy.jsonl. Empty bundle_dir →
+        FileNotFoundError naming the missing file."""
         loaders = _build_task_loaders(("arc_easy",), tmp_path)
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(FileNotFoundError, match=r"arc_easy.jsonl"):
             loaders["arc_easy"]()
 
     def test_private_hard_loader_calls_private_hard_load(self, tmp_path):


### PR DESCRIPTION
What this commit ships:

  1. load_task_examples(bundle_dir, task_name) — the production loader. Reads {bundle_dir}/{task_name}.jsonl, parses each line per the task's mode (TASK_SPECS[task_name].mode), and returns a list of MCRawRow / SchemaRawRow / LMRawRow ready for run_downstream_eval.

  2. _read_jsonl(path) — JSONL reader that skips blank lines and raises ValueError naming the line number on the first invalid JSON line. A downloader / mirror that produced a corrupt file fails clean rather than silently dropping examples.

  3. _parse_mc_row / _parse_schema_row / _parse_lm_row — per-mode parsers enforcing the canonical Karpa schema:
       * MC:     {"id": str, "query": str, "choices": [str, ...],
                  "gold": int}
       * Schema: {"id": str, "contexts": [str, ...],
                  "continuations": [str, ...], "gold": int}
       * LM:     {"id": str, "context": str, "target": str,
                  "accept_set": [str, ...] | optional}

     Validation errors name the row number and the missing/invalid field for fast debugging. `gold` is checked against the choices / variants length. Schema rows enforce contexts/continuations length parity. LM rows tolerate omitted `accept_set` (defaults to `()` for LAMBADA-style tasks).

What this commit does NOT ship (operational follow-up):

  * The bundle download itself. `load_task_examples` takes a pre-downloaded `bundle_dir` as input — the operator downloads `https://karpathy-public.s3.us-west-2.amazonaws.com/eval_bundle.zip` (per DCLM_EVAL_BUNDLE_URL), unzips it, optionally re-keys the per- task JSONLs into the canonical schema, and points `bundle_dir` at the resulting tree. The SHA pin (B1-D2) lands in the same operational step.

  * Re-keying from DCLM's per-task JSONL formats into the canonical Karpa schema. If the upstream bundle's MC/schema/LM tasks use different field names (e.g., `ctx`/`endings`/`label` for HellaSwag), the downloader script adapts them — keeping the loader's per-mode parsing simple.

Tests (13 new cases in test_downstream_core22.py):

  * Routing: unknown task rejected / missing file raises with the bundle URL in the message.
  * MC happy path: 2 rows parse to MCRawRow with right fields.
  * Schema happy path: contexts/continuations parsed.
  * LM happy path: context + target + optional accept_set.
  * Blank lines skipped (not parsed as malformed JSON).
  * Invalid JSON raises with line number.
  * MC errors: missing field / out-of-range gold / non-string choice.
  * Schema errors: contexts/continuations length mismatch.
  * LM errors: missing context / non-list accept_set.

Also updates the existing test_core22_loader_calls_core22_load case in test_downstream_runner_cli.py: the loader no longer raises NotImplementedError; the empty bundle_dir now raises FileNotFoundError naming the missing per-task file. Same intent (the runner CLI plumbing reaches the loader); updated assertion matches the new behaviour.

Full suite: 535/535 passing. Ruff clean on touched files.