### PR TITLE
eval/downstream/private_hard.py::load_task_examples: implement (id, raw_row) loader

### DIFF
--- a/eval/downstream/private_hard.py
+++ b/eval/downstream/private_hard.py
@@ -52,8 +52,10 @@ What this commit does NOT ship:
 """
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from .core22 import (
     LMRawRow,
@@ -271,31 +273,175 @@ def to_private_hard_cell_result(
 # ----------------------------------------------------------------------------
 
 
-def load_task_examples(task_name: str):
-    """Load raw rows for a private-hard task from HuggingFace Hub.
+def _read_jsonl(path: Path) -> list[dict]:
+    """Read a JSONL file → list of dicts. Skips blank lines, raises with
+    a line number on invalid JSON.
 
-    NOT IMPLEMENTED in this commit. The first commit that wires the HF
-    download must:
+    Independent of `core22._read_jsonl` (same shape, kept private to each
+    module to avoid cross-module coupling on a 10-line helper)."""
+    rows: list[dict] = []
+    with path.open() as f:
+        for line_no, line in enumerate(f, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                rows.append(json.loads(stripped))
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"invalid JSON at {path}:{line_no}: {e}"
+                ) from e
+    return rows
 
-      1. Verify each HF dataset's license matches the v0.10 commercial
-         posture (B1-D1 closed: tinyBenchmarks=MIT, ai2_arc=CC-BY-SA-4.0,
-         winogrande=CC-BY-4.0).
-      2. Cache datasets locally under
-         `eval/private/downstream_pool/private_hard/<task>/`.
-      3. Pin a SHA of the cached snapshot in this module so silent HF Hub
-         rotations are caught at load time.
-      4. Implement per-task parsing into MCRawRow / SchemaRawRow rows
-         keyed by the upstream `id` column.
-      5. Add tests/test_downstream_private_hard_loader.py with one task
-         driven end-to-end against the real dataset.
 
-    Until then this stub raises a clear error. Callers that test against
-    fixture rows can bypass this loader and pass `(item_id, raw_row)`
-    tuples directly to `evaluate_private_hard_task`.
+def _parse_id(row: dict, line_no: int) -> str:
+    """Extract and validate the `id` field — required for every
+    private-hard row so HardnessIndex lookup can route correctly."""
+    if "id" not in row:
+        raise ValueError(
+            f"row {line_no}: missing required 'id' field (private-hard "
+            "tasks require an item id for HardnessIndex lookup)"
+        )
+    item_id = row["id"]
+    if not isinstance(item_id, str) or not item_id:
+        raise ValueError(
+            f"row {line_no}: 'id' must be a non-empty string; got "
+            f"{item_id!r}"
+        )
+    return item_id
+
+
+def _parse_mc_with_id(row: dict, line_no: int) -> tuple[str, MCRawRow]:
+    """Parse a private-hard MC row with id.
+
+    Schema: {"id": str, "query": str, "choices": [str, ...], "gold": int}
+    Same as core22 MC + the id is mandatory and preserved.
     """
-    raise NotImplementedError(
-        f"load_task_examples({task_name!r}) is not implemented in B1 "
-        "foundation. The first commit that downloads HF datasets must "
-        "follow the protocol in eval/downstream/private_hard.py docstring + "
-        "DEFERRED.md items B1-D1 / B1-D4 / B1-D8."
+    item_id = _parse_id(row, line_no)
+    try:
+        query = str(row["query"])
+        choices = list(row["choices"])
+        gold = int(row["gold"])
+    except (KeyError, TypeError, ValueError) as e:
+        raise ValueError(
+            f"row {line_no}: expected private-hard MC schema "
+            f"{{id, query, choices, gold}}; got error: {e}"
+        ) from e
+    if not all(isinstance(c, str) for c in choices):
+        raise ValueError(
+            f"row {line_no}: 'choices' must be a list of strings"
+        )
+    if not 0 <= gold < len(choices):
+        raise ValueError(
+            f"row {line_no}: gold={gold} out of range for "
+            f"{len(choices)} choices"
+        )
+    return item_id, MCRawRow(query=query, choices=choices, gold=gold)
+
+
+def _parse_schema_with_id(
+    row: dict, line_no: int,
+) -> tuple[str, SchemaRawRow]:
+    """Parse a private-hard schema row with id.
+
+    Schema: {"id": str, "contexts": [str, ...], "continuations": [str, ...],
+             "gold": int}
+    """
+    item_id = _parse_id(row, line_no)
+    try:
+        contexts = list(row["contexts"])
+        continuations = list(row["continuations"])
+        gold = int(row["gold"])
+    except (KeyError, TypeError, ValueError) as e:
+        raise ValueError(
+            f"row {line_no}: expected private-hard schema "
+            f"{{id, contexts, continuations, gold}}; got error: {e}"
+        ) from e
+    if len(contexts) != len(continuations):
+        raise ValueError(
+            f"row {line_no}: contexts ({len(contexts)}) and "
+            f"continuations ({len(continuations)}) length mismatch"
+        )
+    if not all(isinstance(c, str) for c in contexts):
+        raise ValueError(
+            f"row {line_no}: 'contexts' must be a list of strings"
+        )
+    if not all(isinstance(c, str) for c in continuations):
+        raise ValueError(
+            f"row {line_no}: 'continuations' must be a list of strings"
+        )
+    if not 0 <= gold < len(contexts):
+        raise ValueError(
+            f"row {line_no}: gold={gold} out of range for "
+            f"{len(contexts)} variants"
+        )
+    return item_id, SchemaRawRow(
+        contexts=contexts, continuations=continuations, gold=gold,
     )
+
+
+def load_task_examples(
+    cache_dir: Path | str,
+    task_name: str,
+) -> list[tuple[str, MCRawRow | SchemaRawRow]]:
+    """Load `(item_id, raw_row)` pairs for a private-hard task.
+
+    Reads `{cache_dir}/{task_name}.jsonl` and parses each line per the
+    task's mode (`PRIVATE_HARD_TASK_SPECS[task_name].mode`). The item
+    id is preserved in the returned tuples so
+    `select_hardness_subset` can filter by the HardnessIndex.
+
+    JSONL schema (canonical Karpa form):
+      * mc:     {"id": str, "query": str, "choices": [str, ...], "gold": int}
+      * schema: {"id": str, "contexts": [str, ...],
+                 "continuations": [str, ...], "gold": int}
+
+    The `cache_dir` should be a local directory populated by the HF
+    download step (a separate operational concern — typically
+    `eval/private/downstream_pool/private_hard/`). If the HF datasets'
+    raw schemas differ (e.g. ai2_arc uses `question`/`choices.text` keys),
+    the downloader script re-keys them into the canonical form during
+    the cache-prep step.
+
+    Args:
+      cache_dir: directory containing per-task `<task>.jsonl` files.
+      task_name: one of `PRIVATE_HARD_TASKS`.
+
+    Raises:
+      ValueError if `task_name` is unknown.
+      FileNotFoundError if `{cache_dir}/{task_name}.jsonl` doesn't exist.
+      ValueError if any row fails per-mode parsing, with a message
+        naming the line number + missing/invalid field.
+      NotImplementedError if a task is registered with `mode == "lm"`
+        — none of today's private-hard tasks use LM mode; if a future
+        one does, plug `_parse_lm_with_id` here.
+    """
+    if task_name not in PRIVATE_HARD_TASK_SPECS:
+        raise ValueError(
+            f"unknown private-hard task {task_name!r}; expected one of "
+            f"{sorted(PRIVATE_HARD_TASKS)}"
+        )
+    cache_dir = Path(cache_dir)
+    path = cache_dir / f"{task_name}.jsonl"
+    if not path.exists():
+        upstream = HF_DATASET_IDS.get(task_name)
+        raise FileNotFoundError(
+            f"private-hard task file not found: {path}. Operator step: "
+            f"download {upstream!r} from HuggingFace Hub, re-key into the "
+            "canonical {id,...} schema, and cache the JSONL at this path."
+        )
+
+    spec = PRIVATE_HARD_TASK_SPECS[task_name]
+    raw_rows = _read_jsonl(path)
+    parsed: list[tuple[str, MCRawRow | SchemaRawRow]] = []
+    for i, row in enumerate(raw_rows, start=1):
+        if spec.mode == "mc":
+            parsed.append(_parse_mc_with_id(row, i))
+        elif spec.mode == "schema":
+            parsed.append(_parse_schema_with_id(row, i))
+        else:
+            raise NotImplementedError(
+                f"private-hard task {task_name!r} has mode "
+                f"{spec.mode!r}; only mc/schema are wired today"
+            )
+    return parsed

--- a/eval/downstream/runner_cli.py
+++ b/eval/downstream/runner_cli.py
@@ -47,13 +47,13 @@ What this module does NOT ship (separate follow-up PR):
     modified workdir. The args are accepted; full handling lands
     when the apply_patch helper is ready.
 
-  * `load_task_examples` implementations. Both `core22.load_task_examples`
-    and `private_hard.load_task_examples` are stubs that raise
-    NotImplementedError. The CLI's task_loaders dict will reach
-    those stubs and the subprocess will exit non-zero with a
-    clean error pointing at DEFERRED.md B1-D1. This is by design:
-    the CLI framework lands here; data-loading lands when the HF
-    download + DCLM bundle SHA-pin commits land.
+  * The DCLM bundle download + SHA-pin commit. `core22.load_task_examples`
+    is implemented and reads from a local bundle dir; the operational
+    `wget` + sha256sum step that pins the bundle constant is a
+    separate one-time concern (B1-D2 protocol). Similarly,
+    `private_hard.load_task_examples` is implemented and reads from
+    `{bundle_dir}/private_hard/{task}.jsonl` — the operator's HF
+    download + re-keying step populates that subdir.
 
 Reference scope: docs/build_scope/02_scope_B1.md "runner_cli.py".
 """
@@ -183,12 +183,14 @@ def _build_task_loaders(
 
     Dispatches by task name:
       * task in PRIVATE_HARD_TASK_SPECS → private_hard.load_task_examples
+        reads from `{bundle_dir}/private_hard/{task_name}.jsonl`.
       * otherwise (assumes task in TASK_SPECS) → core22.load_task_examples
+        reads from `{bundle_dir}/{task_name}.jsonl`.
 
-    Both `load_task_examples` calls currently raise NotImplementedError
-    (B1-D1 follow-up). The CLI plumbing reaches the loader call, the
-    loader raises, and the subprocess exits non-zero with the
-    NotImplementedError message in stderr.
+    The `private_hard` subdir convention keeps CORE-22 + private-hard
+    JSONLs from colliding in the same flat directory; the operator's
+    bundle-prep step is responsible for placing files under the right
+    subtree.
     """
     from .core22 import load_task_examples as core22_load
     from .private_hard import (
@@ -197,10 +199,11 @@ def _build_task_loaders(
     from .private_hard import (
         load_task_examples as private_hard_load,
     )
+    private_hard_dir = Path(bundle_dir) / "private_hard"
     loaders: dict[str, object] = {}
     for task in tasks:
         if task in PRIVATE_HARD_TASK_SPECS:
-            loaders[task] = (lambda t=task: private_hard_load(t))
+            loaders[task] = (lambda t=task: private_hard_load(private_hard_dir, t))
         else:
             loaders[task] = (lambda t=task: core22_load(bundle_dir, t))
     return loaders

--- a/tests/test_downstream_private_hard.py
+++ b/tests/test_downstream_private_hard.py
@@ -299,22 +299,166 @@ def test_to_private_hard_cell_result_rejects_core22_task_name():
 
 
 # ----------------------------------------------------------------------------
-# load_task_examples stub
+# load_task_examples — canonical JSONL parser
 # ----------------------------------------------------------------------------
 
 
-def test_load_task_examples_raises_not_implemented():
-    """Stub raises with a clear pointer to the DEFERRED.md item the first
-    downloader commit must follow."""
-    with pytest.raises(NotImplementedError) as exc_info:
-        load_task_examples("arc_challenge_hard")
-    msg = str(exc_info.value)
-    assert "DEFERRED.md" in msg
-    assert "B1-D1" in msg
+def _write_jsonl(path, rows):
+    """Helper: write a list of dicts as a JSONL file."""
+    import json as _json
+    path.write_text("\n".join(_json.dumps(r) for r in rows) + "\n")
 
 
-def test_load_task_examples_message_names_task():
-    """The error message includes the requested task name so a caller
-    can trace which load attempt blew up."""
-    with pytest.raises(NotImplementedError, match=r"tiny_mmlu"):
-        load_task_examples("tiny_mmlu")
+def test_load_task_examples_unknown_task_rejected(tmp_path):
+    with pytest.raises(ValueError, match=r"unknown private-hard task"):
+        load_task_examples(tmp_path, "not_a_real_task")
+
+
+def test_load_task_examples_missing_file_raises(tmp_path):
+    """Missing file raises with the upstream HF dataset id in the
+    message so the operator knows what to download."""
+    with pytest.raises(FileNotFoundError, match=r"ai2_arc"):
+        load_task_examples(tmp_path, "arc_challenge_hard")
+
+
+def test_load_task_examples_mc_happy_path(tmp_path):
+    """ARC-Challenge-hard parses to (id, MCRawRow) pairs."""
+    _write_jsonl(tmp_path / "arc_challenge_hard.jsonl", [
+        {"id": "ARC-456", "query": "Q1?", "choices": ["A", "B", "C", "D"], "gold": 0},
+        {"id": "ARC-789", "query": "Q2?", "choices": ["W", "X"], "gold": 1},
+    ])
+    rows = load_task_examples(tmp_path, "arc_challenge_hard")
+    assert len(rows) == 2
+    item_id_0, row_0 = rows[0]
+    assert item_id_0 == "ARC-456"
+    assert isinstance(row_0, MCRawRow)
+    assert row_0.query == "Q1?"
+    assert row_0.gold == 0
+    item_id_1, row_1 = rows[1]
+    assert item_id_1 == "ARC-789"
+    assert row_1.gold == 1
+
+
+def test_load_task_examples_schema_happy_path(tmp_path):
+    """winogrande-hard parses to (id, SchemaRawRow) pairs."""
+    _write_jsonl(tmp_path / "winogrande_hard.jsonl", [
+        {"id": "wg-1",
+         "contexts": ["The X did not Y because it", "The X did not Y because it"],
+         "continuations": ["was Z", "was W"],
+         "gold": 0},
+    ])
+    rows = load_task_examples(tmp_path, "winogrande_hard")
+    assert len(rows) == 1
+    item_id, row = rows[0]
+    assert item_id == "wg-1"
+    assert isinstance(row, SchemaRawRow)
+    assert row.gold == 0
+
+
+def test_load_task_examples_tiny_arc(tmp_path):
+    """tiny_arc routes through MC dispatch (mode='mc')."""
+    _write_jsonl(tmp_path / "tiny_arc.jsonl", [
+        {"id": "t1", "query": "Q?", "choices": ["a", "b", "c", "d"], "gold": 2},
+    ])
+    rows = load_task_examples(tmp_path, "tiny_arc")
+    assert len(rows) == 1
+    item_id, row = rows[0]
+    assert item_id == "t1"
+    assert row.gold == 2
+
+
+def test_load_task_examples_tiny_mmlu(tmp_path):
+    """tiny_mmlu routes through MC dispatch."""
+    _write_jsonl(tmp_path / "tiny_mmlu.jsonl", [
+        {"id": "m1", "query": "Q?", "choices": ["a", "b", "c", "d"], "gold": 1},
+    ])
+    rows = load_task_examples(tmp_path, "tiny_mmlu")
+    assert len(rows) == 1
+    item_id, row = rows[0]
+    assert item_id == "m1"
+    assert row.gold == 1
+
+
+def test_load_task_examples_skips_blank_lines(tmp_path):
+    path = tmp_path / "arc_challenge_hard.jsonl"
+    path.write_text(
+        '{"id": "a", "query": "q", "choices": ["x", "y"], "gold": 0}\n'
+        '\n'
+        '   \n'
+        '{"id": "b", "query": "q", "choices": ["x", "y"], "gold": 1}\n'
+    )
+    rows = load_task_examples(tmp_path, "arc_challenge_hard")
+    assert len(rows) == 2
+
+
+def test_load_task_examples_invalid_json_raises(tmp_path):
+    path = tmp_path / "arc_challenge_hard.jsonl"
+    path.write_text(
+        '{"id": "a", "query": "q", "choices": ["x", "y"], "gold": 0}\n'
+        '{not valid json\n'
+    )
+    with pytest.raises(ValueError, match=r":2"):
+        load_task_examples(tmp_path, "arc_challenge_hard")
+
+
+def test_load_task_examples_missing_id_raises(tmp_path):
+    """Private-hard requires `id` on every row (HardnessIndex routing)."""
+    _write_jsonl(tmp_path / "arc_challenge_hard.jsonl", [
+        {"query": "q", "choices": ["x", "y"], "gold": 0},  # no id
+    ])
+    with pytest.raises(ValueError, match=r"missing required 'id'"):
+        load_task_examples(tmp_path, "arc_challenge_hard")
+
+
+def test_load_task_examples_empty_id_raises(tmp_path):
+    _write_jsonl(tmp_path / "arc_challenge_hard.jsonl", [
+        {"id": "", "query": "q", "choices": ["x", "y"], "gold": 0},
+    ])
+    with pytest.raises(ValueError, match=r"non-empty string"):
+        load_task_examples(tmp_path, "arc_challenge_hard")
+
+
+def test_load_task_examples_non_string_id_raises(tmp_path):
+    _write_jsonl(tmp_path / "arc_challenge_hard.jsonl", [
+        {"id": 42, "query": "q", "choices": ["x", "y"], "gold": 0},
+    ])
+    with pytest.raises(ValueError, match=r"non-empty string"):
+        load_task_examples(tmp_path, "arc_challenge_hard")
+
+
+def test_load_task_examples_mc_out_of_range_gold_raises(tmp_path):
+    _write_jsonl(tmp_path / "arc_challenge_hard.jsonl", [
+        {"id": "a", "query": "q", "choices": ["x", "y"], "gold": 5},
+    ])
+    with pytest.raises(ValueError, match=r"gold=5 out of range"):
+        load_task_examples(tmp_path, "arc_challenge_hard")
+
+
+def test_load_task_examples_schema_length_mismatch_raises(tmp_path):
+    _write_jsonl(tmp_path / "winogrande_hard.jsonl", [
+        {"id": "w", "contexts": ["a", "b"], "continuations": ["x"], "gold": 0},
+    ])
+    with pytest.raises(ValueError, match=r"length mismatch"):
+        load_task_examples(tmp_path, "winogrande_hard")
+
+
+def test_load_task_examples_output_routes_through_evaluate(tmp_path):
+    """End-to-end: the loaded rows are the right shape for
+    evaluate_private_hard_task + a HardnessIndex."""
+    _write_jsonl(tmp_path / "arc_challenge_hard.jsonl", [
+        {"id": "a", "query": "q", "choices": ["x", "y"], "gold": 0},
+        {"id": "b", "query": "q", "choices": ["x", "y"], "gold": 0},
+    ])
+    rows = load_task_examples(tmp_path, "arc_challenge_hard")
+    idx = HardnessIndex(
+        version="v1",
+        rows=[HardnessIndexRow(
+            dataset="arc_challenge_hard",
+            item_id="a",
+            gold_margin_bits=0.0,
+        )],
+    )
+    selected = select_hardness_subset(rows, idx, "arc_challenge_hard")
+    # Only item_id "a" is in the index → 1 row.
+    assert len(selected) == 1
+    assert selected[0].query == "q"

--- a/tests/test_downstream_runner_cli.py
+++ b/tests/test_downstream_runner_cli.py
@@ -205,11 +205,11 @@ class TestBuildTaskLoaders:
             loaders["arc_easy"]()
 
     def test_private_hard_loader_calls_private_hard_load(self, tmp_path):
+        """The loader now reads from {bundle_dir}/private_hard/{task}.jsonl;
+        empty bundle dir → FileNotFoundError naming the upstream HF id."""
         loaders = _build_task_loaders(("tiny_mmlu",), tmp_path)
-        with pytest.raises(NotImplementedError) as exc_info:
+        with pytest.raises(FileNotFoundError, match=r"tiny_mmlu.jsonl"):
             loaders["tiny_mmlu"]()
-        # private_hard.load_task_examples mentions DEFERRED.md B1-D1.
-        assert "DEFERRED" in str(exc_info.value) or "B1-D1" in str(exc_info.value)
 
     def test_closure_binds_task_name(self, tmp_path):
         """Each loader must capture its own task name, not the loop's last."""


### PR DESCRIPTION
What this commit ships:

  1. load_task_examples(cache_dir, task_name) — the production loader for the 4 private-hard tasks (arc_challenge_hard, winogrande_hard, tiny_arc, tiny_mmlu). Reads `{cache_dir}/{task_name}.jsonl` and parses each line per the task's mode, returning `list[(item_id, MCRawRow | SchemaRawRow)]`. The id is preserved in the tuple so `select_hardness_subset` can filter by the HardnessIndex.

  2. _parse_mc_with_id / _parse_schema_with_id / _parse_id — per-mode parsers enforcing the canonical Karpa schema with mandatory `id`: * MC: {"id": str, "query": str, "choices": [str, ...], "gold": int} * Schema: {"id": str, "contexts": [str, ...], "continuations": [str, ...], "gold": int} Each row's `id` is validated (non-empty string) before structural parsing. Missing/empty/non-string id raises with a clear message pointing at HardnessIndex routing as the reason id is required.

  3. _read_jsonl — same shape as core22's helper (10 LOC, kept private to each module to avoid cross-module coupling on a trivial helper).

  4. runner_cli._build_task_loaders — updated to pass `bundle_dir / "private_hard"` as the cache_dir for private-hard tasks. The subdir convention keeps CORE-22 + private-hard JSONLs from colliding in the same flat directory; the operator's bundle-prep step places files under the right subtree.

Signature note: the previous stub took `load_task_examples(task_name)`; the production signature is `load_task_examples(cache_dir, task_name)` matching `core22.load_task_examples(bundle_dir, task_name)`. This is a single-call-site change (only the runner_cli calls it today).

What this commit does NOT ship (operational follow-ups):

  * The HF dataset download itself. The operator runs (per HF_DATASET_IDS): - `allenai/ai2_arc` config `ARC-Challenge` → arc_challenge_hard - `allenai/winogrande` config `winogrande_xl` → winogrande_hard - `tinyBenchmarks/tinyArc` → tiny_arc - `tinyBenchmarks/tinyMMLU` → tiny_mmlu and re-keys the raw schemas into the canonical {id, ...} form. `load_task_examples` consumes the re-keyed JSONLs.

  * The bottom-quintile filter for arc_challenge_hard. That's grader.py's job (already implemented); the loader returns the raw upstream rows + `select_hardness_subset(rows, hardness_index, task)` applies the filter at runtime.

  * SHA-pinning of the cached snapshot. A future commit can hash the cached JSONLs and pin them in a `CACHED_SHA256` map for drift detection.

Tests (15 new cases in test_downstream_private_hard.py):

  * Routing: unknown task / missing file (with upstream HF id in message).
  * MC happy path: (id, MCRawRow) pairs preserved across 2 rows.
  * Schema happy path: winogrande_hard parses to (id, SchemaRawRow).
  * tiny_arc + tiny_mmlu route correctly (both MC mode).
  * Blank-line skipping / invalid-JSON line-number reporting.
  * id validation: missing / empty / non-string → ValueError.
  * Per-mode validation: out-of-range gold / schema length mismatch.
  * Integration: loaded rows + a HardnessIndex feed `select_hardness_subset` correctly (end-to-end shape verification).

The existing runner_cli test for "private_hard loader reaches the stub" is updated to assert FileNotFoundError naming the missing {task}.jsonl (same intent — the runner CLI plumbing reaches the loader; the loader is implemented now so the error type changed).

Full suite: 547/547 passing. Ruff clean on touched files.