### PR TITLE
C1-LITE: parent_king_attestation_hash lineage + ladder accept + apply_patch

### DIFF
--- a/chain_layer/bittensor_chain.py
+++ b/chain_layer/bittensor_chain.py
@@ -279,6 +279,8 @@ class BittensorChain(ChainInterface):
             crowned_at=d.get("crowned_at", 0.0),
             proof_dir=d.get("proof_dir"),
             previous_king=d.get("previous_king"),
+            king_attestation_hash=d.get("king_attestation_hash", ""),
+            parent_king_attestation_hash=d.get("parent_king_attestation_hash"),
         )
 
     def set_king(self, king: KingRecord) -> None:
@@ -302,6 +304,12 @@ class BittensorChain(ChainInterface):
         }
         if king.previous_king:
             d["previous_king"] = king.previous_king
+        # v0.11-lite lineage fields. Omitted when empty/None for legacy
+        # byte-equivalent serialization.
+        if king.king_attestation_hash:
+            d["king_attestation_hash"] = king.king_attestation_hash
+        if king.parent_king_attestation_hash is not None:
+            d["parent_king_attestation_hash"] = king.parent_king_attestation_hash
         (self.chain_dir / "king.json").write_text(json.dumps(d, indent=2, sort_keys=True))
 
     # ---- Audit / blacklist ----

--- a/chain_layer/interface.py
+++ b/chain_layer/interface.py
@@ -26,6 +26,22 @@ class HandshakeRecord:
 
 @dataclass
 class KingRecord:
+    """One king's record on the chain.
+
+    v0.11-lite lineage fields:
+      * `king_attestation_hash` — the king's OWN attestation hash (64-char
+        lowercase hex, sha256 of canonical attestation payload). The
+        primary cryptographic identifier for lineage chaining. Defaults
+        to "" for legacy / pre-v0.11 records.
+      * `parent_king_attestation_hash` — the prior king's attestation
+        hash that this king built on top of. None at genesis. Replaces
+        the v0.10 nested `previous_king` dict with a flat 64-char hex
+        pointer that's cheap to verify and chain-walk.
+
+    `previous_king` is retained for v0.10 byte-equivalent legacy
+    serialization but is NOT consulted by v0.11 lineage verification.
+    """
+
     miner_hotkey: str
     bundle_hash: str
     val_bpb: float
@@ -34,6 +50,8 @@ class KingRecord:
     crowned_at: float
     proof_dir: Optional[str] = None
     previous_king: Optional[dict] = None
+    king_attestation_hash: str = ""
+    parent_king_attestation_hash: Optional[str] = None
 
 
 class ChainInterface(ABC):

--- a/chain_layer/local.py
+++ b/chain_layer/local.py
@@ -85,6 +85,8 @@ class LocalChain(ChainInterface):
             crowned_at=d.get("crowned_at", 0.0),
             proof_dir=d.get("proof_dir"),
             previous_king=d.get("previous_king"),
+            king_attestation_hash=d.get("king_attestation_hash", ""),
+            parent_king_attestation_hash=d.get("parent_king_attestation_hash"),
         )
 
     def set_king(self, king: KingRecord) -> None:
@@ -99,6 +101,12 @@ class LocalChain(ChainInterface):
         }
         if king.previous_king:
             d["previous_king"] = king.previous_king
+        # v0.11-lite lineage fields. Omitted from JSON when empty/None to
+        # keep legacy king.json byte-equivalent for pre-v0.11 callers.
+        if king.king_attestation_hash:
+            d["king_attestation_hash"] = king.king_attestation_hash
+        if king.parent_king_attestation_hash is not None:
+            d["parent_king_attestation_hash"] = king.parent_king_attestation_hash
         (self.chain_dir / "king.json").write_text(json.dumps(d, indent=2, sort_keys=True))
 
     def append_event(self, event: dict) -> None:

--- a/eval/downstream/runner_cli.py
+++ b/eval/downstream/runner_cli.py
@@ -61,7 +61,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import torch
@@ -216,6 +219,47 @@ def _build_tokenize_fn():
     return lambda text: enc.encode(text)
 
 
+def _apply_patch_to_workdir(patch_path: Path, karpa_root: Path) -> Path:
+    """Copy `karpa_root` to a tmp workdir + apply `patch_path` via `patch -p1`.
+
+    Returns the path of the patched workdir. The caller adds it to
+    `sys.path` so `import model` resolves to the PATCHED model package.
+
+    Empty patches are tolerated (no-op canonical baseline). Patch failures
+    raise RuntimeError with the patch tool's stdout+stderr; partial
+    application is not allowed (`--no-backup-if-mismatch`).
+
+    Closes B1-D13 in full.
+    """
+    karpa_root = karpa_root.resolve()
+    patch_path = patch_path.resolve()
+    if not karpa_root.exists():
+        raise FileNotFoundError(f"karpa_root not found: {karpa_root}")
+    if not patch_path.exists():
+        raise FileNotFoundError(f"patch not found: {patch_path}")
+    workdir = Path(tempfile.mkdtemp(prefix="karpa_patched_"))
+    # Copy the karpa root into the workdir. We use a child dir so
+    # `workdir` itself is a clean container and can be cleaned up
+    # whole-tree on completion.
+    target = workdir / "karpa_root"
+    shutil.copytree(karpa_root, target, symlinks=True)
+    if patch_path.stat().st_size == 0:
+        # Empty patch == canonical baseline. Nothing to do.
+        return target
+    result = subprocess.run(
+        ["patch", "-p1", "-i", str(patch_path), "--no-backup-if-mismatch"],
+        cwd=target,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"patch failed (rc={result.returncode}):\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return target
+
+
 def main(argv: list[str] | None = None) -> int:
     """Subprocess entrypoint. Returns the process exit code.
 
@@ -234,16 +278,21 @@ def main(argv: list[str] | None = None) -> int:
     """
     args = _build_parser().parse_args(argv)
 
-    if args.patch is not None:
-        raise NotImplementedError(
-            "Structural-patch application is deferred to the apply_patch "
-            "follow-up PR per DEFERRED.md B1-D13. The --patch + --karpa-root "
-            "args are accepted at the CLI surface so the contract is stable; "
-            "full integration is a separate deliverable. Submissions without "
-            "a structural patch should not pass --patch."
-        )
-
     config = EvalConfig.from_dict(json.loads(args.config.read_text()))
+
+    # Structural-patch handling (closes B1-D13): if --patch is supplied, apply
+    # it to a tmp copy of --karpa-root and import the model package from the
+    # patched workdir. Without --patch, _import_karpa_model uses the karpa
+    # root as-is (sys.path insert + `from model import ...`).
+    if args.patch is not None:
+        if args.karpa_root is None:
+            raise ValueError(
+                "--patch requires --karpa-root so the patched recipe tree "
+                "has a base to patch against"
+            )
+        patched_workdir = _apply_patch_to_workdir(args.patch, args.karpa_root)
+        # Re-route the model import to the patched workdir.
+        sys.path.insert(0, str(patched_workdir))
 
     KarpaBase, KarpaConfig = _import_karpa_model(args.karpa_root)
     ckpt_config, state_dict = _load_checkpoint(args.checkpoint)

--- a/restricted_files.yaml
+++ b/restricted_files.yaml
@@ -31,6 +31,12 @@ restricted_paths:
   # in case a miner's patch tries to include it.
   - "validator/**"
 
+  # v0.11-lite lineage state (C1-LITE) — the per-validator state file +
+  # parent-CSDP-reproduction cache directory. Miner-side patches that touch
+  # these would let a miner forge cached parent-CSDP payloads for free.
+  - "validator/state/**"
+  - "validator/cache/**"
+
   # Proof-test runner — same reasoning.
   - "proof/**"
 

--- a/tests/test_downstream_runner_cli.py
+++ b/tests/test_downstream_runner_cli.py
@@ -229,10 +229,13 @@ class TestBuildTaskLoaders:
 
 
 class TestMainPatchHandling:
-    def test_patch_arg_raises_not_implemented(self, tmp_path):
+    def test_patch_with_missing_files_raises_filenotfound(self, tmp_path):
+        """C1-LITE: --patch is now fully wired. Bogus paths surface as
+        FileNotFoundError from _apply_patch_to_workdir, NOT
+        NotImplementedError."""
         cfg_path = tmp_path / "cfg.json"
         cfg_path.write_text(json.dumps({"tasks": ["arc_easy"]}))
-        with pytest.raises(NotImplementedError) as exc_info:
+        with pytest.raises(FileNotFoundError):
             main([
                 "--checkpoint", "x",
                 "--config", str(cfg_path),
@@ -243,9 +246,6 @@ class TestMainPatchHandling:
                 "--patch", "/tmp/p.patch",
                 "--karpa-root", "/tmp/root",
             ])
-        msg = str(exc_info.value)
-        assert "Structural-patch" in msg or "structural-patch" in msg.lower()
-        assert "B1-D13" in msg
 
     def test_no_patch_passes_through(self, tmp_path):
         """Without --patch, main() proceeds past the gate (fails later for

--- a/tests/test_lineage_parent_attestation.py
+++ b/tests/test_lineage_parent_attestation.py
@@ -1,0 +1,364 @@
+"""C1-LITE lineage primitive tests.
+
+Covers:
+  * compute_king_attestation_hash determinism + canonical form +
+    quorum-sig stripping
+  * is_valid_attestation_hash + case-sensitivity
+  * ParentCsdpCache round-trip via to_dict/from_dict
+  * verify_parent_lineage: genesis / missing cache / hash mismatch /
+    bad format / unknown parent / age gate / signature structure /
+    happy path
+  * KingRecord serialization preserves the new lineage fields
+    (LocalChain backend)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from chain_layer.interface import KingRecord
+from chain_layer.local import LocalChain
+from validator.lineage import (
+    ATTESTATION_HASH_LEN,
+    DEFAULT_CACHE_AGE_THRESHOLD_DAYS,
+    ParentCsdpCache,
+    compute_king_attestation_hash,
+    is_valid_attestation_hash,
+    verify_parent_lineage,
+)
+
+# ============================================================================
+# compute_king_attestation_hash
+# ============================================================================
+
+
+def test_attestation_hash_deterministic():
+    p = {"miner_hotkey": "5F6W...", "csdp": {"s3": 0.7}, "branch_id": "main"}
+    assert compute_king_attestation_hash(p) == compute_king_attestation_hash(p)
+
+
+def test_attestation_hash_canonical_key_order():
+    """Key order in input dict must not affect the hash."""
+    a = {"a": 1, "b": 2, "c": 3}
+    b = {"c": 3, "b": 2, "a": 1}
+    assert compute_king_attestation_hash(a) == compute_king_attestation_hash(b)
+
+
+def test_attestation_hash_strips_quorum_sig():
+    """Adding/removing validator_quorum_sig must not affect the hash —
+    signatures are appended AFTER hashing."""
+    base = {"king_attestation_hash": None, "branch_id": "main", "csdp": {"s3": 0.6}}
+    with_sig = dict(base)
+    with_sig["validator_quorum_sig"] = {"signers": ["v1", "v2"], "signatures": ["a" * 128]}
+    assert compute_king_attestation_hash(base) == compute_king_attestation_hash(with_sig)
+
+
+def test_attestation_hash_changes_with_content():
+    a = {"miner_hotkey": "X", "csdp": {"s3": 0.6}}
+    b = {"miner_hotkey": "X", "csdp": {"s3": 0.7}}
+    assert compute_king_attestation_hash(a) != compute_king_attestation_hash(b)
+
+
+def test_attestation_hash_format():
+    h = compute_king_attestation_hash({"x": 1})
+    assert len(h) == ATTESTATION_HASH_LEN
+    assert h == h.lower()
+    int(h, 16)  # valid hex
+
+
+# ============================================================================
+# is_valid_attestation_hash
+# ============================================================================
+
+
+def test_is_valid_accepts_real_hash():
+    assert is_valid_attestation_hash(compute_king_attestation_hash({"x": 1}))
+
+
+def test_is_valid_rejects_uppercase():
+    h = compute_king_attestation_hash({"x": 1}).upper()
+    assert not is_valid_attestation_hash(h)
+
+
+def test_is_valid_rejects_wrong_length():
+    assert not is_valid_attestation_hash("a" * 63)
+    assert not is_valid_attestation_hash("a" * 65)
+
+
+def test_is_valid_rejects_non_hex():
+    assert not is_valid_attestation_hash("z" * 64)
+
+
+def test_is_valid_rejects_non_string():
+    assert not is_valid_attestation_hash(12345)
+    assert not is_valid_attestation_hash(None)
+    assert not is_valid_attestation_hash(b"a" * 64)
+
+
+# ============================================================================
+# ParentCsdpCache round-trip
+# ============================================================================
+
+
+def _sample_cache_dict(parent_hash: str = "a" * 64) -> dict:
+    return {
+        "parent_king_attestation_hash": parent_hash,
+        "csdp_summary": {"s1_overall": 0.4, "s2_overall": 0.55, "s3_overall": 0.7},
+        "streams_root_hash_at_evaluation": "deadbeef" * 8,
+        "cached_at_iso": "2026-06-12T00:00:00Z",
+        "cached_at_block": 1024,
+        "quorum_signatures": [
+            {"signer": "validator_1", "sig": "11" * 32},
+            {"signer": "validator_2", "sig": "22" * 32},
+        ],
+    }
+
+
+def test_parent_csdp_cache_round_trip():
+    d = _sample_cache_dict()
+    cache = ParentCsdpCache.from_dict(d)
+    assert cache.to_dict() == d
+
+
+def test_parent_csdp_cache_missing_field_raises():
+    d = _sample_cache_dict()
+    del d["streams_root_hash_at_evaluation"]
+    with pytest.raises(KeyError):
+        ParentCsdpCache.from_dict(d)
+
+
+def test_parent_csdp_cache_quorum_sigs_default_empty():
+    d = _sample_cache_dict()
+    del d["quorum_signatures"]
+    cache = ParentCsdpCache.from_dict(d)
+    assert cache.quorum_signatures == []
+
+
+# ============================================================================
+# verify_parent_lineage
+# ============================================================================
+
+
+@pytest.fixture
+def chain_with_king(tmp_path):
+    """LocalChain seeded with one crowned king."""
+    chain = LocalChain(tmp_path / "chain")
+    parent_hash = "a" * 64
+    chain.append_event({
+        "type": "king_crowned",
+        "king_attestation_hash": parent_hash,
+        "miner_hotkey": "5F_parent",
+        "branch_id": "main",
+    })
+    return chain, parent_hash
+
+
+def test_verify_lineage_genesis_ok(tmp_path):
+    chain = LocalChain(tmp_path / "chain")
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash=None,
+        parent_csdp_cache=None,
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+    )
+    assert ok and reason == "genesis_ok"
+
+
+def test_verify_lineage_genesis_with_cache_rejected(tmp_path):
+    """A cache without a parent hash is suspicious — reject."""
+    chain = LocalChain(tmp_path / "chain")
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash=None,
+        parent_csdp_cache=ParentCsdpCache.from_dict(_sample_cache_dict()),
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+    )
+    assert not ok and reason == "unexpected_parent_cache_at_genesis"
+
+
+def test_verify_lineage_missing_cache(chain_with_king):
+    chain, parent_hash = chain_with_king
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash=parent_hash,
+        parent_csdp_cache=None,
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+    )
+    assert not ok and reason == "missing_parent_cache"
+
+
+def test_verify_lineage_bad_parent_hash_format(chain_with_king):
+    chain, _ = chain_with_king
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash="not_a_real_hash",
+        parent_csdp_cache=ParentCsdpCache.from_dict(_sample_cache_dict()),
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+    )
+    assert not ok and reason == "bad_parent_hash_format"
+
+
+def test_verify_lineage_hash_mismatch(chain_with_king):
+    chain, parent_hash = chain_with_king
+    cache = ParentCsdpCache.from_dict(_sample_cache_dict(parent_hash="b" * 64))
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash=parent_hash,
+        parent_csdp_cache=cache,
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+    )
+    assert not ok and reason == "parent_hash_mismatch"
+
+
+def test_verify_lineage_parent_not_on_chain(tmp_path):
+    chain = LocalChain(tmp_path / "chain")  # empty chain
+    parent_hash = "c" * 64
+    cache = ParentCsdpCache.from_dict(_sample_cache_dict(parent_hash=parent_hash))
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash=parent_hash,
+        parent_csdp_cache=cache,
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+    )
+    assert not ok and reason == "parent_not_on_chain"
+
+
+def test_verify_lineage_cache_in_future(chain_with_king):
+    chain, parent_hash = chain_with_king
+    cache_dict = _sample_cache_dict(parent_hash=parent_hash)
+    cache_dict["cached_at_iso"] = "2027-01-01T00:00:00Z"
+    cache = ParentCsdpCache.from_dict(cache_dict)
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash=parent_hash,
+        parent_csdp_cache=cache,
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+    )
+    assert not ok and reason == "cache_in_future"
+
+
+def test_verify_lineage_cache_too_old(chain_with_king):
+    chain, parent_hash = chain_with_king
+    cache_dict = _sample_cache_dict(parent_hash=parent_hash)
+    cache_dict["cached_at_iso"] = "2026-01-01T00:00:00Z"
+    cache = ParentCsdpCache.from_dict(cache_dict)
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash=parent_hash,
+        parent_csdp_cache=cache,
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+        cache_age_threshold_days=DEFAULT_CACHE_AGE_THRESHOLD_DAYS,
+    )
+    assert not ok and reason == "cache_too_old"
+
+
+def test_verify_lineage_no_quorum_signatures(chain_with_king):
+    chain, parent_hash = chain_with_king
+    cache_dict = _sample_cache_dict(parent_hash=parent_hash)
+    cache_dict["quorum_signatures"] = []
+    cache = ParentCsdpCache.from_dict(cache_dict)
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash=parent_hash,
+        parent_csdp_cache=cache,
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+    )
+    assert not ok and reason == "no_quorum_signatures"
+
+
+def test_verify_lineage_bad_signature_structure(chain_with_king):
+    chain, parent_hash = chain_with_king
+    cache_dict = _sample_cache_dict(parent_hash=parent_hash)
+    cache_dict["quorum_signatures"] = [{"signer": "v1"}]  # no sig field
+    cache = ParentCsdpCache.from_dict(cache_dict)
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash=parent_hash,
+        parent_csdp_cache=cache,
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+    )
+    assert not ok and reason.startswith("signature_entry_0_bad_sig")
+
+
+def test_verify_lineage_happy_path(chain_with_king):
+    chain, parent_hash = chain_with_king
+    cache = ParentCsdpCache.from_dict(_sample_cache_dict(parent_hash=parent_hash))
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash=parent_hash,
+        parent_csdp_cache=cache,
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+    )
+    assert ok, f"expected genesis_ok or accept; got reason={reason!r}"
+
+
+def test_verify_lineage_fallback_to_get_king(tmp_path):
+    """A parent that's the current king (no event log entry) is also accepted."""
+    chain = LocalChain(tmp_path / "chain")
+    parent_hash = "d" * 64
+    chain.set_king(KingRecord(
+        miner_hotkey="5F_parent",
+        bundle_hash="bh_parent",
+        val_bpb=1.0,
+        benchmark_accuracy=0.4,
+        compute_cost=0.0,
+        crowned_at=0.0,
+        king_attestation_hash=parent_hash,
+        parent_king_attestation_hash=None,
+    ))
+    cache = ParentCsdpCache.from_dict(_sample_cache_dict(parent_hash=parent_hash))
+    ok, _ = verify_parent_lineage(
+        parent_attestation_hash=parent_hash,
+        parent_csdp_cache=cache,
+        chain=chain,
+        now_iso="2026-06-12T00:00:00Z",
+    )
+    assert ok
+
+
+# ============================================================================
+# KingRecord serialization includes the new fields
+# ============================================================================
+
+
+def test_king_record_round_trip_lineage_fields(tmp_path):
+    chain = LocalChain(tmp_path / "chain")
+    parent_hash = "e" * 64
+    king_hash = "f" * 64
+    chain.set_king(KingRecord(
+        miner_hotkey="5F_child",
+        bundle_hash="bh_child",
+        val_bpb=0.9,
+        benchmark_accuracy=0.5,
+        compute_cost=2.0,
+        crowned_at=1234.0,
+        king_attestation_hash=king_hash,
+        parent_king_attestation_hash=parent_hash,
+    ))
+    got = chain.get_king()
+    assert got is not None
+    assert got.king_attestation_hash == king_hash
+    assert got.parent_king_attestation_hash == parent_hash
+
+
+def test_king_record_legacy_byte_equivalent_when_lineage_empty(tmp_path):
+    """A v0.10-shaped king (no lineage fields) round-trips without
+    introducing new keys to king.json."""
+    import json as _json
+    chain = LocalChain(tmp_path / "chain")
+    chain.set_king(KingRecord(
+        miner_hotkey="5F_legacy",
+        bundle_hash="bh_legacy",
+        val_bpb=1.5,
+        benchmark_accuracy=0.2,
+        compute_cost=0.0,
+        crowned_at=0.0,
+    ))
+    on_disk = _json.loads((tmp_path / "chain" / "king.json").read_text())
+    assert "king_attestation_hash" not in on_disk
+    assert "parent_king_attestation_hash" not in on_disk

--- a/tests/test_restricted_scanner.py
+++ b/tests/test_restricted_scanner.py
@@ -236,6 +236,37 @@ def test_eval_private_calibration_blocked():
     )
 
 
+# ----------------------------------------------------------------------------
+# C1-LITE: validator/state/ + validator/cache/ globs for v0.11-lite lineage.
+# ----------------------------------------------------------------------------
+
+
+def test_validator_state_lineage_blocked():
+    """A patch touching validator/state/lineage_state.json is rejected."""
+    diff = _diff_touching("validator/state/lineage_state.json")
+    assert "validator/state/lineage_state.json" in scan_diff_for_restricted(
+        diff, LIVE_RESTRICTED + ["validator/state/**", "validator/cache/**"],
+    )
+
+
+def test_validator_cache_parent_blocked():
+    """A patch touching validator/cache/parent_reproductions/ is rejected."""
+    diff = _diff_touching("validator/cache/parent_reproductions/abc.json")
+    assert "validator/cache/parent_reproductions/abc.json" in scan_diff_for_restricted(
+        diff, LIVE_RESTRICTED + ["validator/state/**", "validator/cache/**"],
+    )
+
+
+def test_c1_lite_globs_present_in_live_yaml():
+    """validator/state/** and validator/cache/** must be in the live yaml."""
+    yaml_path = Path(__file__).resolve().parent.parent / "restricted_files.yaml"
+    text = yaml_path.read_text()
+    for glob in ("validator/state/**", "validator/cache/**"):
+        assert f'"{glob}"' in text, (
+            f"C1-LITE glob {glob!r} missing from restricted_files.yaml"
+        )
+
+
 def test_b1_d10_explicit_globs_present_in_live_yaml():
     """Read the live restricted_files.yaml and verify the B1-D10 globs
     are recorded. Catches accidental removals."""

--- a/tests/test_runner_cli_apply_patch.py
+++ b/tests/test_runner_cli_apply_patch.py
@@ -1,0 +1,124 @@
+"""C1-LITE runner_cli apply_patch integration tests.
+
+The B1-D13 stub is replaced by a real implementation that:
+  * Copies --karpa-root to a tmp workdir
+  * Applies --patch via `patch -p1 --no-backup-if-mismatch`
+  * Prepends the patched workdir to sys.path before model import
+
+These tests exercise the patch-application path directly (without
+invoking the full model import + eval chain).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from eval.downstream.runner_cli import _apply_patch_to_workdir, main
+
+# ============================================================================
+# _apply_patch_to_workdir helper
+# ============================================================================
+
+
+def _write_recipe(root: Path):
+    """Create a tiny "karpa root" layout with a recipe file we can patch."""
+    root.mkdir(parents=True)
+    (root / "recipe").mkdir()
+    (root / "recipe" / "config.txt").write_text("baseline_lr=1e-3\n")
+
+
+def test_apply_patch_to_workdir_returns_distinct_dir(tmp_path):
+    karpa = tmp_path / "karpa"
+    _write_recipe(karpa)
+    patch = tmp_path / "empty.patch"
+    patch.write_text("")  # empty patch == no-op
+    out = _apply_patch_to_workdir(patch, karpa)
+    assert out != karpa
+    assert (out / "recipe" / "config.txt").exists()
+
+
+def test_apply_patch_empty_patch_is_noop(tmp_path):
+    karpa = tmp_path / "karpa"
+    _write_recipe(karpa)
+    patch = tmp_path / "empty.patch"
+    patch.write_text("")
+    out = _apply_patch_to_workdir(patch, karpa)
+    assert (out / "recipe" / "config.txt").read_text() == "baseline_lr=1e-3\n"
+
+
+def test_apply_patch_real_patch_modifies_workdir(tmp_path):
+    """A unified diff modifying config.txt is applied cleanly."""
+    karpa = tmp_path / "karpa"
+    _write_recipe(karpa)
+    patch_text = (
+        "--- a/recipe/config.txt\n"
+        "+++ b/recipe/config.txt\n"
+        "@@ -1 +1 @@\n"
+        "-baseline_lr=1e-3\n"
+        "+baseline_lr=5e-4\n"
+    )
+    patch = tmp_path / "p.patch"
+    patch.write_text(patch_text)
+    out = _apply_patch_to_workdir(patch, karpa)
+    assert (out / "recipe" / "config.txt").read_text() == "baseline_lr=5e-4\n"
+    # Original is untouched.
+    assert (karpa / "recipe" / "config.txt").read_text() == "baseline_lr=1e-3\n"
+
+
+def test_apply_patch_failure_raises(tmp_path):
+    """A patch against missing context fails loudly."""
+    karpa = tmp_path / "karpa"
+    _write_recipe(karpa)
+    patch_text = (
+        "--- a/recipe/config.txt\n"
+        "+++ b/recipe/config.txt\n"
+        "@@ -1 +1 @@\n"
+        "-this_line_does_not_exist\n"
+        "+but_we_are_patching_it_anyway\n"
+    )
+    patch = tmp_path / "p.patch"
+    patch.write_text(patch_text)
+    with pytest.raises(RuntimeError, match=r"patch failed"):
+        _apply_patch_to_workdir(patch, karpa)
+
+
+def test_apply_patch_missing_karpa_root_raises(tmp_path):
+    patch = tmp_path / "p.patch"
+    patch.write_text("")
+    with pytest.raises(FileNotFoundError, match=r"karpa_root"):
+        _apply_patch_to_workdir(patch, tmp_path / "missing")
+
+
+def test_apply_patch_missing_patch_raises(tmp_path):
+    karpa = tmp_path / "karpa"
+    _write_recipe(karpa)
+    with pytest.raises(FileNotFoundError, match=r"patch"):
+        _apply_patch_to_workdir(tmp_path / "missing.patch", karpa)
+
+
+# ============================================================================
+# main() --patch surface
+# ============================================================================
+
+
+def test_main_requires_karpa_root_when_patch_given(tmp_path):
+    """--patch without --karpa-root must fail cleanly (no GPU work attempted)."""
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text('{"tasks": ["arc_easy"]}')
+    patch = tmp_path / "p.patch"
+    patch.write_text("")
+    with pytest.raises(ValueError, match=r"--patch requires --karpa-root"):
+        main([
+            "--checkpoint", "x",
+            "--config", str(cfg),
+            "--output", str(tmp_path / "out.json"),
+            "--bundle-sha", "x",
+            "--bundle-dir", str(tmp_path),
+            "--vocab-size", "50257",
+            "--patch", str(patch),
+        ])

--- a/tests/test_validator_ladder_accept.py
+++ b/tests/test_validator_ladder_accept.py
@@ -1,0 +1,343 @@
+"""C1-LITE validator/ladder.py acceptance-path tests.
+
+Covers:
+  * read_submission: bundle layout + missing/bad fields + optional cache
+  * accept_submission: each rejection reason path + happy path + genesis
+  * Chain event emission (submission_received) on every call
+  * KARPA_VOCAB_SIZE enforcement
+  * Branch id format
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from chain_layer.local import LocalChain
+from eval.downstream.runner import KARPA_VOCAB_SIZE
+from validator.ladder import (
+    ACCEPT_OK,
+    SUPPORTED_SCHEMA_VERSIONS,
+    Submission,
+    accept_submission,
+    read_submission,
+)
+from validator.lineage import ParentCsdpCache
+
+# ============================================================================
+# Test fixtures
+# ============================================================================
+
+
+def _make_cache_dict(parent_hash: str = "a" * 64) -> dict:
+    return {
+        "parent_king_attestation_hash": parent_hash,
+        "csdp_summary": {"s3_overall": 0.7},
+        "streams_root_hash_at_evaluation": "f" * 64,
+        "cached_at_iso": "2026-06-12T00:00:00Z",
+        "cached_at_block": 1024,
+        "quorum_signatures": [
+            {"signer": "validator_1", "sig": "11" * 32},
+        ],
+    }
+
+
+def _make_submission_bundle(
+    tmp_path,
+    *,
+    schema_version: str = "v0.11",
+    parent_hash: str | None = "a" * 64,
+    branch_id: str = "main",
+    bundle_hash: str = "bh",
+    miner_hotkey: str = "5F_miner",
+    vocab_size: int = KARPA_VOCAB_SIZE,
+    include_cache: bool = True,
+    cache_overrides: dict | None = None,
+) -> Path:
+    bundle = tmp_path / "submission"
+    bundle.mkdir()
+    sub = {
+        "schema_version": schema_version,
+        "parent_king_attestation_hash": parent_hash,
+        "branch_id": branch_id,
+        "bundle_hash": bundle_hash,
+        "miner_hotkey": miner_hotkey,
+        "vocab_size": vocab_size,
+    }
+    (bundle / "submission.json").write_text(json.dumps(sub))
+    if include_cache and parent_hash:
+        cache = _make_cache_dict(parent_hash=parent_hash)
+        if cache_overrides:
+            cache.update(cache_overrides)
+        (bundle / "parent_csdp_cache.json").write_text(json.dumps(cache))
+    return bundle
+
+
+@pytest.fixture
+def chain(tmp_path):
+    c = LocalChain(tmp_path / "chain")
+    return c
+
+
+@pytest.fixture
+def chain_with_king(tmp_path):
+    c = LocalChain(tmp_path / "chain")
+    c.append_event({
+        "type": "king_crowned",
+        "king_attestation_hash": "a" * 64,
+        "miner_hotkey": "5F_parent",
+        "branch_id": "main",
+    })
+    return c
+
+
+# ============================================================================
+# read_submission
+# ============================================================================
+
+
+def test_read_submission_happy_path(tmp_path):
+    bundle = _make_submission_bundle(tmp_path)
+    sub = read_submission(bundle)
+    assert sub.schema_version == "v0.11"
+    assert sub.parent_king_attestation_hash == "a" * 64
+    assert sub.branch_id == "main"
+    assert sub.vocab_size == KARPA_VOCAB_SIZE
+    assert sub.parent_csdp_cache is not None
+    assert sub.parent_csdp_cache.parent_king_attestation_hash == "a" * 64
+
+
+def test_read_submission_missing_file_raises(tmp_path):
+    bundle = tmp_path / "empty"
+    bundle.mkdir()
+    with pytest.raises(FileNotFoundError, match=r"submission.json"):
+        read_submission(bundle)
+
+
+def test_read_submission_missing_required_field_raises(tmp_path):
+    bundle = tmp_path / "bad"
+    bundle.mkdir()
+    (bundle / "submission.json").write_text(json.dumps({"schema_version": "v0.11"}))
+    with pytest.raises(ValueError, match=r"missing required fields"):
+        read_submission(bundle)
+
+
+def test_read_submission_genesis_omits_cache(tmp_path):
+    bundle = _make_submission_bundle(
+        tmp_path, parent_hash=None, include_cache=False,
+    )
+    sub = read_submission(bundle)
+    assert sub.parent_king_attestation_hash is None
+    assert sub.parent_csdp_cache is None
+
+
+def test_read_submission_bad_cache_json_raises(tmp_path):
+    bundle = _make_submission_bundle(tmp_path)
+    (bundle / "parent_csdp_cache.json").write_text("{this is not json")
+    with pytest.raises(ValueError, match=r"parent_csdp_cache.json invalid JSON"):
+        read_submission(bundle)
+
+
+# ============================================================================
+# accept_submission rejection paths
+# ============================================================================
+
+
+def test_accept_rejects_unsupported_schema_version(chain):
+    sub = Submission(
+        schema_version="v0.99",
+        parent_king_attestation_hash=None,
+        branch_id="main",
+        bundle_hash="bh",
+        miner_hotkey="5F",
+        vocab_size=KARPA_VOCAB_SIZE,
+    )
+    result = accept_submission(sub, chain, now_iso="2026-06-12T00:00:00Z")
+    assert not result.accepted
+    assert result.reason.startswith("bad_submission_format")
+
+
+def test_accept_rejects_bad_branch_id(chain):
+    sub = Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash=None,
+        branch_id="random_string",
+        bundle_hash="bh",
+        miner_hotkey="5F",
+        vocab_size=KARPA_VOCAB_SIZE,
+    )
+    result = accept_submission(sub, chain, now_iso="2026-06-12T00:00:00Z")
+    assert not result.accepted
+    assert result.reason == "bad_branch_id"
+
+
+def test_accept_rejects_vocab_mismatch(chain):
+    sub = Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash=None,
+        branch_id="main",
+        bundle_hash="bh",
+        miner_hotkey="5F",
+        vocab_size=40000,
+    )
+    result = accept_submission(sub, chain, now_iso="2026-06-12T00:00:00Z")
+    assert not result.accepted
+    assert result.reason == "vocab_mismatch"
+
+
+def test_accept_rejects_bad_parent_hash_format(chain):
+    sub = Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash="not_64_chars",
+        branch_id="main",
+        bundle_hash="bh",
+        miner_hotkey="5F",
+        vocab_size=KARPA_VOCAB_SIZE,
+        parent_csdp_cache=ParentCsdpCache.from_dict(_make_cache_dict()),
+    )
+    result = accept_submission(sub, chain, now_iso="2026-06-12T00:00:00Z")
+    assert not result.accepted
+    assert result.reason == "parent_unverifiable:bad_parent_hash_format"
+
+
+def test_accept_rejects_parent_not_on_chain(chain):
+    sub = Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash="b" * 64,
+        branch_id="main",
+        bundle_hash="bh",
+        miner_hotkey="5F",
+        vocab_size=KARPA_VOCAB_SIZE,
+        parent_csdp_cache=ParentCsdpCache.from_dict(_make_cache_dict(parent_hash="b" * 64)),
+    )
+    result = accept_submission(sub, chain, now_iso="2026-06-12T00:00:00Z")
+    assert not result.accepted
+    assert result.reason == "parent_unverifiable:parent_not_on_chain"
+
+
+# ============================================================================
+# accept_submission happy paths
+# ============================================================================
+
+
+def test_accept_genesis_happy_path(chain):
+    sub = Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash=None,
+        branch_id="main",
+        bundle_hash="bh_genesis",
+        miner_hotkey="5F_genesis",
+        vocab_size=KARPA_VOCAB_SIZE,
+    )
+    result = accept_submission(sub, chain, now_iso="2026-06-12T00:00:00Z")
+    assert result.accepted
+    assert result.reason == ACCEPT_OK
+
+
+def test_accept_with_parent_happy_path(chain_with_king):
+    sub = Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash="a" * 64,
+        branch_id="main",
+        bundle_hash="bh_child",
+        miner_hotkey="5F_child",
+        vocab_size=KARPA_VOCAB_SIZE,
+        parent_csdp_cache=ParentCsdpCache.from_dict(_make_cache_dict()),
+    )
+    result = accept_submission(sub, chain_with_king, now_iso="2026-06-12T00:00:00Z")
+    assert result.accepted, f"unexpected reject reason: {result.reason}"
+    assert result.reason == ACCEPT_OK
+
+
+def test_accept_branch_open_format(chain_with_king):
+    sub = Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash="a" * 64,
+        branch_id="open_new_branch_my_idea",
+        bundle_hash="bh",
+        miner_hotkey="5F",
+        vocab_size=KARPA_VOCAB_SIZE,
+        parent_csdp_cache=ParentCsdpCache.from_dict(_make_cache_dict()),
+    )
+    result = accept_submission(sub, chain_with_king, now_iso="2026-06-12T00:00:00Z")
+    assert result.accepted
+
+
+def test_accept_existing_branch_format(chain_with_king):
+    sub = Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash="a" * 64,
+        branch_id="branch-3",
+        bundle_hash="bh",
+        miner_hotkey="5F",
+        vocab_size=KARPA_VOCAB_SIZE,
+        parent_csdp_cache=ParentCsdpCache.from_dict(_make_cache_dict()),
+    )
+    result = accept_submission(sub, chain_with_king, now_iso="2026-06-12T00:00:00Z")
+    assert result.accepted
+
+
+# ============================================================================
+# Chain event emission
+# ============================================================================
+
+
+def test_accept_emits_submission_received_event(chain):
+    sub = Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash=None,
+        branch_id="main",
+        bundle_hash="bh",
+        miner_hotkey="5F",
+        vocab_size=KARPA_VOCAB_SIZE,
+    )
+    accept_submission(sub, chain, now_iso="2026-06-12T00:00:00Z")
+    events = chain.get_events(limit=10)
+    received = [e for e in events if e["type"] == "submission_received"]
+    assert len(received) == 1
+    assert received[0]["accepted"] is True
+    assert received[0]["reason"] == ACCEPT_OK
+    assert received[0]["branch_id"] == "main"
+
+
+def test_accept_emits_event_on_rejection(chain):
+    sub = Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash=None,
+        branch_id="main",
+        bundle_hash="bh",
+        miner_hotkey="5F",
+        vocab_size=12345,
+    )
+    accept_submission(sub, chain, now_iso="2026-06-12T00:00:00Z")
+    events = chain.get_events(limit=10)
+    received = [e for e in events if e["type"] == "submission_received"]
+    assert received[0]["accepted"] is False
+    assert received[0]["reason"] == "vocab_mismatch"
+
+
+def test_accept_event_emission_can_be_disabled(chain):
+    sub = Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash=None,
+        branch_id="main",
+        bundle_hash="bh",
+        miner_hotkey="5F",
+        vocab_size=KARPA_VOCAB_SIZE,
+    )
+    accept_submission(sub, chain, now_iso="2026-06-12T00:00:00Z", emit_chain_event=False)
+    assert chain.get_events(limit=10) == []
+
+
+# ============================================================================
+# Module constants pinning
+# ============================================================================
+
+
+def test_supported_schema_versions_pinned_to_v0_11_lite():
+    assert SUPPORTED_SCHEMA_VERSIONS == {"v0.11"}

--- a/validator/ladder.py
+++ b/validator/ladder.py
@@ -1,0 +1,309 @@
+"""v0.11-lite validator ladder — acceptance path with parent-cache verification.
+
+C1-LITE scope: this module ships the SUBMISSION ACCEPTANCE half of the
+validator ladder — the cheap, GPU-free preflight that runs on every
+incoming child submission BEFORE the S1/S2/S3 CSDP eval is invoked.
+
+What this module ships (v0.11-lite):
+
+  * `Submission` — frozen dataclass for the in-process representation
+    of a child submission's metadata + bundled parent_csdp_cache.
+  * `LadderAcceptResult` — frozen dataclass for the verdict.
+  * `read_submission(submission_dir)` — load submission.json +
+    parent_csdp_cache.json from a miner's PR bundle.
+  * `accept_submission(submission, chain, *, now_iso, ...)` — run the
+    GPU-free preflight: format checks, vocab pin, parent lineage
+    verification. Emits a single `submission_received` chain event on
+    every call (including rejections, for audit). Returns
+    `LadderAcceptResult` indicating whether the submission proceeds to
+    the GPU eval stage.
+
+What this module does NOT ship (C2-LITE):
+
+  * The actual S1/S2/S3 dispatch — `eval/downstream/runner_cli.py` is
+    invoked with the patched recipe, sealed-stream config, hardness
+    index, and yields a `DownstreamReport`. The orchestration code
+    that wraps that invocation lives in C2-LITE.
+  * `HiddenEvalResult.downstream` population from the report — also
+    C2-LITE.
+  * `--legacy` mode preserving `to_legacy_dict` byte-equivalence — the
+    accept_submission preflight is mode-agnostic; mode handling enters
+    in C2-LITE's eval driver.
+
+For C1-LITE, `accept_submission` is the visible API. C2-LITE's
+`run_ladder_eval(submission, ladder_eval_config)` will consume an
+ACCEPTED submission and produce the CSDP report.
+
+Reference: docs/rearch_2026_06/00_v0_11_master.md §4.1 Validator.
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from chain_layer.interface import ChainInterface
+from eval.downstream.runner import KARPA_VOCAB_SIZE
+
+from .lineage import (
+    DEFAULT_CACHE_AGE_THRESHOLD_DAYS,
+    ParentCsdpCache,
+    is_valid_attestation_hash,
+    verify_parent_lineage,
+)
+
+# Acceptance reasons (stable for chain event consumers + audit log).
+ACCEPT_OK = "accept_ok"
+REJECT_BAD_FORMAT = "bad_submission_format"
+REJECT_VOCAB_MISMATCH = "vocab_mismatch"
+REJECT_BAD_BRANCH_ID = "bad_branch_id"
+
+# Supported submission schema versions. v0.11-lite accepts only "v0.11";
+# v0.11-full will extend with required sealed-shard fields under a v0.11.1
+# bump.
+SUPPORTED_SCHEMA_VERSIONS = frozenset({"v0.11"})
+
+# Branch id format: "main" or "branch-<int>" or "open_new_branch_<slug>".
+# Slug regex is enforced separately in C5-PASS-FULL; v0.11-lite checks the
+# prefix only.
+_BRANCH_PREFIXES = ("main", "branch-", "open_new_branch_")
+
+
+# ----------------------------------------------------------------------------
+# Dataclasses
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Submission:
+    """Validator's in-process view of a miner's submission bundle.
+
+    Constructed by `read_submission` from a bundle directory. The fields
+    are deliberately the v0.11-lite minimum; v0.11-full will extend with
+    sealed-shard, license_spdx, dco_signed_off_by, novelty_score, etc.
+    """
+
+    schema_version: str
+    parent_king_attestation_hash: Optional[str]
+    branch_id: str
+    bundle_hash: str
+    miner_hotkey: str
+    vocab_size: int
+    parent_csdp_cache: Optional[ParentCsdpCache] = None
+
+    def to_dict(self) -> dict:
+        d = {
+            "schema_version": self.schema_version,
+            "parent_king_attestation_hash": self.parent_king_attestation_hash,
+            "branch_id": self.branch_id,
+            "bundle_hash": self.bundle_hash,
+            "miner_hotkey": self.miner_hotkey,
+            "vocab_size": self.vocab_size,
+        }
+        if self.parent_csdp_cache is not None:
+            d["parent_csdp_cache"] = self.parent_csdp_cache.to_dict()
+        return d
+
+
+@dataclass(frozen=True)
+class LadderAcceptResult:
+    """Verdict of `accept_submission`.
+
+    `accepted=True` means the submission cleared every GPU-free preflight
+    check and is eligible for the S1/S2/S3 CSDP eval (C2-LITE). `reason`
+    is the stable underscore-snake-case tag the validator emits to the
+    chain event log so downstream auditors can group rejections by cause.
+    """
+
+    accepted: bool
+    reason: str
+    submission_dict: dict = field(default_factory=dict)
+
+
+# ----------------------------------------------------------------------------
+# Submission loader
+# ----------------------------------------------------------------------------
+
+
+def read_submission(submission_dir: Path) -> Submission:
+    """Load `submission.json` (+ optional `parent_csdp_cache.json`) from
+    a miner bundle directory.
+
+    Expected layout:
+      <submission_dir>/
+        submission.json           — required
+        parent_csdp_cache.json    — required iff parent_king_attestation_hash is set
+        recipe/                   — modified recipe tree (touched here only for
+                                    docstring; the patched-eval driver consumes it)
+        proof/                    — attestation quote + training_log etc.
+
+    Raises:
+      FileNotFoundError if submission.json is missing.
+      ValueError on JSON parse error or missing required fields.
+    """
+    submission_dir = Path(submission_dir)
+    sub_path = submission_dir / "submission.json"
+    if not sub_path.exists():
+        raise FileNotFoundError(f"submission.json not found in {submission_dir}")
+    try:
+        d = json.loads(sub_path.read_text())
+    except json.JSONDecodeError as e:
+        raise ValueError(f"submission.json invalid JSON: {e}") from e
+
+    required = {"schema_version", "branch_id", "bundle_hash", "miner_hotkey", "vocab_size"}
+    missing = required - d.keys()
+    if missing:
+        raise ValueError(
+            f"submission.json missing required fields: {sorted(missing)}"
+        )
+
+    parent_hash = d.get("parent_king_attestation_hash")
+    cache: Optional[ParentCsdpCache] = None
+    cache_path = submission_dir / "parent_csdp_cache.json"
+    if cache_path.exists():
+        try:
+            cache_dict = json.loads(cache_path.read_text())
+        except json.JSONDecodeError as e:
+            raise ValueError(f"parent_csdp_cache.json invalid JSON: {e}") from e
+        try:
+            cache = ParentCsdpCache.from_dict(cache_dict)
+        except (KeyError, ValueError) as e:
+            raise ValueError(
+                f"parent_csdp_cache.json missing/invalid fields: {e}"
+            ) from e
+
+    return Submission(
+        schema_version=str(d["schema_version"]),
+        parent_king_attestation_hash=parent_hash if parent_hash else None,
+        branch_id=str(d["branch_id"]),
+        bundle_hash=str(d["bundle_hash"]),
+        miner_hotkey=str(d["miner_hotkey"]),
+        vocab_size=int(d["vocab_size"]),
+        parent_csdp_cache=cache,
+    )
+
+
+# ----------------------------------------------------------------------------
+# Acceptance preflight
+# ----------------------------------------------------------------------------
+
+
+def _validate_branch_id(branch_id: str) -> bool:
+    """v0.11-lite branch-id check: must be one of the known prefixes.
+    Full slug validation lands in C5-PASS-FULL."""
+    if not branch_id:
+        return False
+    if branch_id == "main":
+        return True
+    return any(branch_id.startswith(p) for p in _BRANCH_PREFIXES if p != "main")
+
+
+def accept_submission(
+    submission: Submission,
+    chain: ChainInterface,
+    *,
+    now_iso: Optional[str] = None,
+    cache_age_threshold_days: int = DEFAULT_CACHE_AGE_THRESHOLD_DAYS,
+    emit_chain_event: bool = True,
+) -> LadderAcceptResult:
+    """Run the v0.11-lite GPU-free preflight on a submission.
+
+    Checks (in order, fail-fast):
+      1. schema_version ∈ SUPPORTED_SCHEMA_VERSIONS
+      2. branch_id well-formed
+      3. vocab_size == KARPA_VOCAB_SIZE (50257)
+      4. parent_king_attestation_hash format (if non-empty)
+      5. verify_parent_lineage (signature + age + parent existence)
+
+    Emits a `submission_received` chain event on every call (including
+    rejections), with the verdict for downstream audit / reward
+    accounting.
+
+    Returns:
+      LadderAcceptResult with `accepted` + a stable underscore-snake-case
+      `reason` tag.
+    """
+    if now_iso is None:
+        now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    result = _run_preflight(
+        submission,
+        chain,
+        now_iso=now_iso,
+        cache_age_threshold_days=cache_age_threshold_days,
+    )
+
+    if emit_chain_event:
+        chain.append_event({
+            "type": "submission_received",
+            "schema_version": submission.schema_version,
+            "branch_id": submission.branch_id,
+            "bundle_hash": submission.bundle_hash,
+            "miner_hotkey": submission.miner_hotkey,
+            "parent_king_attestation_hash": submission.parent_king_attestation_hash,
+            "accepted": result.accepted,
+            "reason": result.reason,
+            "now_iso": now_iso,
+        })
+
+    return result
+
+
+def _run_preflight(
+    submission: Submission,
+    chain: ChainInterface,
+    *,
+    now_iso: str,
+    cache_age_threshold_days: int,
+) -> LadderAcceptResult:
+    """Inner preflight — separated so the event emission can wrap it."""
+    if submission.schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+        return LadderAcceptResult(
+            accepted=False,
+            reason=REJECT_BAD_FORMAT + f":schema_version_{submission.schema_version}",
+            submission_dict=submission.to_dict(),
+        )
+
+    if not _validate_branch_id(submission.branch_id):
+        return LadderAcceptResult(
+            accepted=False,
+            reason=REJECT_BAD_BRANCH_ID,
+            submission_dict=submission.to_dict(),
+        )
+
+    if submission.vocab_size != KARPA_VOCAB_SIZE:
+        return LadderAcceptResult(
+            accepted=False,
+            reason=REJECT_VOCAB_MISMATCH,
+            submission_dict=submission.to_dict(),
+        )
+
+    parent_hash = submission.parent_king_attestation_hash
+    if parent_hash and not is_valid_attestation_hash(parent_hash):
+        return LadderAcceptResult(
+            accepted=False,
+            reason="parent_unverifiable:bad_parent_hash_format",
+            submission_dict=submission.to_dict(),
+        )
+
+    ok, reason = verify_parent_lineage(
+        parent_attestation_hash=parent_hash,
+        parent_csdp_cache=submission.parent_csdp_cache,
+        chain=chain,
+        now_iso=now_iso,
+        cache_age_threshold_days=cache_age_threshold_days,
+    )
+    if not ok:
+        return LadderAcceptResult(
+            accepted=False,
+            reason=f"parent_unverifiable:{reason}",
+            submission_dict=submission.to_dict(),
+        )
+
+    return LadderAcceptResult(
+        accepted=True,
+        reason=ACCEPT_OK,
+        submission_dict=submission.to_dict(),
+    )

--- a/validator/lineage.py
+++ b/validator/lineage.py
@@ -1,0 +1,341 @@
+"""v0.11-lite lineage primitives — attestation hashing + parent-cache verification.
+
+The Karpa v0.11 protocol replaces the v0.10 nested `KingRecord.previous_king`
+dict with a flat cryptographic pointer `parent_king_attestation_hash`. Each
+king carries its OWN `king_attestation_hash` (sha256 of canonical attestation
+payload) and points back to its parent's hash via
+`parent_king_attestation_hash`. Walking the chain back to genesis (where
+`parent_king_attestation_hash is None`) reconstructs the full lineage.
+
+For v0.11-lite (the B6 sprint scope), validators do NO GPU work to verify a
+parent. Instead, the child miner reproduces the parent's CSDP on their own
+GPU and bundles `parent_csdp_cache.json` (the parent's scores plus a quorum
+signature from the parent-time validators). The validator's only work is a
+SIGNATURE CHECK against the cached payload — option (c) from the protocol
+design that preserves the "validators do minimal work" axiom.
+
+What this module ships (v0.11-lite):
+
+  * `compute_king_attestation_hash(payload)` — canonical sha256 of an
+    attestation payload (JSON sort_keys, separators tight, signatures
+    appended after hashing so signatures don't change the hash).
+  * `ParentCsdpCache` — frozen dataclass for the cached parent payload.
+    Includes the parent_king_attestation_hash, CSDP summary, age fields,
+    and quorum signature list.
+  * `verify_parent_lineage(parent_attestation_hash, parent_csdp_cache,
+    chain, *, now_iso, cache_age_threshold_days=14)` — the main
+    verification entry point.
+
+What this module does NOT ship (v0.11-full, post-B6 PASS):
+
+  * Real ed25519 quorum signature verification with rotating validator
+    pubkey sets — for v0.11-lite, signatures are structurally validated
+    only (presence + format), and the LOCAL chain backend trusts
+    well-formed caches. Cryptographic verification with bonded validator
+    quorums lands in C5-PASS-FULL.
+  * NOW-quorum age gate (>= 14 days requires fresh 2/3 NOW-validator
+    co-sign) — the age check is implemented here, but the "fresh
+    signature" path raises a clean rejection rather than re-requesting
+    signatures from the live quorum.
+  * Sealed-shard accumulator binding (corpus_root_hash, shard_root_hash
+    in the attestation payload's TDX user_data) — v0.11-full only.
+
+Reference: docs/rearch_2026_06/00_v0_11_master.md §2.2 Lineage Chain.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Optional
+
+from chain_layer.interface import ChainInterface
+
+# Field that contains the quorum signatures inside an attestation payload.
+# Hashing skips this field so signatures can be appended after the hash is
+# computed (matching the v0.11 design where multiple validators co-sign
+# the same content-addressed payload).
+_QUORUM_SIG_FIELD = "validator_quorum_sig"
+
+# Attestation hash format: lowercase hex of sha256, 64 chars total.
+ATTESTATION_HASH_LEN = 64
+
+# v0.11-lite cache age threshold. Caches older than this require a fresh
+# NOW-quorum signature; under v0.11-lite that path raises a clean
+# rejection (real fresh-signature negotiation is C5-PASS-FULL).
+DEFAULT_CACHE_AGE_THRESHOLD_DAYS = 14
+
+
+# ----------------------------------------------------------------------------
+# Attestation hash
+# ----------------------------------------------------------------------------
+
+
+def _canonical_payload_bytes(payload: dict) -> bytes:
+    """Serialize a dict for hashing — sort_keys=True, tight separators, UTF-8.
+
+    The validator_quorum_sig field (if present) is REMOVED before hashing
+    so signatures can be appended after content is content-addressed.
+    """
+    stripped = {k: v for k, v in payload.items() if k != _QUORUM_SIG_FIELD}
+    return json.dumps(
+        stripped,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def compute_king_attestation_hash(payload: dict) -> str:
+    """sha256 of the canonical attestation payload (without quorum sig).
+
+    The output is the 64-char lowercase hex digest that the protocol
+    stores in `KingRecord.king_attestation_hash` and in chain events.
+    Two attestation payloads with identical content (modulo their
+    signature lists) produce identical hashes.
+    """
+    return hashlib.sha256(_canonical_payload_bytes(payload)).hexdigest()
+
+
+def is_valid_attestation_hash(value: Any) -> bool:
+    """True if `value` is a 64-char lowercase hex string."""
+    if not isinstance(value, str) or len(value) != ATTESTATION_HASH_LEN:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return value == value.lower()
+
+
+# ----------------------------------------------------------------------------
+# Parent CSDP cache
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ParentCsdpCache:
+    """The cached parent-CSDP payload the child miner bundles.
+
+    Produced when the child miner re-executes the parent recipe on its own
+    GPU. The parent-time validator quorum that originally crowned the
+    parent signs the resulting payload; the child includes those
+    signatures in its submission so the validator that scores the child
+    can verify the parent's CSDP without re-running it.
+
+    Schema:
+      * `parent_king_attestation_hash` — the parent we re-evaluated;
+        must match the child's submission.parent_king_attestation_hash.
+      * `csdp_summary` — dict of per-rung overall scores plus per-axis
+        breakdown (e.g. `{"s1_overall", "s2_overall", "s3_overall",
+        "core22_s3", "private_hard_s3", "val_bpb_s2"}`). Free-form for
+        v0.11-lite; v0.11-full pins a stricter schema.
+      * `streams_root_hash_at_evaluation` — the manifest root the
+        parent's eval ran against; lets the child prove it used the
+        same sealed-stream config as the parent.
+      * `cached_at_iso` — wall-clock timestamp when the cache was
+        produced. Compared to `now_iso` for the age gate.
+      * `cached_at_block` — chain block at cache time; supports the
+        future NOW-quorum re-signing path.
+      * `quorum_signatures` — list of dicts (one per signer) with
+        `{"signer": "<ss58 or pubkey>", "sig": "<hex>"}`. v0.11-lite
+        validates structure only; v0.11-full ed25519-verifies each.
+    """
+
+    parent_king_attestation_hash: str
+    csdp_summary: dict
+    streams_root_hash_at_evaluation: str
+    cached_at_iso: str
+    cached_at_block: int
+    quorum_signatures: list[dict] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ParentCsdpCache:
+        """Inverse of `to_dict`. Required-field violations raise KeyError;
+        type violations raise ValueError at field access."""
+        return cls(
+            parent_king_attestation_hash=str(d["parent_king_attestation_hash"]),
+            csdp_summary=dict(d["csdp_summary"]),
+            streams_root_hash_at_evaluation=str(d["streams_root_hash_at_evaluation"]),
+            cached_at_iso=str(d["cached_at_iso"]),
+            cached_at_block=int(d["cached_at_block"]),
+            quorum_signatures=list(d.get("quorum_signatures", [])),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "parent_king_attestation_hash": self.parent_king_attestation_hash,
+            "csdp_summary": dict(self.csdp_summary),
+            "streams_root_hash_at_evaluation": self.streams_root_hash_at_evaluation,
+            "cached_at_iso": self.cached_at_iso,
+            "cached_at_block": self.cached_at_block,
+            "quorum_signatures": list(self.quorum_signatures),
+        }
+
+
+# ----------------------------------------------------------------------------
+# Verification
+# ----------------------------------------------------------------------------
+
+
+def _parse_iso(iso: str) -> datetime:
+    """Parse ISO 8601 timestamp (UTC; trailing Z accepted).
+
+    The chain stores cached_at_iso in `YYYY-MM-DDTHH:MM:SSZ` form; older
+    payloads may use `+00:00`. Both are accepted.
+    """
+    s = iso.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s)
+
+
+def _age_days(cached_iso: str, now_iso: str) -> float:
+    """Wall-clock age of a cache in days (floats; negative when cache is
+    in the future, which raises in the caller).
+    """
+    return (_parse_iso(now_iso) - _parse_iso(cached_iso)).total_seconds() / 86400.0
+
+
+def _structural_signature_check(sigs: list[dict]) -> tuple[bool, str]:
+    """v0.11-lite structural validation of the quorum signature list.
+
+    Each entry must be `{"signer": <non-empty str>, "sig": <hex str>}`.
+    At least one signature must be present (genesis is the exception,
+    handled by the caller before this is called).
+
+    v0.11-full replaces this with ed25519 verification against a
+    chain-derived validator pubkey set.
+    """
+    if not sigs:
+        return False, "no_quorum_signatures"
+    for i, entry in enumerate(sigs):
+        if not isinstance(entry, dict):
+            return False, f"signature_entry_{i}_not_dict"
+        signer = entry.get("signer")
+        sig = entry.get("sig")
+        if not isinstance(signer, str) or not signer:
+            return False, f"signature_entry_{i}_bad_signer"
+        if not isinstance(sig, str) or not sig:
+            return False, f"signature_entry_{i}_bad_sig"
+        try:
+            int(sig, 16)
+        except ValueError:
+            return False, f"signature_entry_{i}_sig_not_hex"
+    return True, ""
+
+
+def verify_parent_lineage(
+    parent_attestation_hash: Optional[str],
+    parent_csdp_cache: Optional[ParentCsdpCache],
+    chain: ChainInterface,
+    *,
+    now_iso: str,
+    cache_age_threshold_days: int = DEFAULT_CACHE_AGE_THRESHOLD_DAYS,
+) -> tuple[bool, str]:
+    """Validate a child submission's parent-CSDP cache.
+
+    Returns `(ok, reason)`:
+      * `(True, "")` if the lineage is valid (genesis OR cached payload
+        verifies cleanly).
+      * `(False, "<reason>")` on any failure; reason is a short
+        underscore-snake-case tag the validator emits to the chain as
+        `parent_unverifiable:<reason>`.
+
+    Args:
+      parent_attestation_hash: from `submission.parent_king_attestation_hash`.
+        `None` indicates genesis; both `None` and `""` are treated as
+        genesis for tolerance.
+      parent_csdp_cache: the cached payload bundled by the miner. Required
+        when `parent_attestation_hash` is non-empty; `None` at genesis.
+      chain: the live chain interface for parent-king lookup.
+      now_iso: wall-clock ISO 8601 timestamp for the age gate.
+      cache_age_threshold_days: caches older than this require a fresh
+        NOW-quorum signature; v0.11-lite rejects with `cache_too_old`
+        (real re-signing path is C5-PASS-FULL).
+
+    Failure tags (stable for chain event consumers):
+      genesis_ok                       — no parent; submission accepted
+      missing_parent_cache             — parent hash given but no cache
+      bad_parent_hash_format           — hash not 64-char lowercase hex
+      parent_hash_mismatch             — cache parent != submission parent
+      parent_not_on_chain              — parent not found in chain history
+      no_quorum_signatures             — empty signature list (post-genesis)
+      signature_entry_<i>_bad_*        — structural signature issue
+      cache_in_future                  — cached_at_iso > now_iso
+      cache_too_old                    — beyond cache_age_threshold_days
+    """
+    # Genesis: no parent, no cache required. The CALLER must ensure
+    # genesis submissions are otherwise valid (operator's GenesisAttestation
+    # event signed separately).
+    if not parent_attestation_hash:
+        if parent_csdp_cache is not None:
+            return False, "unexpected_parent_cache_at_genesis"
+        return True, "genesis_ok"
+
+    if not is_valid_attestation_hash(parent_attestation_hash):
+        return False, "bad_parent_hash_format"
+
+    if parent_csdp_cache is None:
+        return False, "missing_parent_cache"
+
+    if parent_csdp_cache.parent_king_attestation_hash != parent_attestation_hash:
+        return False, "parent_hash_mismatch"
+
+    # Parent must exist somewhere in chain history. v0.11-lite walks the
+    # last N events; v0.11-full uses a maintained lineage index.
+    if not _lookup_parent_in_chain(parent_attestation_hash, chain):
+        return False, "parent_not_on_chain"
+
+    # Cache age gate.
+    try:
+        age = _age_days(parent_csdp_cache.cached_at_iso, now_iso)
+    except ValueError:
+        return False, "bad_cached_at_iso"
+    if age < 0:
+        return False, "cache_in_future"
+    if age > cache_age_threshold_days:
+        # v0.11-full requires a fresh NOW-quorum co-sign here. v0.11-lite
+        # rejects loudly so the operator sees the issue rather than
+        # silently degrading trust.
+        return False, "cache_too_old"
+
+    # Structural signature validation (v0.11-lite). v0.11-full ed25519
+    # verifies each signer against a chain-derived validator pubkey set.
+    ok, reason = _structural_signature_check(parent_csdp_cache.quorum_signatures)
+    if not ok:
+        return False, reason
+
+    return True, ""
+
+
+def _lookup_parent_in_chain(
+    parent_attestation_hash: str,
+    chain: ChainInterface,
+    *,
+    event_scan_limit: int = 10_000,
+) -> bool:
+    """Return True iff a `king_crowned` event with this attestation hash
+    has been emitted.
+
+    v0.11-lite scans the last `event_scan_limit` events linearly. v0.11-full
+    maintains an indexed lineage tree at `validator/state/lineage_state.json`
+    for O(1) lookup. The linear scan is acceptable for testnet 16 where
+    crowning events number in the hundreds, not the millions.
+
+    Also recognises a current king (read via `chain.get_king()`) whose
+    `king_attestation_hash` matches — useful for fresh chains where the
+    crowning event may not have been re-indexed yet.
+    """
+    # Fast path: current king.
+    current = chain.get_king()
+    if current is not None and current.king_attestation_hash == parent_attestation_hash:
+        return True
+    # Event scan: any KingCrowned event referencing this hash.
+    for event in chain.get_events(limit=event_scan_limit):
+        if event.get("type") != "king_crowned":
+            continue
+        if event.get("king_attestation_hash") == parent_attestation_hash:
+            return True
+    return False


### PR DESCRIPTION
- KingRecord: + king_attestation_hash + parent_king_attestation_hash (both backends; legacy byte-equivalent when empty)
- validator/lineage.py: compute_king_attestation_hash + ParentCsdpCache + verify_parent_lineage (genesis / format / mismatch / not-on-chain / age gate / sig structure)
- validator/ladder.py: Submission + accept_submission preflight (schema + branch + vocab + lineage); emits submission_received chain event
- runner_cli.py: --patch fully wired via _apply_patch_to_workdir (closes B1-D13)
- restricted_files.yaml: + validator/state/** + validator/cache/**
- 55 new tests. Full suite: 602/602.