### PR TITLE
OPS-1: DCLM downloader + HF asset cache + refs.json builder

### DIFF
--- a/scripts/build_refs_from_published.py
+++ b/scripts/build_refs_from_published.py
@@ -1,0 +1,122 @@
+"""Build `refs.json` for `analyze_b6_rho.py` from a published-scores file.
+
+The B6 protocol locks the reference set to
+`{olmo_2_1b_step_30b, pythia_1_4b, tinyllama_1_1b_3t}`. For each of the
+N=12 recipes, we need to assemble a `{recipe_id -> {ref_name -> score}}`
+mapping that `analyze_b6_rho.py` consumes.
+
+Two paths supported, mirroring the pre-registration language:
+  * **Published path (default):** the operator supplies a YAML/JSON
+    `published_scores.json` mapping `recipe_id -> {ref_name -> score}`
+    directly. This script just validates the shape, fills missing
+    references with `NaN` (which `analyze_b6_rho` drops per-reference),
+    and writes the result to `refs.json`.
+  * **Internal-eval path:** the operator runs each reference checkpoint
+    through their own eval tooling (lm-eval-harness, etc.) and
+    aggregates per-recipe scores into the same `published_scores.json`
+    shape. This script's contract is unchanged.
+
+USAGE:
+    python scripts/build_refs_from_published.py \\
+        --recipes-config eval/private/b6/b6_recipes.json \\
+        --published-scores eval/private/b6/published_scores.json \\
+        --output runs/b6_<id>/refs.json
+
+INPUTS:
+  recipes-config: same schema as scripts/b6_run.py — used to determine
+    the canonical recipe id ordering.
+  published-scores: JSON of shape
+    {
+      "r1": {"olmo_2_1b_step_30b": 0.62, "pythia_1_4b": 0.58, ...},
+      "r2": {...},
+      ...
+    }
+    Missing entries become NaN (analyze_b6_rho drops them per-reference).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.analyze_b6_rho import PINNED_REFERENCES  # noqa: E402
+from scripts.b6_run import load_recipes_config  # noqa: E402
+
+
+def build_refs(
+    recipe_ids: list[str],
+    published_scores: dict[str, dict[str, float]],
+) -> dict:
+    """Assemble the refs.json content.
+
+    For each recipe in `recipe_ids`, emit a sub-dict mapping each pinned
+    reference name to its float score (or NaN if missing). Returns the
+    full dict (caller writes JSON).
+    """
+    out: dict[str, dict[str, float]] = {}
+    for recipe_id in recipe_ids:
+        sub = published_scores.get(recipe_id, {})
+        out[recipe_id] = {}
+        for ref_name in PINNED_REFERENCES:
+            val = sub.get(ref_name)
+            if val is None:
+                out[recipe_id][ref_name] = float("nan")
+                continue
+            try:
+                f = float(val)
+            except (TypeError, ValueError):
+                out[recipe_id][ref_name] = float("nan")
+                continue
+            out[recipe_id][ref_name] = f
+    return out
+
+
+def _summary(refs: dict) -> dict:
+    """Coverage report: how many recipes have each reference."""
+    counts = {ref: 0 for ref in PINNED_REFERENCES}
+    missing: dict[str, list[str]] = {ref: [] for ref in PINNED_REFERENCES}
+    for recipe_id, ref_map in refs.items():
+        for ref_name in PINNED_REFERENCES:
+            v = ref_map.get(ref_name, float("nan"))
+            if isinstance(v, float) and math.isnan(v):
+                missing[ref_name].append(recipe_id)
+            else:
+                counts[ref_name] += 1
+    return {
+        "n_recipes": len(refs),
+        "coverage_per_reference": counts,
+        "missing_per_reference": missing,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="scripts.build_refs_from_published")
+    p.add_argument("--recipes-config", required=True, type=Path)
+    p.add_argument("--published-scores", required=True, type=Path)
+    p.add_argument("--output", required=True, type=Path)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        recipes = load_recipes_config(args.recipes_config)
+        published = json.loads(args.published_scores.read_text())
+    except Exception as e:
+        print(f"build_refs FAILED: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+    recipe_ids = [r.id for r in recipes]
+    refs = build_refs(recipe_ids, published)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(refs, indent=2, sort_keys=True))
+    summary = _summary(refs)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cache_hf_assets.py
+++ b/scripts/cache_hf_assets.py
@@ -1,0 +1,360 @@
+"""Cache + re-key the 4 private-hard HF datasets to canonical Karpa JSONL.
+
+Pulls each of the 4 datasets in `eval/downstream/private_hard.HF_DATASET_IDS`
+from HuggingFace Hub via the `datasets` library, iterates the rows, and
+re-keys each into the canonical Karpa schema that
+`private_hard.load_task_examples` consumes:
+
+  * MC tasks (arc_challenge_hard, tiny_arc, tiny_mmlu):
+      {"id": str, "query": str, "choices": [str, ...], "gold": int}
+  * Schema tasks (winogrande_hard):
+      {"id": str, "contexts": [str, ...], "continuations": [str, ...],
+       "gold": int}
+
+Each per-task JSONL is written to
+`eval/private/downstream_pool/private_hard/{task_name}.jsonl`. A
+manifest file `manifest.json` carries the HF revision SHA for each
+dataset so the operator can re-pull deterministically later.
+
+USAGE:
+    pip install datasets huggingface_hub
+    python scripts/cache_hf_assets.py \\
+        [--output-dir eval/private/downstream_pool/private_hard] \\
+        [--task arc_challenge_hard ... --task tiny_mmlu]  # subset, default = all 4
+        [--hf-token <token>]   # optional, for gated datasets
+        [--revision <sha>]     # pin a specific revision per task (advanced)
+
+OUTPUTS:
+  {output_dir}/
+    arc_challenge_hard.jsonl    canonical MC schema, ordered by upstream id
+    winogrande_hard.jsonl       canonical schema (variants) schema
+    tiny_arc.jsonl              canonical MC
+    tiny_mmlu.jsonl             canonical MC
+    manifest.json               {task -> {hf_id, hf_config, hf_revision, row_count}}
+
+Notes on per-task field mapping (the operator should re-verify against the
+upstream dataset card if HF changes the schema):
+
+  * arc_challenge_hard (allenai/ai2_arc / ARC-Challenge):
+      `question`     -> query
+      `choices.text` -> choices  (the `choices` column is a dict
+                                  {"text": [...], "label": [...]})
+      `answerKey`    -> gold (after mapping the label letter to its index
+                              in `choices.label`)
+  * winogrande_hard (allenai/winogrande / winogrande_xl):
+      `sentence`     -> two variants (contexts/continuations split on the
+                        underscore placeholder per the wino convention)
+      `option1` / `option2` -> insert into each context to produce 2
+                                continuations
+      `answer`        -> 0 if option1, 1 if option2
+  * tiny_arc + tiny_mmlu (tinyBenchmarks/tinyArc, tinyBenchmarks/tinyMMLU):
+      tinyBenchmarks ships canonical-friendly schemas already. We accept
+      MMLU-style 4-choice items keyed by `question` / `choices` / `answer`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from eval.downstream.private_hard import (  # noqa: E402
+    HF_DATASET_IDS,
+    PRIVATE_HARD_TASK_SPECS,
+    PRIVATE_HARD_TASKS,
+)
+
+
+def _load_hf(
+    hf_id: str,
+    hf_config: str | None,
+    *,
+    hf_token: str | None,
+    revision: str | None,
+    split: str = "validation",
+):
+    """Load one HF dataset split. Network-required; raises ImportError if
+    the `datasets` package isn't installed (operator: `pip install datasets`).
+    """
+    from datasets import load_dataset
+    kwargs: dict = {"split": split}
+    if hf_config is not None:
+        kwargs["name"] = hf_config
+    if hf_token is not None:
+        kwargs["token"] = hf_token
+    if revision is not None:
+        kwargs["revision"] = revision
+    return load_dataset(hf_id, **kwargs)
+
+
+# ----------------------------------------------------------------------------
+# Per-task converters
+# ----------------------------------------------------------------------------
+
+
+def convert_arc_row(row: dict) -> dict | None:
+    """allenai/ai2_arc / ARC-Challenge → canonical MC row.
+
+    Returns None on a malformed row (caller skips). ARC's choices field
+    is `{"text": [...], "label": [...]}`; the answerKey is the LABEL of
+    the correct choice (e.g. "A", "B", "C", "D" or "1", "2", ...).
+    """
+    try:
+        item_id = str(row["id"])
+        query = str(row["question"])
+        ch_field = row["choices"]
+        if isinstance(ch_field, dict):
+            choices = list(ch_field.get("text", []))
+            labels = list(ch_field.get("label", []))
+        elif isinstance(ch_field, list):
+            # Some HF revisions ship choices as a list of dicts.
+            choices = [str(c.get("text", c)) for c in ch_field]
+            labels = [str(c.get("label", "")) for c in ch_field]
+        else:
+            return None
+        if not choices or len(choices) != len(labels):
+            return None
+        answer_key = str(row["answerKey"]).strip()
+        try:
+            gold = labels.index(answer_key)
+        except ValueError:
+            return None
+        return {"id": item_id, "query": query,
+                "choices": [str(c) for c in choices], "gold": gold}
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def convert_winogrande_row(row: dict) -> dict | None:
+    """allenai/winogrande / winogrande_xl → canonical schema row.
+
+    Winogrande sentences contain a single `_` placeholder. We construct
+    TWO variants by substituting option1 and option2 in, and split the
+    resulting sentence at the placeholder location into context +
+    continuation (the continuation is everything from the option onward
+    to the end of the sentence).
+    """
+    try:
+        sentence = str(row["sentence"])
+        if "_" not in sentence:
+            return None
+        prefix, _, suffix = sentence.partition("_")
+        option1 = str(row["option1"])
+        option2 = str(row["option2"])
+        answer = str(row["answer"]).strip()
+        if answer not in ("1", "2"):
+            return None
+        gold = 0 if answer == "1" else 1
+        # Two variants, each with prefix as context and "{option}{suffix}"
+        # as continuation. This matches the schema_score convention.
+        return {
+            "id": str(row.get("qID", row.get("id", ""))),
+            "contexts": [prefix, prefix],
+            "continuations": [option1 + suffix, option2 + suffix],
+            "gold": gold,
+        }
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def convert_tinybench_mc_row(row: dict) -> dict | None:
+    """tinyBenchmarks/tinyArc and tinyMMLU → canonical MC row.
+
+    Both tinyBenchmarks variants ship with `question` / `choices` /
+    `answer` fields; `choices` is a list of strings and `answer` is the
+    integer index of the correct choice (0-based). `id` is the upstream
+    item id or `input_id` field.
+    """
+    try:
+        item_id = str(
+            row.get("id") or row.get("input_id") or row.get("item_id") or ""
+        )
+        query = str(row["question"])
+        choices_field = row["choices"]
+        if isinstance(choices_field, dict):
+            choices = list(choices_field.get("text", []))
+        else:
+            choices = list(choices_field)
+        choices = [str(c) for c in choices]
+        if not choices:
+            return None
+        gold = int(row.get("answer", row.get("gold", -1)))
+        if not 0 <= gold < len(choices):
+            return None
+        return {"id": item_id, "query": query, "choices": choices, "gold": gold}
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+# Per-task converter dispatch table. The operator can swap converters here
+# if HF rotates a schema.
+TASK_CONVERTERS = {
+    "arc_challenge_hard": convert_arc_row,
+    "winogrande_hard": convert_winogrande_row,
+    "tiny_arc": convert_tinybench_mc_row,
+    "tiny_mmlu": convert_tinybench_mc_row,
+}
+
+
+# ----------------------------------------------------------------------------
+# Main loop
+# ----------------------------------------------------------------------------
+
+
+def cache_one_task(
+    task_name: str,
+    *,
+    output_dir: Path,
+    hf_token: str | None = None,
+    revision: str | None = None,
+    split: str = "validation",
+) -> dict:
+    """Pull + re-key one private-hard task. Returns a manifest entry.
+
+    Skips rows that fail per-row conversion (logged in the manifest as
+    `n_rows_skipped`). The output JSONL is written atomically via a
+    `.tmp` rename so a crashed pull never leaves a half-written file.
+    """
+    if task_name not in HF_DATASET_IDS:
+        raise ValueError(
+            f"unknown private-hard task {task_name!r}; expected one of "
+            f"{sorted(PRIVATE_HARD_TASKS)}"
+        )
+    hf_id, hf_config = HF_DATASET_IDS[task_name]
+    converter = TASK_CONVERTERS[task_name]
+    ds = _load_hf(hf_id, hf_config, hf_token=hf_token,
+                  revision=revision, split=split)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / f"{task_name}.jsonl"
+    tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+
+    n_in = 0
+    n_out = 0
+    n_skipped = 0
+    with tmp_path.open("w") as f:
+        for row in ds:
+            n_in += 1
+            converted = converter(row)
+            if converted is None:
+                n_skipped += 1
+                continue
+            f.write(json.dumps(converted) + "\n")
+            n_out += 1
+    tmp_path.replace(out_path)
+
+    # Best-effort revision pin: some HF versions expose `_info.version`
+    # or expose nothing; fall back to a placeholder if unavailable.
+    pinned_revision = revision or _best_effort_revision(ds)
+
+    return {
+        "task": task_name,
+        "hf_id": hf_id,
+        "hf_config": hf_config,
+        "hf_revision_pinned": pinned_revision,
+        "mode": PRIVATE_HARD_TASK_SPECS[task_name].mode,
+        "n_rows_in": n_in,
+        "n_rows_written": n_out,
+        "n_rows_skipped": n_skipped,
+        "output_path": str(out_path),
+    }
+
+
+def _best_effort_revision(ds) -> str:
+    """Try a few attributes to recover the HF revision SHA. Returns
+    "unknown" if nothing usable surfaces."""
+    info = getattr(ds, "info", None)
+    if info is not None:
+        for attr in ("version", "revision", "dataset_version"):
+            v = getattr(info, attr, None)
+            if v:
+                return str(v)
+    return "unknown"
+
+
+def cache_all(
+    *,
+    output_dir: Path,
+    tasks: tuple[str, ...] | None = None,
+    hf_token: str | None = None,
+    revisions: dict[str, str] | None = None,
+    split: str = "validation",
+) -> dict:
+    """Drive cache_one_task across the requested tasks. Writes the
+    manifest. Returns the manifest dict."""
+    tasks = tasks or PRIVATE_HARD_TASKS
+    revisions = revisions or {}
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    entries: list[dict] = []
+    for task in tasks:
+        entries.append(cache_one_task(
+            task,
+            output_dir=output_dir,
+            hf_token=hf_token,
+            revision=revisions.get(task),
+            split=split,
+        ))
+
+    manifest = {
+        "_meta": "karpa-private-hard-cache-manifest",
+        "version": "v1",
+        "tasks": entries,
+    }
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True)
+    )
+    return manifest
+
+
+# ----------------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="scripts.cache_hf_assets")
+    p.add_argument("--output-dir", type=Path,
+                   default=Path("eval/private/downstream_pool/private_hard"))
+    p.add_argument("--task", action="append", dest="tasks", default=None,
+                   help="repeat for each task; default = all 4 private-hard tasks")
+    p.add_argument("--hf-token", default=None)
+    p.add_argument("--revision", action="append", default=None,
+                   help="pin a specific HF revision in the form task=<sha>; "
+                        "repeat for multiple tasks")
+    p.add_argument("--split", default="validation",
+                   help="HF dataset split to pull (default: validation)")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    revisions: dict[str, str] = {}
+    for entry in (args.revision or []):
+        if "=" not in entry:
+            print(f"ERROR: --revision must be task=<sha>, got {entry!r}",
+                  file=sys.stderr)
+            return 2
+        task, sha = entry.split("=", 1)
+        revisions[task.strip()] = sha.strip()
+    try:
+        manifest = cache_all(
+            output_dir=args.output_dir,
+            tasks=tuple(args.tasks) if args.tasks else None,
+            hf_token=args.hf_token,
+            revisions=revisions,
+            split=args.split,
+        )
+    except Exception as e:
+        print(f"cache_hf_assets FAILED: {type(e).__name__}: {e}",
+              file=sys.stderr)
+        return 1
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/download_dclm_bundle.py
+++ b/scripts/download_dclm_bundle.py
@@ -1,0 +1,166 @@
+"""Download + SHA-verify + unzip the DCLM CORE-22 eval bundle.
+
+One-time operational step (per DEFERRED.md B1-D2). Pulls the bundle from
+the pinned S3 URL (`eval/downstream/core22.py::DCLM_EVAL_BUNDLE_URL`),
+verifies the SHA256 (if an expected digest is supplied), and unzips to
+the local mirror at `eval/private/downstream_pool/bundle_v1/`.
+
+After running this script, **manually** update the
+`DCLM_EVAL_BUNDLE_SHA256` constant in `eval/downstream/core22.py` with
+the digest printed below. A one-line PR closes B1-D2's last open item.
+
+USAGE:
+    python scripts/download_dclm_bundle.py \\
+        [--url <override>] \\
+        [--output-dir eval/private/downstream_pool/bundle_v1] \\
+        [--expected-sha <hex>] \\
+        [--keep-zip]
+
+OUTPUTS:
+  eval/private/downstream_pool/bundle_v1/
+    eval_bundle.zip          (kept iff --keep-zip)
+    SHA256SUM                manifest with the digest + url + timestamp
+    <task>.jsonl, ...        unzipped task files (DCLM-native schema)
+
+The downloader does NOT re-key the per-task JSONLs into the canonical
+Karpa schema — that's `cache_hf_assets.py`'s and a follow-up adapter's
+concern. The bundle here is the raw upstream artifact.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+import time
+import urllib.request
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from eval.downstream.core22 import DCLM_EVAL_BUNDLE_URL  # noqa: E402
+
+_CHUNK = 1 << 16  # 64KB streaming chunks for both download and hash
+
+
+def _download(url: str, dest: Path) -> None:
+    """Stream-download `url` to `dest`. Overwrites if present."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with urllib.request.urlopen(url, timeout=120) as resp, dest.open("wb") as f:
+        shutil.copyfileobj(resp, f)
+
+
+def sha256_of_file(path: Path) -> str:
+    """Lowercase hex SHA256 of a file, chunked to keep memory bounded."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(_CHUNK), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _unzip(zip_path: Path, target_dir: Path) -> list[str]:
+    """Unzip `zip_path` into `target_dir`. Returns the list of extracted
+    member names for the operator's discovery report."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+        zf.extractall(target_dir)
+    return names
+
+
+def _write_manifest(
+    manifest_path: Path,
+    *,
+    url: str,
+    sha256: str,
+    extracted_count: int,
+) -> None:
+    """Write a small JSON manifest that the SHA-pin commit references."""
+    manifest_path.write_text(json.dumps({
+        "_meta": "karpa-dclm-bundle-manifest",
+        "url": url,
+        "sha256": sha256,
+        "extracted_member_count": extracted_count,
+        "downloaded_at_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }, indent=2, sort_keys=True))
+
+
+def download_and_verify(
+    *,
+    url: str,
+    output_dir: Path,
+    expected_sha: str | None = None,
+    keep_zip: bool = False,
+) -> dict:
+    """Run the whole pipeline. Returns the manifest dict."""
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = output_dir / "eval_bundle.zip"
+
+    _download(url, zip_path)
+    actual_sha = sha256_of_file(zip_path)
+
+    if expected_sha is not None and expected_sha.lower() != actual_sha:
+        raise ValueError(
+            f"SHA mismatch: expected {expected_sha}, got {actual_sha}. "
+            "Either the upstream bundle rotated or the network corrupted "
+            "the download. Re-pull and re-verify before proceeding."
+        )
+
+    member_names = _unzip(zip_path, output_dir)
+    manifest_path = output_dir / "SHA256SUM"
+    _write_manifest(
+        manifest_path, url=url, sha256=actual_sha,
+        extracted_count=len(member_names),
+    )
+
+    if not keep_zip:
+        zip_path.unlink()
+
+    return {
+        "url": url,
+        "sha256": actual_sha,
+        "extracted_count": len(member_names),
+        "manifest_path": str(manifest_path),
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="scripts.download_dclm_bundle")
+    p.add_argument("--url", default=DCLM_EVAL_BUNDLE_URL)
+    p.add_argument("--output-dir", type=Path,
+                   default=Path("eval/private/downstream_pool/bundle_v1"))
+    p.add_argument("--expected-sha", default=None,
+                   help="If supplied, abort on SHA mismatch.")
+    p.add_argument("--keep-zip", action="store_true",
+                   help="Retain eval_bundle.zip after unzip (default: delete).")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = download_and_verify(
+            url=args.url,
+            output_dir=args.output_dir,
+            expected_sha=args.expected_sha,
+            keep_zip=args.keep_zip,
+        )
+    except Exception as e:
+        print(f"download_dclm_bundle FAILED: {type(e).__name__}: {e}",
+              file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    print(
+        f"\nNext step: update DCLM_EVAL_BUNDLE_SHA256 in "
+        f"eval/downstream/core22.py with:\n  \"{result['sha256']}\"\n",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_build_refs_from_published.py
+++ b/tests/test_build_refs_from_published.py
@@ -1,0 +1,174 @@
+"""Tests for scripts/build_refs_from_published.py.
+
+Pure data transformation — no mocks. Verifies the shape of the
+output refs.json + missing-reference handling + summary coverage report.
+"""
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from scripts.analyze_b6_rho import PINNED_REFERENCES
+from scripts.build_refs_from_published import _summary, build_refs, main
+
+
+def _recipes_config_with_ids(ids: list[str]) -> dict:
+    return {
+        "recipes": [
+            {"id": rid, "checkpoint": f"/x/{rid}.pt",
+             "seed_primary": i, "tasks": ["arc_easy"]}
+            for i, rid in enumerate(ids)
+        ]
+    }
+
+
+# ============================================================================
+# build_refs
+# ============================================================================
+
+
+def test_build_refs_happy_path():
+    recipe_ids = ["r1", "r2", "r3"]
+    published = {
+        "r1": {ref: 0.5 for ref in PINNED_REFERENCES},
+        "r2": {ref: 0.6 for ref in PINNED_REFERENCES},
+        "r3": {ref: 0.7 for ref in PINNED_REFERENCES},
+    }
+    refs = build_refs(recipe_ids, published)
+    assert set(refs.keys()) == {"r1", "r2", "r3"}
+    for recipe_id in recipe_ids:
+        assert set(refs[recipe_id].keys()) == set(PINNED_REFERENCES)
+
+
+def test_build_refs_missing_recipe_yields_all_nan():
+    refs = build_refs(["r1", "r2"], {"r1": {ref: 0.5 for ref in PINNED_REFERENCES}})
+    assert refs["r1"]["olmo_2_1b_step_30b"] == 0.5
+    for ref in PINNED_REFERENCES:
+        assert math.isnan(refs["r2"][ref])
+
+
+def test_build_refs_missing_reference_in_recipe():
+    refs = build_refs(["r1"], {"r1": {"olmo_2_1b_step_30b": 0.6}})
+    assert refs["r1"]["olmo_2_1b_step_30b"] == 0.6
+    assert math.isnan(refs["r1"]["pythia_1_4b"])
+    assert math.isnan(refs["r1"]["tinyllama_1_1b_3t"])
+
+
+def test_build_refs_non_numeric_score_becomes_nan():
+    refs = build_refs(["r1"], {"r1": {"olmo_2_1b_step_30b": "not_a_number"}})
+    assert math.isnan(refs["r1"]["olmo_2_1b_step_30b"])
+
+
+def test_build_refs_int_score_coerced_to_float():
+    refs = build_refs(["r1"], {"r1": {"olmo_2_1b_step_30b": 1}})
+    assert refs["r1"]["olmo_2_1b_step_30b"] == 1.0
+    assert isinstance(refs["r1"]["olmo_2_1b_step_30b"], float)
+
+
+def test_build_refs_preserves_recipe_order():
+    recipe_ids = ["r3", "r1", "r2"]  # explicit non-sorted
+    refs = build_refs(recipe_ids, {})
+    assert list(refs.keys()) == recipe_ids
+
+
+# ============================================================================
+# _summary
+# ============================================================================
+
+
+def test_summary_full_coverage():
+    refs = {
+        "r1": {ref: 0.5 for ref in PINNED_REFERENCES},
+        "r2": {ref: 0.6 for ref in PINNED_REFERENCES},
+    }
+    s = _summary(refs)
+    assert s["n_recipes"] == 2
+    for ref in PINNED_REFERENCES:
+        assert s["coverage_per_reference"][ref] == 2
+        assert s["missing_per_reference"][ref] == []
+
+
+def test_summary_partial_coverage_lists_missing():
+    refs = {
+        "r1": {"olmo_2_1b_step_30b": 0.5,
+               "pythia_1_4b": float("nan"),
+               "tinyllama_1_1b_3t": 0.4},
+        "r2": {"olmo_2_1b_step_30b": float("nan"),
+               "pythia_1_4b": 0.55,
+               "tinyllama_1_1b_3t": 0.45},
+    }
+    s = _summary(refs)
+    assert s["coverage_per_reference"]["olmo_2_1b_step_30b"] == 1
+    assert s["missing_per_reference"]["olmo_2_1b_step_30b"] == ["r2"]
+    assert s["missing_per_reference"]["pythia_1_4b"] == ["r1"]
+
+
+# ============================================================================
+# main (CLI)
+# ============================================================================
+
+
+def test_main_happy_path(tmp_path):
+    recipes_path = tmp_path / "recipes.json"
+    recipes_path.write_text(json.dumps(_recipes_config_with_ids(["r1", "r2"])))
+    pub_path = tmp_path / "pub.json"
+    pub_path.write_text(json.dumps({
+        "r1": {ref: 0.5 for ref in PINNED_REFERENCES},
+        "r2": {ref: 0.6 for ref in PINNED_REFERENCES},
+    }))
+    out_path = tmp_path / "refs.json"
+    rc = main([
+        "--recipes-config", str(recipes_path),
+        "--published-scores", str(pub_path),
+        "--output", str(out_path),
+    ])
+    assert rc == 0
+    assert out_path.exists()
+    on_disk = json.loads(out_path.read_text())
+    assert set(on_disk.keys()) == {"r1", "r2"}
+
+
+def test_main_creates_parent_dir(tmp_path):
+    recipes_path = tmp_path / "recipes.json"
+    recipes_path.write_text(json.dumps(_recipes_config_with_ids(["r1"])))
+    pub_path = tmp_path / "pub.json"
+    pub_path.write_text(json.dumps({"r1": {}}))
+    out_path = tmp_path / "deep" / "nested" / "refs.json"
+    rc = main([
+        "--recipes-config", str(recipes_path),
+        "--published-scores", str(pub_path),
+        "--output", str(out_path),
+    ])
+    assert rc == 0
+    assert out_path.exists()
+
+
+def test_main_bad_recipes_config_returns_one(tmp_path):
+    pub_path = tmp_path / "pub.json"
+    pub_path.write_text("{}")
+    out_path = tmp_path / "refs.json"
+    rc = main([
+        "--recipes-config", str(tmp_path / "nonexistent.json"),
+        "--published-scores", str(pub_path),
+        "--output", str(out_path),
+    ])
+    assert rc == 1
+
+
+def test_main_bad_published_json_returns_one(tmp_path):
+    recipes_path = tmp_path / "recipes.json"
+    recipes_path.write_text(json.dumps(_recipes_config_with_ids(["r1"])))
+    pub_path = tmp_path / "pub.json"
+    pub_path.write_text("{not valid json")
+    out_path = tmp_path / "refs.json"
+    rc = main([
+        "--recipes-config", str(recipes_path),
+        "--published-scores", str(pub_path),
+        "--output", str(out_path),
+    ])
+    assert rc == 1

--- a/tests/test_cache_hf_assets.py
+++ b/tests/test_cache_hf_assets.py
@@ -1,0 +1,290 @@
+"""Tests for scripts/cache_hf_assets.py.
+
+The `datasets` HF library is heavyweight + network-required. All HF
+calls are mocked. We verify:
+  * Per-task row converters produce canonical-schema dicts
+  * cache_one_task writes JSONL atomically + correct manifest entry
+  * Unknown task name rejected
+  * CLI arg parsing including --revision=task=<sha> form
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from scripts.cache_hf_assets import (
+    TASK_CONVERTERS,
+    _build_parser,
+    cache_all,
+    cache_one_task,
+    convert_arc_row,
+    convert_tinybench_mc_row,
+    convert_winogrande_row,
+)
+
+# ============================================================================
+# convert_arc_row
+# ============================================================================
+
+
+class TestConvertArcRow:
+    def test_canonical_arc_dict_choices(self):
+        row = {
+            "id": "ARC-1",
+            "question": "Why does X happen?",
+            "choices": {"text": ["a", "b", "c", "d"], "label": ["A", "B", "C", "D"]},
+            "answerKey": "C",
+        }
+        out = convert_arc_row(row)
+        assert out == {"id": "ARC-1", "query": "Why does X happen?",
+                       "choices": ["a", "b", "c", "d"], "gold": 2}
+
+    def test_numeric_label(self):
+        row = {
+            "id": "ARC-2",
+            "question": "Q",
+            "choices": {"text": ["x", "y"], "label": ["1", "2"]},
+            "answerKey": "2",
+        }
+        out = convert_arc_row(row)
+        assert out["gold"] == 1
+
+    def test_unknown_answer_key_returns_none(self):
+        row = {
+            "id": "x",
+            "question": "Q",
+            "choices": {"text": ["a", "b"], "label": ["A", "B"]},
+            "answerKey": "Z",
+        }
+        assert convert_arc_row(row) is None
+
+    def test_choices_as_list_of_dicts(self):
+        """Some HF revisions ship choices as a list of {text, label} dicts."""
+        row = {
+            "id": "x",
+            "question": "Q",
+            "choices": [
+                {"text": "alpha", "label": "A"},
+                {"text": "beta", "label": "B"},
+            ],
+            "answerKey": "B",
+        }
+        out = convert_arc_row(row)
+        assert out["choices"] == ["alpha", "beta"]
+        assert out["gold"] == 1
+
+    def test_missing_field_returns_none(self):
+        assert convert_arc_row({"id": "x"}) is None
+
+
+# ============================================================================
+# convert_winogrande_row
+# ============================================================================
+
+
+class TestConvertWinogrande:
+    def test_basic_two_variants(self):
+        row = {
+            "qID": "wino-1",
+            "sentence": "The trophy didn't fit in the suitcase because _ was too small.",
+            "option1": "the trophy",
+            "option2": "the suitcase",
+            "answer": "2",
+        }
+        out = convert_winogrande_row(row)
+        assert out is not None
+        assert out["id"] == "wino-1"
+        assert out["gold"] == 1
+        # Both contexts identical (the prefix)
+        assert out["contexts"][0] == out["contexts"][1]
+        assert out["continuations"][0].startswith("the trophy")
+        assert out["continuations"][1].startswith("the suitcase")
+
+    def test_missing_underscore_returns_none(self):
+        row = {
+            "qID": "wino-bad",
+            "sentence": "no placeholder here",
+            "option1": "a", "option2": "b", "answer": "1",
+        }
+        assert convert_winogrande_row(row) is None
+
+    def test_bad_answer_returns_none(self):
+        row = {
+            "qID": "wino-bad-ans",
+            "sentence": "X _ Y", "option1": "a", "option2": "b", "answer": "3",
+        }
+        assert convert_winogrande_row(row) is None
+
+
+# ============================================================================
+# convert_tinybench_mc_row
+# ============================================================================
+
+
+class TestConvertTinybenchMc:
+    def test_canonical_mc(self):
+        row = {
+            "id": "tiny-1",
+            "question": "Q?",
+            "choices": ["a", "b", "c", "d"],
+            "answer": 2,
+        }
+        out = convert_tinybench_mc_row(row)
+        assert out == {"id": "tiny-1", "query": "Q?",
+                       "choices": ["a", "b", "c", "d"], "gold": 2}
+
+    def test_dict_choices(self):
+        row = {
+            "id": "tiny-1",
+            "question": "Q?",
+            "choices": {"text": ["a", "b"]},
+            "answer": 0,
+        }
+        out = convert_tinybench_mc_row(row)
+        assert out["choices"] == ["a", "b"]
+        assert out["gold"] == 0
+
+    def test_out_of_range_gold_returns_none(self):
+        row = {"id": "x", "question": "Q?", "choices": ["a", "b"], "answer": 5}
+        assert convert_tinybench_mc_row(row) is None
+
+    def test_input_id_fallback(self):
+        row = {"input_id": "ii-1", "question": "Q", "choices": ["a", "b"], "answer": 0}
+        out = convert_tinybench_mc_row(row)
+        assert out["id"] == "ii-1"
+
+
+# ============================================================================
+# cache_one_task — mocked HF
+# ============================================================================
+
+
+class _FakeDataset:
+    """Minimal HF dataset stand-in. Iterates a list of dicts; has an
+    `info` attribute with a `version` field."""
+
+    def __init__(self, rows: list[dict], version: str = "v_fake"):
+        self._rows = rows
+        self.info = type("I", (), {"version": version})()
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+def _mock_load_hf(monkeypatch, rows: list[dict], version: str = "v_fake"):
+    fake = _FakeDataset(rows, version=version)
+    monkeypatch.setattr(
+        "scripts.cache_hf_assets._load_hf",
+        lambda hf_id, hf_config, *, hf_token, revision, split: fake,
+    )
+
+
+def test_cache_one_task_writes_jsonl(tmp_path, monkeypatch):
+    rows = [
+        {"id": "1", "question": "Q1", "choices": {"text": ["a", "b"],
+         "label": ["A", "B"]}, "answerKey": "A"},
+        {"id": "2", "question": "Q2", "choices": {"text": ["x", "y"],
+         "label": ["A", "B"]}, "answerKey": "B"},
+    ]
+    _mock_load_hf(monkeypatch, rows)
+    entry = cache_one_task(
+        "arc_challenge_hard",
+        output_dir=tmp_path / "out",
+    )
+    assert entry["n_rows_in"] == 2
+    assert entry["n_rows_written"] == 2
+    assert entry["n_rows_skipped"] == 0
+    out_path = tmp_path / "out" / "arc_challenge_hard.jsonl"
+    assert out_path.exists()
+    lines = [json.loads(ln) for ln in out_path.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 2
+    assert lines[0]["gold"] == 0
+    assert lines[1]["gold"] == 1
+
+
+def test_cache_one_task_atomic_no_tmp_leftover(tmp_path, monkeypatch):
+    _mock_load_hf(monkeypatch, [])
+    cache_one_task("arc_challenge_hard", output_dir=tmp_path / "out")
+    assert not (tmp_path / "out" / "arc_challenge_hard.jsonl.tmp").exists()
+
+
+def test_cache_one_task_skips_malformed_rows(tmp_path, monkeypatch):
+    """Rows that fail conversion are counted in n_rows_skipped."""
+    rows = [
+        {"id": "ok", "question": "Q", "choices": {"text": ["a", "b"],
+         "label": ["A", "B"]}, "answerKey": "A"},
+        {"id": "bad", "question": "Q"},  # missing choices/answerKey
+    ]
+    _mock_load_hf(monkeypatch, rows)
+    entry = cache_one_task("arc_challenge_hard", output_dir=tmp_path / "out")
+    assert entry["n_rows_in"] == 2
+    assert entry["n_rows_written"] == 1
+    assert entry["n_rows_skipped"] == 1
+
+
+def test_cache_one_task_unknown_task_raises(tmp_path):
+    with pytest.raises(ValueError, match=r"unknown private-hard task"):
+        cache_one_task("not_a_task", output_dir=tmp_path / "out")
+
+
+def test_cache_all_writes_manifest(tmp_path, monkeypatch):
+    _mock_load_hf(monkeypatch, [])
+    manifest = cache_all(output_dir=tmp_path / "out", tasks=("arc_challenge_hard",))
+    assert manifest["_meta"] == "karpa-private-hard-cache-manifest"
+    assert manifest["version"] == "v1"
+    assert len(manifest["tasks"]) == 1
+    on_disk = json.loads((tmp_path / "out" / "manifest.json").read_text())
+    assert on_disk == manifest
+
+
+def test_task_converters_cover_all_4_private_hard_tasks():
+    from eval.downstream.private_hard import PRIVATE_HARD_TASKS
+    assert set(TASK_CONVERTERS.keys()) == set(PRIVATE_HARD_TASKS)
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+
+def test_cli_default_runs_all_tasks(tmp_path):
+    parser = _build_parser()
+    args = parser.parse_args([])
+    assert args.tasks is None  # cache_all picks default = all 4
+
+
+def test_cli_subset_via_repeat(tmp_path):
+    parser = _build_parser()
+    args = parser.parse_args([
+        "--task", "arc_challenge_hard",
+        "--task", "winogrande_hard",
+    ])
+    assert args.tasks == ["arc_challenge_hard", "winogrande_hard"]
+
+
+def test_cli_revision_parsing(tmp_path, monkeypatch):
+    """The --revision task=<sha> form parses into a per-task dict."""
+    from scripts.cache_hf_assets import main
+    _mock_load_hf(monkeypatch, [])
+    rc = main([
+        "--output-dir", str(tmp_path / "out"),
+        "--task", "arc_challenge_hard",
+        "--revision", "arc_challenge_hard=abc123",
+    ])
+    assert rc == 0
+
+
+def test_cli_bad_revision_format_rejected(tmp_path):
+    """Missing `=` in --revision arg returns exit 2."""
+    from scripts.cache_hf_assets import main
+    rc = main([
+        "--output-dir", str(tmp_path / "out"),
+        "--revision", "no_equals_sign",
+    ])
+    assert rc == 2

--- a/tests/test_download_dclm_bundle.py
+++ b/tests/test_download_dclm_bundle.py
@@ -1,0 +1,186 @@
+"""Tests for scripts/download_dclm_bundle.py.
+
+Network isn't available in CI for the actual DCLM bundle, so the download
+path is mocked. We verify the sha + unzip + manifest + cleanup logic
+end-to-end against a synthetic local zip.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import karpa_bootstrap  # noqa: F401
+from scripts.download_dclm_bundle import (
+    _build_parser,
+    download_and_verify,
+    sha256_of_file,
+)
+
+
+def _make_fake_zip(path: Path, contents: dict[str, bytes]) -> str:
+    """Write a fake zip; return its sha256 hex."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in contents.items():
+            zf.writestr(name, data)
+    return sha256_of_file(path)
+
+
+def _patch_download(monkeypatch, source_zip: Path):
+    """Monkey-patch _download to copy source_zip to dest instead of network."""
+    import shutil
+
+    import scripts.download_dclm_bundle as mod
+
+    def fake_download(url, dest):
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(source_zip, dest)
+
+    monkeypatch.setattr(mod, "_download", fake_download)
+
+
+# ============================================================================
+# sha256_of_file
+# ============================================================================
+
+
+def test_sha256_of_file_known_content(tmp_path):
+    path = tmp_path / "x.bin"
+    path.write_bytes(b"hello world")
+    expected = (
+        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+    )
+    assert sha256_of_file(path) == expected
+
+
+def test_sha256_chunked_large_file(tmp_path):
+    """A file larger than _CHUNK reads through multiple iterations."""
+    path = tmp_path / "big.bin"
+    path.write_bytes(b"x" * (1 << 17))  # 128 KB
+    h = sha256_of_file(path)
+    assert len(h) == 64
+
+
+# ============================================================================
+# download_and_verify happy path
+# ============================================================================
+
+
+def test_download_and_verify_happy_path(tmp_path, monkeypatch):
+    src = tmp_path / "src.zip"
+    sha = _make_fake_zip(src, {"task_a.jsonl": b'{"x":1}\n', "task_b.jsonl": b''})
+    _patch_download(monkeypatch, src)
+    out_dir = tmp_path / "out"
+    result = download_and_verify(
+        url="https://example.com/eval_bundle.zip",
+        output_dir=out_dir,
+        expected_sha=sha,
+    )
+    assert result["sha256"] == sha
+    assert result["extracted_count"] == 2
+    assert (out_dir / "task_a.jsonl").read_text() == '{"x":1}\n'
+    assert (out_dir / "SHA256SUM").exists()
+    # Zip auto-deleted by default
+    assert not (out_dir / "eval_bundle.zip").exists()
+
+
+def test_download_and_verify_keeps_zip_when_requested(tmp_path, monkeypatch):
+    src = tmp_path / "src.zip"
+    _make_fake_zip(src, {"a.jsonl": b''})
+    _patch_download(monkeypatch, src)
+    out_dir = tmp_path / "out"
+    download_and_verify(
+        url="x",
+        output_dir=out_dir,
+        keep_zip=True,
+    )
+    assert (out_dir / "eval_bundle.zip").exists()
+
+
+def test_download_and_verify_sha_mismatch_raises(tmp_path, monkeypatch):
+    src = tmp_path / "src.zip"
+    _make_fake_zip(src, {"a.jsonl": b''})
+    _patch_download(monkeypatch, src)
+    with pytest.raises(ValueError, match=r"SHA mismatch"):
+        download_and_verify(
+            url="x",
+            output_dir=tmp_path / "out",
+            expected_sha="0" * 64,
+        )
+
+
+def test_download_and_verify_no_expected_sha_accepts_any(tmp_path, monkeypatch):
+    src = tmp_path / "src.zip"
+    _make_fake_zip(src, {"a.jsonl": b''})
+    _patch_download(monkeypatch, src)
+    result = download_and_verify(
+        url="x",
+        output_dir=tmp_path / "out",
+        expected_sha=None,
+    )
+    assert result["sha256"]  # set
+
+
+def test_manifest_schema(tmp_path, monkeypatch):
+    src = tmp_path / "src.zip"
+    _make_fake_zip(src, {"a.jsonl": b''})
+    _patch_download(monkeypatch, src)
+    out_dir = tmp_path / "out"
+    download_and_verify(url="https://example.com/foo.zip", output_dir=out_dir)
+    manifest = json.loads((out_dir / "SHA256SUM").read_text())
+    assert manifest["_meta"] == "karpa-dclm-bundle-manifest"
+    assert manifest["url"] == "https://example.com/foo.zip"
+    assert len(manifest["sha256"]) == 64
+    assert manifest["extracted_member_count"] == 1
+    assert manifest["downloaded_at_iso"]
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+
+def test_cli_default_url_is_pinned_constant():
+    from eval.downstream.core22 import DCLM_EVAL_BUNDLE_URL
+    parser = _build_parser()
+    args = parser.parse_args([])
+    assert args.url == DCLM_EVAL_BUNDLE_URL
+
+
+def test_cli_overrides(tmp_path):
+    parser = _build_parser()
+    args = parser.parse_args([
+        "--url", "https://x.example/y.zip",
+        "--output-dir", str(tmp_path / "out"),
+        "--expected-sha", "a" * 64,
+        "--keep-zip",
+    ])
+    assert args.url == "https://x.example/y.zip"
+    assert args.output_dir == tmp_path / "out"
+    assert args.expected_sha == "a" * 64
+    assert args.keep_zip is True
+
+
+def test_cli_main_succeeds(tmp_path, monkeypatch):
+    """CLI main returns 0 on a successful (mocked) download."""
+    from scripts.download_dclm_bundle import main
+    src = tmp_path / "src.zip"
+    _make_fake_zip(src, {"a.jsonl": b''})
+
+    with mock.patch("scripts.download_dclm_bundle._download") as fake_dl:
+        def _copy(url, dest):
+            import shutil
+            shutil.copy(src, dest)
+        fake_dl.side_effect = _copy
+        rc = main([
+            "--url", "x",
+            "--output-dir", str(tmp_path / "out"),
+        ])
+    assert rc == 0


### PR DESCRIPTION
- scripts/download_dclm_bundle.py: streams DCLM zip, sha256 verify, unzip, manifest with digest
- scripts/cache_hf_assets.py: pulls + re-keys 4 private-hard HF datasets (ARC-Challenge / winogrande / tinyArc / tinyMMLU) to canonical Karpa JSONL; per-task converters; atomic writes; HF revision pinning
- scripts/build_refs_from_published.py: assembles refs.json from published-scores JSON; NaN for missing; coverage summary
- 44 new tests (network mocked). Full suite: 719/719.