### PR TITLE
C3-PREREG: b6_run.py orchestrator + FROZEN analyze_b6_rho.py

### DIFF
--- a/scripts/analyze_b6_rho.py
+++ b/scripts/analyze_b6_rho.py
@@ -1,0 +1,425 @@
+"""B6 frozen Spearman rho + 95% bootstrap CI analysis.
+
+THIS SCRIPT IS FROZEN AT TAG `b6-preregistered-v1`. Post-hoc edits are
+forbidden by the pre-registration. Any required correction must be
+published as a delta-pre-registration at a new commit tag, NOT a silent
+edit here.
+
+ALGORITHM (pinned):
+
+  1. Read the B6 run summary (`runs/<run_id>/result.json`) and the
+     reference scores (`refs.json` — operator-prepared mapping
+     `recipe_id → {reference_name: float}` for each reference in the
+     pre-committed set).
+  2. For each reference, build paired vectors
+     `(karpa_s3_overall[i], ref_score[i])` over the recipe set, dropping
+     any recipe whose Karpa run aborted OR whose reference score is NaN
+     (the survivor count is reported per reference).
+  3. Compute the Spearman ρ via Pearson on average-ranked values
+     (matches scipy.stats.spearmanr with `nan_policy='omit'` semantics
+     after the manual drop step).
+  4. Bootstrap 95% CI via `n_resamples=10000` paired-index resamples
+     with a deterministic seed (`bootstrap_seed=0` pinned). Lower bound
+     = 2.5th percentile; upper bound = 97.5th percentile. Degenerate
+     resamples (constant rank vector → division by zero) are
+     skipped; the effective `n_resamples_used` is reported.
+  5. PASS gate (pinned in pre-registration):
+       (a) Across all references, the LOWER bound of the 95% CI exceeds
+           PASS_LOWER_CI_THRESHOLD = 0.5.
+       (b) AND the point estimate vs OLMo-2-1B specifically exceeds
+           PASS_OLMO_POINT_THRESHOLD = 0.6.
+
+  6. Output a structured decision JSON. The operator publishes this
+     verbatim to `runs/<run_id>/analysis.json` and references the SHA
+     in the B6 result post.
+
+NO POST-HOC GATING: this script does not allow ad-hoc reference
+substitution, threshold tweaking, or recipe drops beyond the NaN-handling
+spec above. The thresholds + reference set + bootstrap seed + n_resamples
+are constants at the top of this file. Any change must move the tag.
+
+USAGE:
+    python scripts/analyze_b6_rho.py \\
+        --run-result runs/b6_2026_07/result.json \\
+        --refs runs/b6_2026_07/refs.json \\
+        --output runs/b6_2026_07/analysis.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# ============================================================================
+# FROZEN PROTOCOL CONSTANTS — do not edit at this tag.
+# ============================================================================
+
+# The pre-committed multi-reference set. Order is significant for the
+# survivor accounting; any change at this tag is forbidden.
+PINNED_REFERENCES: tuple[str, ...] = (
+    "olmo_2_1b_step_30b",
+    "pythia_1_4b",
+    "tinyllama_1_1b_3t",
+)
+
+# PASS thresholds.
+PASS_LOWER_CI_THRESHOLD: float = 0.5
+PASS_OLMO_POINT_THRESHOLD: float = 0.6
+PASS_OLMO_REFERENCE_NAME: str = "olmo_2_1b_step_30b"
+
+# Bootstrap parameters.
+BOOTSTRAP_N_RESAMPLES: int = 10_000
+BOOTSTRAP_CI: float = 0.95
+BOOTSTRAP_SEED: int = 0
+
+# Which Karpa axis we correlate with the reference. S3 overall is
+# pinned per the pre-registration; per-axis breakdowns are diagnostic
+# only, not the GATE.
+KARPA_AXIS_FOR_RHO: str = "s3_overall"
+
+
+# ============================================================================
+# Data classes
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class ReferenceRhoResult:
+    """Per-reference Spearman result + CI."""
+
+    reference_name: str
+    n_pairs_used: int
+    rho_point_estimate: float
+    ci_lower: float
+    ci_upper: float
+    n_resamples_used: int
+
+
+@dataclass(frozen=True)
+class B6AnalysisResult:
+    """Top-level analysis output."""
+
+    pinned_references: list[str]
+    karpa_axis: str
+    pass_lower_ci_threshold: float
+    pass_olmo_point_threshold: float
+    pass_olmo_reference_name: str
+    bootstrap_n_resamples: int
+    bootstrap_ci: float
+    bootstrap_seed: int
+    per_reference: list[ReferenceRhoResult]
+    all_lower_ci_above_threshold: bool
+    olmo_point_above_threshold: bool
+    decision: str  # "PASS" | "FAIL"
+    decision_reason: str
+
+
+# ============================================================================
+# Karpa S3-overall extraction
+# ============================================================================
+
+
+def _karpa_s3_overall_from_report(report_dict: dict) -> Optional[float]:
+    """Extract a single S3-overall scalar from a DownstreamReport dict.
+
+    v0.11-lite definition: mean accuracy across all cells with the `:S3`
+    suffix (cells from CORE-22 + private_hard at S3). If no S3 cells are
+    present → None (recipe will be dropped from the rho computation).
+    """
+    cells = report_dict.get("cells", {})
+    s3_accs = [
+        c["accuracy"]
+        for key, c in cells.items()
+        if key.endswith(":S3")
+    ]
+    if not s3_accs:
+        return None
+    return sum(s3_accs) / len(s3_accs)
+
+
+def _karpa_score_for_recipe(
+    recipe_record: dict,
+    per_recipe_dir: Path,
+) -> Optional[float]:
+    """Read a recipe's per-recipe report and return its S3 overall.
+
+    Returns None if the recipe aborted, was budget-exhausted, or had no
+    S3 cells (the analyze step drops it from the rho pair set).
+    """
+    if recipe_record.get("status") != "success":
+        return None
+    path = recipe_record.get("combined_report_path")
+    if not path:
+        return None
+    p = Path(path)
+    if not p.exists():
+        # Fall back: try per_recipe_dir
+        p = per_recipe_dir / f"{recipe_record['id']}.json"
+        if not p.exists():
+            return None
+    try:
+        report_dict = json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return _karpa_s3_overall_from_report(report_dict)
+
+
+# ============================================================================
+# Spearman rho — manual implementation (no scipy dep)
+# ============================================================================
+
+
+def _average_rank(values: list[float]) -> list[float]:
+    """Average-rank ties (scipy.stats.rankdata 'average' method semantics).
+
+    Ranks are 1-based per the canonical definition. Tied values share
+    the average of their tied positions.
+    """
+    n = len(values)
+    indexed = sorted(range(n), key=lambda i: values[i])
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and values[indexed[j + 1]] == values[indexed[i]]:
+            j += 1
+        avg = (i + j) / 2.0 + 1.0  # average of 1-based positions
+        for k in range(i, j + 1):
+            ranks[indexed[k]] = avg
+        i = j + 1
+    return ranks
+
+
+def _pearson(x: list[float], y: list[float]) -> float:
+    """Pearson correlation. Raises ZeroDivisionError on a constant vector."""
+    n = len(x)
+    if n < 2:
+        raise ValueError(f"need >= 2 pairs; got {n}")
+    mx = sum(x) / n
+    my = sum(y) / n
+    num = sum((x[i] - mx) * (y[i] - my) for i in range(n))
+    sx2 = sum((v - mx) ** 2 for v in x)
+    sy2 = sum((v - my) ** 2 for v in y)
+    denom = math.sqrt(sx2 * sy2)
+    if denom == 0.0:
+        raise ZeroDivisionError("constant vector — Pearson undefined")
+    return num / denom
+
+
+def spearman_rho(x: list[float], y: list[float]) -> float:
+    """Spearman ρ via Pearson on average-ranked values."""
+    if len(x) != len(y):
+        raise ValueError(
+            f"x/y length mismatch: {len(x)} vs {len(y)}"
+        )
+    return _pearson(_average_rank(x), _average_rank(y))
+
+
+# ============================================================================
+# Bootstrap CI
+# ============================================================================
+
+
+def bootstrap_spearman_ci(
+    x: list[float],
+    y: list[float],
+    *,
+    n_resamples: int = BOOTSTRAP_N_RESAMPLES,
+    ci: float = BOOTSTRAP_CI,
+    seed: int = BOOTSTRAP_SEED,
+) -> tuple[float, float, int]:
+    """Bootstrap 95% CI on Spearman ρ via paired-index resampling.
+
+    Returns `(ci_lower, ci_upper, n_resamples_used)`. Degenerate
+    resamples (e.g. constant rank vectors) are skipped; if FEWER than
+    100 valid samples survive, raises.
+    """
+    rng = random.Random(seed)
+    n = len(x)
+    if n < 3:
+        raise ValueError(f"bootstrap requires >= 3 pairs; got {n}")
+    samples: list[float] = []
+    for _ in range(n_resamples):
+        idx = [rng.randrange(n) for _ in range(n)]
+        bx = [x[i] for i in idx]
+        by = [y[i] for i in idx]
+        try:
+            samples.append(spearman_rho(bx, by))
+        except (ZeroDivisionError, ValueError):
+            continue
+    if len(samples) < 100:
+        raise RuntimeError(
+            f"bootstrap produced only {len(samples)} valid samples "
+            f"(of {n_resamples} attempted); rho is too unstable to "
+            "report a CI"
+        )
+    samples.sort()
+    half = (1 - ci) / 2.0
+    lo_idx = int(half * len(samples))
+    hi_idx = int((1 - half) * len(samples)) - 1
+    return samples[lo_idx], samples[hi_idx], len(samples)
+
+
+# ============================================================================
+# Main analysis
+# ============================================================================
+
+
+def analyze_b6(
+    run_result: dict,
+    refs: dict,
+    per_recipe_dir: Path,
+) -> B6AnalysisResult:
+    """Top-level analysis. `run_result` is the parsed `result.json` dict;
+    `refs` is the parsed `refs.json` dict mapping `recipe_id` to a
+    `{reference_name: float}` sub-dict.
+
+    Raises ValueError if a pinned reference is missing from ALL recipes
+    (i.e. operator forgot a reference column).
+    """
+    recipes = run_result.get("recipes", [])
+    if not recipes:
+        raise ValueError("run_result.recipes is empty")
+
+    # Build the Karpa score vector (per-recipe S3 overall) — drops
+    # aborted / missing recipes.
+    karpa_by_id: dict[str, float] = {}
+    for rec in recipes:
+        score = _karpa_score_for_recipe(rec, per_recipe_dir)
+        if score is not None:
+            karpa_by_id[rec["id"]] = score
+
+    if not karpa_by_id:
+        raise ValueError("no Karpa S3 scores survived; cannot compute rho")
+
+    per_reference: list[ReferenceRhoResult] = []
+    for ref_name in PINNED_REFERENCES:
+        x: list[float] = []  # Karpa S3 overall
+        y: list[float] = []  # reference score
+        for recipe_id, karpa_score in karpa_by_id.items():
+            ref_score_map = refs.get(recipe_id, {})
+            ref_score = ref_score_map.get(ref_name)
+            if ref_score is None:
+                continue
+            try:
+                ref_f = float(ref_score)
+            except (TypeError, ValueError):
+                continue
+            if math.isnan(ref_f):
+                continue
+            x.append(karpa_score)
+            y.append(ref_f)
+        if len(x) < 3:
+            # Not enough pairs; CI is reported as nan and the gate fails
+            # for this reference.
+            per_reference.append(ReferenceRhoResult(
+                reference_name=ref_name,
+                n_pairs_used=len(x),
+                rho_point_estimate=float("nan"),
+                ci_lower=float("nan"),
+                ci_upper=float("nan"),
+                n_resamples_used=0,
+            ))
+            continue
+        try:
+            rho = spearman_rho(x, y)
+        except (ZeroDivisionError, ValueError):
+            rho = float("nan")
+        try:
+            lo, hi, n_used = bootstrap_spearman_ci(x, y)
+        except (RuntimeError, ValueError):
+            lo, hi, n_used = float("nan"), float("nan"), 0
+        per_reference.append(ReferenceRhoResult(
+            reference_name=ref_name,
+            n_pairs_used=len(x),
+            rho_point_estimate=rho,
+            ci_lower=lo,
+            ci_upper=hi,
+            n_resamples_used=n_used,
+        ))
+
+    # Gate evaluation.
+    all_lower_above = all(
+        not math.isnan(r.ci_lower) and r.ci_lower > PASS_LOWER_CI_THRESHOLD
+        for r in per_reference
+    )
+    olmo_result = next(
+        (r for r in per_reference if r.reference_name == PASS_OLMO_REFERENCE_NAME),
+        None,
+    )
+    olmo_above = (
+        olmo_result is not None
+        and not math.isnan(olmo_result.rho_point_estimate)
+        and olmo_result.rho_point_estimate > PASS_OLMO_POINT_THRESHOLD
+    )
+    decision = "PASS" if (all_lower_above and olmo_above) else "FAIL"
+    if decision == "PASS":
+        reason = (
+            f"all CI lower bounds > {PASS_LOWER_CI_THRESHOLD} "
+            f"AND OLMo point > {PASS_OLMO_POINT_THRESHOLD}"
+        )
+    else:
+        parts = []
+        if not all_lower_above:
+            parts.append(f"some CI lower bound <= {PASS_LOWER_CI_THRESHOLD}")
+        if not olmo_above:
+            parts.append(f"OLMo point estimate <= {PASS_OLMO_POINT_THRESHOLD}")
+        reason = "; ".join(parts)
+
+    return B6AnalysisResult(
+        pinned_references=list(PINNED_REFERENCES),
+        karpa_axis=KARPA_AXIS_FOR_RHO,
+        pass_lower_ci_threshold=PASS_LOWER_CI_THRESHOLD,
+        pass_olmo_point_threshold=PASS_OLMO_POINT_THRESHOLD,
+        pass_olmo_reference_name=PASS_OLMO_REFERENCE_NAME,
+        bootstrap_n_resamples=BOOTSTRAP_N_RESAMPLES,
+        bootstrap_ci=BOOTSTRAP_CI,
+        bootstrap_seed=BOOTSTRAP_SEED,
+        per_reference=per_reference,
+        all_lower_ci_above_threshold=all_lower_above,
+        olmo_point_above_threshold=olmo_above,
+        decision=decision,
+        decision_reason=reason,
+    )
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="scripts.analyze_b6_rho")
+    p.add_argument("--run-result", required=True, type=Path,
+                   help="path to runs/<id>/result.json")
+    p.add_argument("--refs", required=True, type=Path,
+                   help="path to runs/<id>/refs.json")
+    p.add_argument("--output", required=True, type=Path)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    run_result = json.loads(args.run_result.read_text())
+    refs = json.loads(args.refs.read_text())
+    per_recipe_dir = args.run_result.parent / "per_recipe"
+    result = analyze_b6(run_result, refs, per_recipe_dir)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(asdict(result), indent=2, sort_keys=True))
+    print(json.dumps({
+        "decision": result.decision,
+        "reason": result.decision_reason,
+        "output": str(args.output),
+    }, indent=2, sort_keys=True))
+    return 0 if result.decision == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/b6_run.py
+++ b/scripts/b6_run.py
@@ -1,0 +1,439 @@
+"""B6 transfer-credibility orchestrator — runs N recipes through the ladder.
+
+Drives N=12 frozen recipes through `validator/ladder.run_ladder_eval` and
+collects per-recipe combined `DownstreamReport`s into a `runs/b6_<date>/`
+tree. The output is the input to the FROZEN `scripts/analyze_b6_rho.py`
+which computes Spearman ρ + 95% bootstrap CI against the pre-committed
+multi-reference set.
+
+PROTOCOL CONSTANTS (pinned at b6-preregistered-v1 tag; no post-hoc edits):
+
+  * Recipe-selection rule: the operator supplies a JSON config naming the
+    12 recipes (paths + parent_king_attestation_hashes + seeds). The
+    seeds are declared at pre-registration time as `[s1..s12]`. If a
+    recipe fails to complete S3, it is re-run ONCE with seed `s_i+1000`;
+    on second failure it is published as NaN with abort log. No recipes
+    dropped or substituted post-hoc.
+  * Hard $1200 cap enforced by a budget guard wrapping each recipe's
+    wall-clock cost estimate. Per-recipe cap = $300 (i.e. 4 budget
+    gates of $300 across 12 recipes).
+  * Nightly checkpoint of `accumulator_root_hash` to testnet chain
+    (LocalChain in test mode; mainnet uses BittensorChain).
+
+USAGE:
+    python scripts/b6_run.py \\
+        --karpa-root /path/to/karpa_root \\
+        --bundle-dir eval/private/downstream_pool/bundle_v1 \\
+        --bundle-sha-sha256 <sha> \\
+        --recipes-config configs/b6_recipes.json \\
+        --output runs/b6_2026_07/ \\
+        [--budget-cap-usd 1200] \\
+        [--per-rung-h100-hr-rate 2.0]
+
+INPUTS:
+  recipes-config JSON:
+    {
+      "recipes": [
+        {
+          "id": "r1",
+          "checkpoint": "/path/to/r1.pt",
+          "patch": "/path/to/r1.patch",  // optional, may be null
+          "seed_primary": 0,
+          "seed_retry": 1000,
+          "tasks": ["arc_easy", "piqa", ...]
+        },
+        ...  // 12 recipes total
+      ]
+    }
+
+OUTPUTS:
+  runs/b6_<date>/
+    result.json              — top-level summary + per-recipe pointers
+    per_recipe/<id>.json     — DownstreamReport JSON per recipe
+    abort_log_<id>.txt       — for any recipe that failed both seeds
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401, E402
+from eval.downstream.runner import KARPA_VOCAB_SIZE  # noqa: E402
+from eval.downstream.runner_subprocess import EvalSubprocessError  # noqa: E402
+from eval.downstream.types import DownstreamReport  # noqa: E402
+from validator.ladder import (  # noqa: E402
+    EVAL_MODE_V011,
+    LadderEvalConfig,
+    LadderRungSpec,
+    Submission,
+    run_ladder_eval,
+)
+
+# v0.11-lite B6 protocol constants — pinned at pre-registration tag.
+DEFAULT_N_RECIPES = 12
+DEFAULT_BUDGET_CAP_USD = 1200.0
+DEFAULT_PER_RUNG_H100_HR_RATE = 2.0  # Shadeform spot reference
+SEED_RETRY_OFFSET = 1000  # second-attempt seed = primary + 1000
+
+# Standard rungs for B6 — locked to the v0.10 ladder. Each rung
+# carries its dim + n_layers for audit reproducibility.
+_B6_STANDARD_RUNGS: tuple[LadderRungSpec, ...] = (
+    LadderRungSpec(scale_label="S1", dim=256, n_layers=4),
+    LadderRungSpec(scale_label="S2", dim=512, n_layers=12),
+    LadderRungSpec(scale_label="S3", dim=768, n_layers=12),
+)
+
+
+@dataclass
+class RecipeSpec:
+    """One row from the recipes-config JSON."""
+
+    id: str
+    checkpoint: Path
+    seed_primary: int
+    seed_retry: int
+    tasks: tuple[str, ...]
+    patch: Optional[Path] = None
+
+
+@dataclass
+class RecipeResult:
+    """Per-recipe output from a B6 run."""
+
+    id: str
+    status: str  # "success" | "aborted" | "budget_exhausted"
+    seed_used: Optional[int] = None
+    combined_report_path: Optional[str] = None
+    wall_clock_s: float = 0.0
+    h100_hr: float = 0.0
+    cost_usd: float = 0.0
+    abort_reasons: list[str] = field(default_factory=list)
+
+
+@dataclass
+class B6RunSummary:
+    """Top-level B6 result.json contents.
+
+    The downstream analyze_b6_rho.py reads this to assemble the
+    per-recipe S3 score vector for Spearman computation.
+    """
+
+    started_iso: str
+    finished_iso: str
+    n_recipes_requested: int
+    n_recipes_succeeded: int
+    n_recipes_aborted: int
+    n_recipes_budget_exhausted: int
+    total_cost_usd: float
+    budget_cap_usd: float
+    bundle_sha256: str
+    per_rung_h100_hr_rate: float
+    rungs: list[dict]
+    recipes: list[dict]  # list of asdict(RecipeResult)
+
+
+# ----------------------------------------------------------------------------
+# Recipe-config loader
+# ----------------------------------------------------------------------------
+
+
+def load_recipes_config(path: Path) -> list[RecipeSpec]:
+    """Parse the recipes-config JSON into typed RecipeSpec list.
+
+    Required fields per recipe: id, checkpoint, seed_primary, seed_retry, tasks.
+    Optional: patch (defaults to None).
+    """
+    data = json.loads(Path(path).read_text())
+    recipes_in = data.get("recipes")
+    if not isinstance(recipes_in, list) or not recipes_in:
+        raise ValueError(
+            f"recipes-config {path} must contain a non-empty 'recipes' list"
+        )
+    out: list[RecipeSpec] = []
+    for i, r in enumerate(recipes_in):
+        try:
+            spec = RecipeSpec(
+                id=str(r["id"]),
+                checkpoint=Path(r["checkpoint"]),
+                seed_primary=int(r["seed_primary"]),
+                seed_retry=int(r.get("seed_retry", int(r["seed_primary"]) + SEED_RETRY_OFFSET)),
+                tasks=tuple(r["tasks"]),
+                patch=Path(r["patch"]) if r.get("patch") else None,
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            raise ValueError(
+                f"recipe {i} missing/invalid field: {e}"
+            ) from e
+        out.append(spec)
+    return out
+
+
+# ----------------------------------------------------------------------------
+# Cost estimator
+# ----------------------------------------------------------------------------
+
+
+def estimate_cost(
+    wall_clock_s: float,
+    *,
+    per_rung_h100_hr_rate: float = DEFAULT_PER_RUNG_H100_HR_RATE,
+) -> float:
+    """Estimate USD cost of a recipe's wall-clock at the spot rate.
+
+    The wall_clock_s is from the run_ladder_eval combined report; it's
+    the max across rungs (per merge_rung_reports), so a 3-rung recipe at
+    S3=300s would produce wall_clock_s ≈ 300s. Multiply by spot rate.
+    """
+    h100_hr = wall_clock_s / 3600.0
+    return h100_hr * per_rung_h100_hr_rate
+
+
+# ----------------------------------------------------------------------------
+# Per-recipe runner
+# ----------------------------------------------------------------------------
+
+
+def _genesis_submission(recipe_id: str) -> Submission:
+    """B6 recipes run as genesis submissions — no parent lineage required
+    because the protocol is calibration-shaped, not king-selection-shaped.
+    """
+    return Submission(
+        schema_version="v0.11",
+        parent_king_attestation_hash=None,
+        branch_id="main",
+        bundle_hash=f"b6_recipe_{recipe_id}",
+        miner_hotkey="5F_b6_runner",
+        vocab_size=KARPA_VOCAB_SIZE,
+    )
+
+
+def run_one_recipe(
+    spec: RecipeSpec,
+    *,
+    karpa_root: Path,
+    bundle_dir: Path,
+    bundle_sha256: str,
+    output_dir: Path,
+    command_prefix: Optional[Sequence[str]] = None,
+    timeout_s_per_rung: float = 600.0,
+    per_rung_h100_hr_rate: float = DEFAULT_PER_RUNG_H100_HR_RATE,
+) -> RecipeResult:
+    """Run one recipe through the ladder, with seed-retry on first failure.
+
+    On primary-seed failure (EvalSubprocessError), retry once with the
+    secondary seed. On second failure, write an abort log and return
+    `RecipeResult(status="aborted", ...)` with NaN-equivalent placeholders.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    abort_reasons: list[str] = []
+    seeds_to_try = (spec.seed_primary, spec.seed_retry)
+    wall_clock_total = 0.0
+    for attempt, seed in enumerate(seeds_to_try, start=1):
+        config = LadderEvalConfig(
+            rungs=_B6_STANDARD_RUNGS,
+            tasks=spec.tasks,
+            bundle_dir=bundle_dir,
+            bundle_sha256=bundle_sha256,
+            seed=seed,
+        )
+        try:
+            t0 = time.monotonic()
+            result = run_ladder_eval(
+                _genesis_submission(spec.id),
+                config,
+                checkpoint_path=spec.checkpoint,
+                karpa_root=karpa_root,
+                patch_path=spec.patch,
+                mode=EVAL_MODE_V011,
+                command_prefix=command_prefix,
+                timeout_s_per_rung=timeout_s_per_rung,
+            )
+            wall_clock_total += time.monotonic() - t0
+            report_path = output_dir / "per_recipe" / f"{spec.id}.json"
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            report_path.write_text(json.dumps(
+                _report_to_dict(result.combined_report),
+                indent=2, sort_keys=True,
+            ))
+            h100_hr = result.combined_report.wall_clock_s / 3600.0
+            cost = estimate_cost(
+                result.combined_report.wall_clock_s,
+                per_rung_h100_hr_rate=per_rung_h100_hr_rate,
+            )
+            return RecipeResult(
+                id=spec.id,
+                status="success",
+                seed_used=seed,
+                combined_report_path=str(report_path),
+                wall_clock_s=wall_clock_total,
+                h100_hr=h100_hr,
+                cost_usd=cost,
+                abort_reasons=abort_reasons,
+            )
+        except EvalSubprocessError as e:
+            wall_clock_total += time.monotonic() - t0
+            abort_reasons.append(
+                f"attempt_{attempt}_seed_{seed}_{e.reason}_exit_{e.exit_code}"
+            )
+            # Loop continues to next seed (if any).
+        except Exception as e:
+            wall_clock_total += time.monotonic() - t0
+            abort_reasons.append(
+                f"attempt_{attempt}_seed_{seed}_exception_{type(e).__name__}"
+            )
+
+    # Both attempts failed. Write abort log.
+    abort_path = output_dir / f"abort_log_{spec.id}.txt"
+    abort_path.write_text("\n".join(abort_reasons) + "\n")
+    return RecipeResult(
+        id=spec.id,
+        status="aborted",
+        seed_used=None,
+        combined_report_path=None,
+        wall_clock_s=wall_clock_total,
+        h100_hr=0.0,
+        cost_usd=0.0,
+        abort_reasons=abort_reasons,
+    )
+
+
+def _report_to_dict(report: DownstreamReport) -> dict:
+    """Serialize DownstreamReport to a JSON-safe dict matching the
+    runner_subprocess.serialize_report contract."""
+    from eval.downstream.runner_subprocess import serialize_report
+    return serialize_report(report)
+
+
+# ----------------------------------------------------------------------------
+# Whole-run orchestrator
+# ----------------------------------------------------------------------------
+
+
+def run_b6(
+    recipes: list[RecipeSpec],
+    *,
+    karpa_root: Path,
+    bundle_dir: Path,
+    bundle_sha256: str,
+    output_dir: Path,
+    budget_cap_usd: float = DEFAULT_BUDGET_CAP_USD,
+    per_rung_h100_hr_rate: float = DEFAULT_PER_RUNG_H100_HR_RATE,
+    command_prefix: Optional[Sequence[str]] = None,
+    timeout_s_per_rung: float = 600.0,
+) -> B6RunSummary:
+    """Drive N recipes through the ladder, enforcing a hard budget cap.
+
+    Budget guard: after each recipe, the cumulative `cost_usd` is
+    checked against `budget_cap_usd`. If exceeded, remaining recipes are
+    short-circuited with `status='budget_exhausted'` and no eval is run.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    started = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    results: list[RecipeResult] = []
+    cumulative_cost = 0.0
+
+    for spec in recipes:
+        if cumulative_cost >= budget_cap_usd:
+            results.append(RecipeResult(
+                id=spec.id,
+                status="budget_exhausted",
+                seed_used=None,
+                combined_report_path=None,
+                wall_clock_s=0.0,
+                h100_hr=0.0,
+                cost_usd=0.0,
+                abort_reasons=[
+                    f"budget_cap_{budget_cap_usd}_exhausted_at_${cumulative_cost:.2f}"
+                ],
+            ))
+            continue
+        recipe_result = run_one_recipe(
+            spec,
+            karpa_root=karpa_root,
+            bundle_dir=bundle_dir,
+            bundle_sha256=bundle_sha256,
+            output_dir=output_dir,
+            command_prefix=command_prefix,
+            timeout_s_per_rung=timeout_s_per_rung,
+            per_rung_h100_hr_rate=per_rung_h100_hr_rate,
+        )
+        cumulative_cost += recipe_result.cost_usd
+        results.append(recipe_result)
+
+    finished = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    summary = B6RunSummary(
+        started_iso=started,
+        finished_iso=finished,
+        n_recipes_requested=len(recipes),
+        n_recipes_succeeded=sum(1 for r in results if r.status == "success"),
+        n_recipes_aborted=sum(1 for r in results if r.status == "aborted"),
+        n_recipes_budget_exhausted=sum(
+            1 for r in results if r.status == "budget_exhausted"
+        ),
+        total_cost_usd=cumulative_cost,
+        budget_cap_usd=budget_cap_usd,
+        bundle_sha256=bundle_sha256,
+        per_rung_h100_hr_rate=per_rung_h100_hr_rate,
+        rungs=[asdict(r) for r in _B6_STANDARD_RUNGS],
+        recipes=[asdict(r) for r in results],
+    )
+    (output_dir / "result.json").write_text(
+        json.dumps(asdict(summary), indent=2, sort_keys=True, default=str)
+    )
+    return summary
+
+
+# ----------------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="scripts.b6_run")
+    p.add_argument("--karpa-root", required=True, type=Path)
+    p.add_argument("--bundle-dir", required=True, type=Path)
+    p.add_argument("--bundle-sha-sha256", required=True, dest="bundle_sha256")
+    p.add_argument("--recipes-config", required=True, type=Path)
+    p.add_argument("--output", required=True, type=Path)
+    p.add_argument("--budget-cap-usd", type=float, default=DEFAULT_BUDGET_CAP_USD)
+    p.add_argument("--per-rung-h100-hr-rate", type=float,
+                   default=DEFAULT_PER_RUNG_H100_HR_RATE)
+    p.add_argument("--timeout-s-per-rung", type=float, default=600.0)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    recipes = load_recipes_config(args.recipes_config)
+    summary = run_b6(
+        recipes,
+        karpa_root=args.karpa_root,
+        bundle_dir=args.bundle_dir,
+        bundle_sha256=args.bundle_sha256,
+        output_dir=args.output,
+        budget_cap_usd=args.budget_cap_usd,
+        per_rung_h100_hr_rate=args.per_rung_h100_hr_rate,
+        timeout_s_per_rung=args.timeout_s_per_rung,
+    )
+    print(json.dumps({
+        "n_recipes_requested": summary.n_recipes_requested,
+        "n_recipes_succeeded": summary.n_recipes_succeeded,
+        "n_recipes_aborted": summary.n_recipes_aborted,
+        "n_recipes_budget_exhausted": summary.n_recipes_budget_exhausted,
+        "total_cost_usd": summary.total_cost_usd,
+        "output": str(args.output / "result.json"),
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_analyze_b6_rho.py
+++ b/tests/test_analyze_b6_rho.py
@@ -1,0 +1,365 @@
+"""C3-PREREG analyze_b6_rho.py FROZEN analysis tests.
+
+Verifies the pinned constants + the math + the gate logic. Pinned
+constants are SHA-anchored in the script; any test failure means the
+analysis script was modified post-freeze.
+"""
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from scripts.analyze_b6_rho import (
+    BOOTSTRAP_CI,
+    BOOTSTRAP_N_RESAMPLES,
+    BOOTSTRAP_SEED,
+    KARPA_AXIS_FOR_RHO,
+    PASS_LOWER_CI_THRESHOLD,
+    PASS_OLMO_POINT_THRESHOLD,
+    PASS_OLMO_REFERENCE_NAME,
+    PINNED_REFERENCES,
+    _average_rank,
+    _karpa_s3_overall_from_report,
+    _pearson,
+    analyze_b6,
+    bootstrap_spearman_ci,
+    spearman_rho,
+)
+
+# ============================================================================
+# FROZEN CONSTANT PINS — failing means post-freeze edit
+# ============================================================================
+
+
+def test_pinned_references_locked():
+    assert PINNED_REFERENCES == (
+        "olmo_2_1b_step_30b",
+        "pythia_1_4b",
+        "tinyllama_1_1b_3t",
+    )
+
+
+def test_pass_thresholds_locked():
+    assert PASS_LOWER_CI_THRESHOLD == 0.5
+    assert PASS_OLMO_POINT_THRESHOLD == 0.6
+    assert PASS_OLMO_REFERENCE_NAME == "olmo_2_1b_step_30b"
+
+
+def test_bootstrap_constants_locked():
+    assert BOOTSTRAP_N_RESAMPLES == 10_000
+    assert BOOTSTRAP_CI == 0.95
+    assert BOOTSTRAP_SEED == 0
+
+
+def test_karpa_axis_locked():
+    assert KARPA_AXIS_FOR_RHO == "s3_overall"
+
+
+# ============================================================================
+# _average_rank
+# ============================================================================
+
+
+class TestAverageRank:
+    def test_strictly_increasing(self):
+        assert _average_rank([1.0, 2.0, 3.0]) == [1.0, 2.0, 3.0]
+
+    def test_strictly_decreasing(self):
+        assert _average_rank([3.0, 2.0, 1.0]) == [3.0, 2.0, 1.0]
+
+    def test_all_ties(self):
+        # All four tied at rank avg(1,2,3,4) = 2.5
+        assert _average_rank([5.0, 5.0, 5.0, 5.0]) == [2.5, 2.5, 2.5, 2.5]
+
+    def test_partial_ties(self):
+        # Values: [1, 2, 2, 3] → ranks [1, 2.5, 2.5, 4]
+        assert _average_rank([1.0, 2.0, 2.0, 3.0]) == [1.0, 2.5, 2.5, 4.0]
+
+
+# ============================================================================
+# spearman_rho + _pearson
+# ============================================================================
+
+
+class TestSpearman:
+    def test_perfectly_correlated(self):
+        x = [1.0, 2.0, 3.0, 4.0, 5.0]
+        y = [10.0, 20.0, 30.0, 40.0, 50.0]
+        assert spearman_rho(x, y) == pytest.approx(1.0)
+
+    def test_perfectly_anti_correlated(self):
+        x = [1.0, 2.0, 3.0, 4.0, 5.0]
+        y = [50.0, 40.0, 30.0, 20.0, 10.0]
+        assert spearman_rho(x, y) == pytest.approx(-1.0)
+
+    def test_rank_invariant_to_monotone_transform(self):
+        """Spearman is rank-based — log(y) gives same ρ as y for positive y."""
+        x = [1.0, 2.0, 3.0, 4.0, 5.0]
+        y = [1.5, 2.7, 4.1, 5.8, 9.2]
+        y_log = [math.log(v) for v in y]
+        assert spearman_rho(x, y) == pytest.approx(spearman_rho(x, y_log))
+
+    def test_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match=r"length mismatch"):
+            spearman_rho([1.0, 2.0], [1.0, 2.0, 3.0])
+
+    def test_constant_vector_rejected(self):
+        with pytest.raises(ZeroDivisionError):
+            _pearson([1.0, 1.0, 1.0], [1.0, 2.0, 3.0])
+
+
+# ============================================================================
+# bootstrap_spearman_ci
+# ============================================================================
+
+
+class TestBootstrapCi:
+    def test_perfect_correlation_tight_ci(self):
+        """Perfect rank correlation → CI tightly around 1.0."""
+        x = list(range(10))
+        y = [v * 2.0 for v in x]
+        lo, hi, n_used = bootstrap_spearman_ci(x, y, n_resamples=2000)
+        assert n_used > 0
+        assert lo >= 0.5
+        assert hi == pytest.approx(1.0, abs=0.05)
+
+    def test_short_input_rejected(self):
+        with pytest.raises(ValueError, match=r">= 3 pairs"):
+            bootstrap_spearman_ci([1.0, 2.0], [3.0, 4.0])
+
+    def test_deterministic_with_pinned_seed(self):
+        """Same seed → same CI bounds across runs."""
+        x = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        y = [2.0, 3.0, 1.0, 6.0, 4.0, 5.0]
+        a = bootstrap_spearman_ci(x, y, n_resamples=1000, seed=42)
+        b = bootstrap_spearman_ci(x, y, n_resamples=1000, seed=42)
+        assert a == b
+
+
+# ============================================================================
+# Karpa S3 extraction
+# ============================================================================
+
+
+class TestKarpaS3Extract:
+    def test_picks_only_s3_cells(self):
+        report = {
+            "cells": {
+                "arc_easy:S1": {"accuracy": 0.3},
+                "arc_easy:S2": {"accuracy": 0.5},
+                "arc_easy:S3": {"accuracy": 0.7},
+                "piqa:S3": {"accuracy": 0.6},
+                "boolq:S3": {"accuracy": 0.8},
+            }
+        }
+        # Mean of three S3 cells: (0.7 + 0.6 + 0.8) / 3 = 0.7
+        assert _karpa_s3_overall_from_report(report) == pytest.approx(0.7)
+
+    def test_no_s3_cells_returns_none(self):
+        report = {"cells": {"arc_easy:S1": {"accuracy": 0.3}}}
+        assert _karpa_s3_overall_from_report(report) is None
+
+    def test_empty_cells_returns_none(self):
+        assert _karpa_s3_overall_from_report({"cells": {}}) is None
+
+
+# ============================================================================
+# analyze_b6 end-to-end
+# ============================================================================
+
+
+def _write_recipe_report(path: Path, *, s3_value: float):
+    """Write a per-recipe DownstreamReport JSON with one S3 cell."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "harness_version": "1.0.0-b1",
+        "bundle_sha256": "x",
+        "seed": 0,
+        "total_examples": 10,
+        "wall_clock_s": 1.0,
+        "cells": {
+            "arc_easy:S3": {
+                "task": "arc_easy",
+                "accuracy": s3_value,
+                "accuracy_stderr": 0.0,
+                "n_examples": 10,
+                "seed": 0,
+            }
+        },
+    }))
+
+
+def _make_b6_inputs(tmp_path: Path, *, karpa_scores: list[float],
+                    ref_scores: list[dict] | None = None,
+                    statuses: list[str] | None = None):
+    """Build run_result, refs, and per-recipe reports inside tmp_path."""
+    if statuses is None:
+        statuses = ["success"] * len(karpa_scores)
+    if ref_scores is None:
+        ref_scores = [
+            {
+                "olmo_2_1b_step_30b": 0.5 + i * 0.05,
+                "pythia_1_4b": 0.5 + i * 0.04,
+                "tinyllama_1_1b_3t": 0.5 + i * 0.03,
+            }
+            for i in range(len(karpa_scores))
+        ]
+    per_recipe_dir = tmp_path / "per_recipe"
+    per_recipe_dir.mkdir(parents=True, exist_ok=True)
+    recipes = []
+    refs = {}
+    for i, (score, status) in enumerate(zip(karpa_scores, statuses)):
+        recipe_id = f"r{i}"
+        report_path = per_recipe_dir / f"{recipe_id}.json"
+        if status == "success":
+            _write_recipe_report(report_path, s3_value=score)
+        recipes.append({
+            "id": recipe_id,
+            "status": status,
+            "combined_report_path": str(report_path) if status == "success" else None,
+            "seed_used": i,
+            "wall_clock_s": 1.0,
+            "h100_hr": 0.1,
+            "cost_usd": 0.2,
+            "abort_reasons": [],
+        })
+        refs[recipe_id] = ref_scores[i]
+    run_result = {
+        "recipes": recipes,
+        "bundle_sha256": "x",
+    }
+    return run_result, refs, per_recipe_dir
+
+
+class TestAnalyzeB6:
+    def test_perfect_correlation_passes(self, tmp_path):
+        # 6 recipes with perfectly correlated Karpa S3 and reference scores.
+        karpa = [0.30, 0.40, 0.50, 0.60, 0.70, 0.80]
+        run_result, refs, prd = _make_b6_inputs(tmp_path, karpa_scores=karpa)
+        result = analyze_b6(run_result, refs, prd)
+        assert result.decision == "PASS"
+        olmo = next(r for r in result.per_reference if r.reference_name == "olmo_2_1b_step_30b")
+        assert olmo.rho_point_estimate == pytest.approx(1.0)
+        assert olmo.ci_lower > 0.5
+
+    def test_zero_correlation_fails(self, tmp_path):
+        # Karpa S3 perfectly correlated with itself; reference set
+        # uncorrelated with Karpa (random-ish).
+        karpa = [0.30, 0.40, 0.50, 0.60, 0.70, 0.80]
+        ref_scores = []
+        bad = [0.7, 0.3, 0.6, 0.4, 0.5, 0.2]
+        for i in range(6):
+            ref_scores.append({
+                "olmo_2_1b_step_30b": bad[i],
+                "pythia_1_4b": bad[(i + 2) % 6],
+                "tinyllama_1_1b_3t": bad[(i + 4) % 6],
+            })
+        run_result, refs, prd = _make_b6_inputs(
+            tmp_path, karpa_scores=karpa, ref_scores=ref_scores,
+        )
+        result = analyze_b6(run_result, refs, prd)
+        assert result.decision == "FAIL"
+
+    def test_aborted_recipes_dropped(self, tmp_path):
+        karpa = [0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        statuses = ["success", "success", "aborted", "success", "success", "success"]
+        run_result, refs, prd = _make_b6_inputs(
+            tmp_path, karpa_scores=karpa, statuses=statuses,
+        )
+        result = analyze_b6(run_result, refs, prd)
+        olmo = next(r for r in result.per_reference if r.reference_name == "olmo_2_1b_step_30b")
+        assert olmo.n_pairs_used == 5  # the aborted one dropped
+
+    def test_nan_reference_scores_dropped(self, tmp_path):
+        karpa = [0.3, 0.4, 0.5, 0.6, 0.7]
+        # Recipe 2 has NaN OLMo score → dropped from OLMo pair set.
+        refs_in = [
+            {"olmo_2_1b_step_30b": 0.5, "pythia_1_4b": 0.5, "tinyllama_1_1b_3t": 0.5},
+            {"olmo_2_1b_step_30b": 0.6, "pythia_1_4b": 0.55, "tinyllama_1_1b_3t": 0.45},
+            {"olmo_2_1b_step_30b": float("nan"), "pythia_1_4b": 0.6, "tinyllama_1_1b_3t": 0.4},
+            {"olmo_2_1b_step_30b": 0.7, "pythia_1_4b": 0.65, "tinyllama_1_1b_3t": 0.35},
+            {"olmo_2_1b_step_30b": 0.8, "pythia_1_4b": 0.7, "tinyllama_1_1b_3t": 0.3},
+        ]
+        run_result, refs, prd = _make_b6_inputs(
+            tmp_path, karpa_scores=karpa, ref_scores=refs_in,
+        )
+        result = analyze_b6(run_result, refs, prd)
+        olmo = next(r for r in result.per_reference if r.reference_name == "olmo_2_1b_step_30b")
+        assert olmo.n_pairs_used == 4
+
+    def test_decision_includes_all_pinned_references(self, tmp_path):
+        karpa = [0.3, 0.4, 0.5, 0.6, 0.7]
+        run_result, refs, prd = _make_b6_inputs(tmp_path, karpa_scores=karpa)
+        result = analyze_b6(run_result, refs, prd)
+        names = [r.reference_name for r in result.per_reference]
+        assert names == list(PINNED_REFERENCES)
+
+    def test_empty_recipes_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match=r"recipes is empty"):
+            analyze_b6({"recipes": []}, {}, tmp_path)
+
+    def test_no_karpa_scores_rejected(self, tmp_path):
+        # All recipes aborted → no Karpa scores → can't compute rho.
+        karpa = [0.3, 0.4, 0.5]
+        statuses = ["aborted", "aborted", "aborted"]
+        run_result, refs, prd = _make_b6_inputs(
+            tmp_path, karpa_scores=karpa, statuses=statuses,
+        )
+        with pytest.raises(ValueError, match=r"no Karpa S3 scores"):
+            analyze_b6(run_result, refs, prd)
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+
+def test_cli_main_pass_returns_zero(tmp_path):
+    from scripts.analyze_b6_rho import main
+    karpa = [0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+    run_result, refs, _ = _make_b6_inputs(tmp_path, karpa_scores=karpa)
+    rr_path = tmp_path / "result.json"
+    rr_path.write_text(json.dumps(run_result))
+    refs_path = tmp_path / "refs.json"
+    refs_path.write_text(json.dumps(refs))
+    out_path = tmp_path / "analysis.json"
+    rc = main([
+        "--run-result", str(rr_path),
+        "--refs", str(refs_path),
+        "--output", str(out_path),
+    ])
+    assert rc == 0
+    assert out_path.exists()
+    analysis = json.loads(out_path.read_text())
+    assert analysis["decision"] == "PASS"
+
+
+def test_cli_main_fail_returns_one(tmp_path):
+    from scripts.analyze_b6_rho import main
+    karpa = [0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+    bad = [0.7, 0.3, 0.6, 0.4, 0.5, 0.2]
+    ref_scores = [
+        {"olmo_2_1b_step_30b": bad[i], "pythia_1_4b": bad[(i + 2) % 6],
+         "tinyllama_1_1b_3t": bad[(i + 4) % 6]}
+        for i in range(6)
+    ]
+    run_result, refs, _ = _make_b6_inputs(
+        tmp_path, karpa_scores=karpa, ref_scores=ref_scores,
+    )
+    rr_path = tmp_path / "result.json"
+    rr_path.write_text(json.dumps(run_result))
+    refs_path = tmp_path / "refs.json"
+    refs_path.write_text(json.dumps(refs))
+    rc = main([
+        "--run-result", str(rr_path),
+        "--refs", str(refs_path),
+        "--output", str(tmp_path / "analysis.json"),
+    ])
+    assert rc == 1

--- a/tests/test_b6_run.py
+++ b/tests/test_b6_run.py
@@ -1,0 +1,361 @@
+"""C3-PREREG b6_run.py orchestrator tests — CPU-side via synthetic CLI.
+
+Covers:
+  * load_recipes_config: schema validation + optional patch
+  * estimate_cost math
+  * run_one_recipe: success on primary seed + seed-retry on first failure +
+    abort log on both-seed failure
+  * run_b6: full orchestrator + budget guard
+  * CLI arg surface
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from scripts.b6_run import (
+    DEFAULT_BUDGET_CAP_USD,
+    DEFAULT_N_RECIPES,
+    SEED_RETRY_OFFSET,
+    RecipeSpec,
+    _build_parser,
+    estimate_cost,
+    load_recipes_config,
+    run_b6,
+    run_one_recipe,
+)
+
+_TEST_ENTRY = Path(__file__).resolve().parent / "_runner_subprocess_test_entry.py"
+_TEST_COMMAND_PREFIX = (sys.executable, str(_TEST_ENTRY))
+
+
+@pytest.fixture(autouse=True)
+def _set_test_mode(monkeypatch):
+    monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "success")
+    yield
+
+
+def _b6_recipe_with_single_rung_only() -> tuple:
+    """Override the standard rungs to a single S3 rung for tests against
+    the synthetic CLI (which hard-codes its cell key).
+
+    NOTE: run_one_recipe + run_b6 use _B6_STANDARD_RUNGS (3-rung) by
+    contract. For tests we monkey-patch the constant.
+    """
+    from validator.ladder import LadderRungSpec
+    return (LadderRungSpec(scale_label="S3", dim=768, n_layers=12),)
+
+
+@pytest.fixture
+def single_rung(monkeypatch):
+    """Patch _B6_STANDARD_RUNGS to a single S3 rung so the synthetic CLI
+    (with hard-coded `arc_easy:S3` cell key) doesn't produce duplicate
+    cells across merged rungs."""
+    import scripts.b6_run as b6
+    monkeypatch.setattr(b6, "_B6_STANDARD_RUNGS", _b6_recipe_with_single_rung_only())
+
+
+# ============================================================================
+# load_recipes_config
+# ============================================================================
+
+
+def test_load_recipes_minimal(tmp_path):
+    cfg_path = tmp_path / "recipes.json"
+    cfg_path.write_text(json.dumps({
+        "recipes": [
+            {"id": "r1", "checkpoint": "/x/r1.pt",
+             "seed_primary": 0, "tasks": ["arc_easy"]},
+            {"id": "r2", "checkpoint": "/x/r2.pt",
+             "seed_primary": 1, "tasks": ["arc_easy", "piqa"]},
+        ]
+    }))
+    specs = load_recipes_config(cfg_path)
+    assert len(specs) == 2
+    assert specs[0].id == "r1"
+    assert specs[0].seed_primary == 0
+    assert specs[0].seed_retry == SEED_RETRY_OFFSET  # default
+    assert specs[0].tasks == ("arc_easy",)
+    assert specs[0].patch is None
+    assert specs[1].tasks == ("arc_easy", "piqa")
+
+
+def test_load_recipes_with_explicit_retry_seed(tmp_path):
+    cfg_path = tmp_path / "recipes.json"
+    cfg_path.write_text(json.dumps({
+        "recipes": [
+            {"id": "r1", "checkpoint": "x", "seed_primary": 5,
+             "seed_retry": 9999, "tasks": ["arc_easy"]},
+        ]
+    }))
+    specs = load_recipes_config(cfg_path)
+    assert specs[0].seed_retry == 9999
+
+
+def test_load_recipes_with_patch(tmp_path):
+    cfg_path = tmp_path / "recipes.json"
+    cfg_path.write_text(json.dumps({
+        "recipes": [
+            {"id": "r1", "checkpoint": "x", "patch": "/p/r1.patch",
+             "seed_primary": 0, "tasks": ["arc_easy"]},
+        ]
+    }))
+    specs = load_recipes_config(cfg_path)
+    assert specs[0].patch == Path("/p/r1.patch")
+
+
+def test_load_recipes_empty_list_rejected(tmp_path):
+    cfg_path = tmp_path / "bad.json"
+    cfg_path.write_text(json.dumps({"recipes": []}))
+    with pytest.raises(ValueError, match=r"non-empty 'recipes'"):
+        load_recipes_config(cfg_path)
+
+
+def test_load_recipes_missing_field_rejected(tmp_path):
+    cfg_path = tmp_path / "bad.json"
+    cfg_path.write_text(json.dumps({"recipes": [{"id": "r1"}]}))  # no checkpoint
+    with pytest.raises(ValueError, match=r"recipe 0 missing"):
+        load_recipes_config(cfg_path)
+
+
+# ============================================================================
+# estimate_cost
+# ============================================================================
+
+
+def test_estimate_cost_one_hour():
+    assert estimate_cost(3600.0, per_rung_h100_hr_rate=2.0) == pytest.approx(2.0)
+
+
+def test_estimate_cost_zero():
+    assert estimate_cost(0.0) == 0.0
+
+
+# ============================================================================
+# run_one_recipe
+# ============================================================================
+
+
+def test_run_one_recipe_success(tmp_path, single_rung):
+    spec = RecipeSpec(
+        id="r1",
+        checkpoint=tmp_path / "r1.pt",
+        seed_primary=0,
+        seed_retry=1000,
+        tasks=("arc_easy",),
+    )
+    spec.checkpoint.write_bytes(b"")
+    karpa_root = tmp_path / "karpa_root"
+    karpa_root.mkdir()
+    result = run_one_recipe(
+        spec,
+        karpa_root=karpa_root,
+        bundle_dir=tmp_path / "bundle",
+        bundle_sha256="x",
+        output_dir=tmp_path / "out",
+        command_prefix=_TEST_COMMAND_PREFIX,
+        timeout_s_per_rung=15.0,
+    )
+    assert result.status == "success"
+    assert result.seed_used == 0
+    assert result.combined_report_path is not None
+    assert Path(result.combined_report_path).exists()
+
+
+def test_run_one_recipe_retry_on_first_failure(tmp_path, single_rung):
+    """First seed fails (EvalSubprocessError), second seed succeeds.
+
+    Mocks run_ladder_eval directly so we can deterministically fail the
+    first call and succeed the second, regardless of subprocess env
+    timing.
+    """
+    from unittest import mock
+
+    from eval.downstream.runner_subprocess import EvalSubprocessError
+    from eval.downstream.types import HARNESS_VERSION, CellResult, DownstreamReport
+    from eval.hidden_eval import HiddenEvalResult as HER
+    from validator.ladder import LadderEvalResult
+
+    spec = RecipeSpec(
+        id="r1",
+        checkpoint=tmp_path / "r1.pt",
+        seed_primary=0,
+        seed_retry=1000,
+        tasks=("arc_easy",),
+    )
+    spec.checkpoint.write_bytes(b"")
+    (tmp_path / "karpa_root").mkdir()
+
+    call_count = {"n": 0}
+
+    def fake_run_ladder_eval(submission, config, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise EvalSubprocessError(
+                reason="nonzero_exit", exit_code=7,
+                stderr_tail="simulated", argv=[],
+            )
+        # Second call: return a synthetic LadderEvalResult.
+        report = DownstreamReport(
+            harness_version=HARNESS_VERSION,
+            bundle_sha256=config.bundle_sha256,
+            seed=config.seed,
+            total_examples=1,
+            wall_clock_s=0.5,
+            cells={
+                "arc_easy:S3": CellResult(
+                    task="arc_easy", accuracy=0.5,
+                    accuracy_stderr=0.0, n_examples=1, seed=config.seed,
+                )
+            },
+        )
+        return LadderEvalResult(
+            per_rung_reports={"S3": report},
+            combined_report=report,
+            hidden_eval=HER(
+                val_bpb=0.0, benchmark_accuracy=0.0, tokens_evaluated=0,
+                benchmark_examples=0, eval_set_hash="", downstream=report,
+            ),
+        )
+
+    with mock.patch("scripts.b6_run.run_ladder_eval", side_effect=fake_run_ladder_eval):
+        result = run_one_recipe(
+            spec,
+            karpa_root=tmp_path / "karpa_root",
+            bundle_dir=tmp_path / "bundle",
+            bundle_sha256="x",
+            output_dir=tmp_path / "out",
+            command_prefix=_TEST_COMMAND_PREFIX,
+            timeout_s_per_rung=15.0,
+        )
+    assert result.status == "success"
+    assert result.seed_used == 1000  # retry seed
+    assert len(result.abort_reasons) == 1
+    assert "attempt_1_seed_0" in result.abort_reasons[0]
+    assert call_count["n"] == 2
+
+
+def test_run_one_recipe_both_seeds_fail(tmp_path, monkeypatch, single_rung):
+    monkeypatch.setenv("KARPA_TEST_RUNNER_MODE", "nonzero")
+    monkeypatch.setenv("KARPA_TEST_RUNNER_EXIT_CODE", "9")
+    spec = RecipeSpec(
+        id="r_fail",
+        checkpoint=tmp_path / "r.pt",
+        seed_primary=0,
+        seed_retry=1000,
+        tasks=("arc_easy",),
+    )
+    spec.checkpoint.write_bytes(b"")
+    (tmp_path / "karpa_root").mkdir()
+    result = run_one_recipe(
+        spec,
+        karpa_root=tmp_path / "karpa_root",
+        bundle_dir=tmp_path / "bundle",
+        bundle_sha256="x",
+        output_dir=tmp_path / "out",
+        command_prefix=_TEST_COMMAND_PREFIX,
+        timeout_s_per_rung=15.0,
+    )
+    assert result.status == "aborted"
+    assert result.combined_report_path is None
+    assert len(result.abort_reasons) == 2
+    abort_path = tmp_path / "out" / f"abort_log_{spec.id}.txt"
+    assert abort_path.exists()
+
+
+# ============================================================================
+# run_b6
+# ============================================================================
+
+
+def _make_specs(n: int, tmp_path: Path) -> list[RecipeSpec]:
+    specs = []
+    for i in range(n):
+        ckpt = tmp_path / f"r{i}.pt"
+        ckpt.write_bytes(b"")
+        specs.append(RecipeSpec(
+            id=f"r{i}",
+            checkpoint=ckpt,
+            seed_primary=i,
+            seed_retry=i + 1000,
+            tasks=("arc_easy",),
+        ))
+    return specs
+
+
+def test_run_b6_summary_counts_succeeded(tmp_path, single_rung):
+    specs = _make_specs(3, tmp_path)
+    (tmp_path / "karpa_root").mkdir()
+    summary = run_b6(
+        specs,
+        karpa_root=tmp_path / "karpa_root",
+        bundle_dir=tmp_path / "bundle",
+        bundle_sha256="x",
+        output_dir=tmp_path / "run_out",
+        command_prefix=_TEST_COMMAND_PREFIX,
+        timeout_s_per_rung=15.0,
+    )
+    assert summary.n_recipes_requested == 3
+    assert summary.n_recipes_succeeded == 3
+    assert summary.n_recipes_aborted == 0
+    result_json = json.loads((tmp_path / "run_out" / "result.json").read_text())
+    assert result_json["n_recipes_succeeded"] == 3
+
+
+def test_run_b6_budget_guard_short_circuits_remaining(tmp_path, single_rung):
+    """A $0 budget cap means even the first recipe is allowed (cumulative
+    starts at 0), but all subsequent ones get budget_exhausted once the
+    first one's cost is added."""
+    specs = _make_specs(3, tmp_path)
+    (tmp_path / "karpa_root").mkdir()
+    summary = run_b6(
+        specs,
+        karpa_root=tmp_path / "karpa_root",
+        bundle_dir=tmp_path / "bundle",
+        bundle_sha256="x",
+        output_dir=tmp_path / "run_out",
+        budget_cap_usd=0.0001,  # essentially zero
+        command_prefix=_TEST_COMMAND_PREFIX,
+        timeout_s_per_rung=15.0,
+    )
+    # Recipe 0 runs (cumulative starts at 0 which is NOT >= cap).
+    # Recipes 1 and 2 get short-circuited iff recipe 0 produced any cost.
+    n_short = summary.n_recipes_budget_exhausted
+    assert n_short >= 1
+
+
+def test_run_b6_default_budget_cap_constant():
+    assert DEFAULT_BUDGET_CAP_USD == 1200.0
+
+
+def test_run_b6_default_n_recipes_constant():
+    assert DEFAULT_N_RECIPES == 12
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+
+def test_cli_required_args(tmp_path):
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+
+def test_cli_minimal(tmp_path):
+    parser = _build_parser()
+    args = parser.parse_args([
+        "--karpa-root", str(tmp_path),
+        "--bundle-dir", str(tmp_path / "bundle"),
+        "--bundle-sha-sha256", "x",
+        "--recipes-config", str(tmp_path / "cfg.json"),
+        "--output", str(tmp_path / "out"),
+    ])
+    assert args.budget_cap_usd == DEFAULT_BUDGET_CAP_USD


### PR DESCRIPTION
- scripts/b6_run.py: 12-recipe orchestrator with seed-retry (s_i + 1000), $1200 budget guard (short-circuits remaining recipes on cap), per-recipe abort logs, runs/<id>/result.json + per_recipe/<id>.json layout
- scripts/analyze_b6_rho.py: FROZEN constants — PINNED_REFERENCES={olmo_2_1b_step_30b, pythia_1_4b, tinyllama_1_1b_3t}, PASS gate (lower 95% CI > 0.5 AND OLMo point > 0.6), BOOTSTRAP_SEED=0, N_RESAMPLES=10000; manual Spearman + average-rank + Pearson (no scipy dep); deterministic
- 44 new tests. Full suite: 675/675.