### PR TITLE
feat: validation-v2 Phase 1 — owner audit reports + on-chain commit

### DIFF
--- a/chain_layer/bittensor_chain.py
+++ b/chain_layer/bittensor_chain.py
@@ -160,6 +160,54 @@ class BittensorChain(ChainInterface):
         _locked_append(self.chain_dir / "handshakes.jsonl", json.dumps(entry) + "\n")
         return nonce
 
+    def commit_audit_root(self, sha256_hex: str) -> int:
+        """Anchor a per-epoch audit-report hash on-chain (validation-v2 Phase 1).
+
+        Commits the 64-char hex sha256 of the canonical report_json via the
+        same `subtensor.set_commitment` path the handshake uses (the proven
+        method on bittensor 10.x; `subtensor.commit` does NOT exist). The
+        commitment overwrites each epoch, so auditors read it from an archive
+        subtensor at the historical block.
+
+        Mirrors `request_handshake_nonce`'s error discipline: RAISE on any
+        failure (SDK drift, rate limit, RPC down) so the caller surfaces it —
+        never silently lose a commit. The caller in service.run_epoch wraps
+        this in try/except so a commit failure can't break weight-setting.
+
+        Returns the block height the commitment landed at.
+        """
+        sha = sha256_hex.lower()
+        if len(sha) != 64 or any(c not in "0123456789abcdef" for c in sha):
+            raise ValueError(
+                f"commit_audit_root expects 64-hex sha256, got {sha256_hex!r}"
+            )
+        try:
+            self.subtensor.set_commitment(
+                wallet=self.wallet,
+                netuid=self.netuid,
+                data=sha,
+            )
+            print(f"[chain] audit root committed on-chain: {sha[:16]}...")
+        except AttributeError:
+            raise RuntimeError(
+                "bittensor SDK has no set_commitment method. "
+                "Expected method on bittensor>=10.0. Got attrs containing "
+                f"'commit': {[a for a in dir(self.subtensor) if 'commit' in a.lower()][:5]}"
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"on-chain audit-root commit failed: {type(e).__name__}: {e}"
+            )
+
+        block = self._current_block()
+        self.append_event({
+            "type": "audit_root_committed",
+            "timestamp": time.time(),
+            "report_sha256": sha,
+            "block": block,
+        })
+        return block
+
     def lookup_handshake(self, nonce: str) -> Optional[HandshakeRecord]:
         path = self.chain_dir / "handshakes.jsonl"
         if not path.exists():

--- a/chain_layer/interface.py
+++ b/chain_layer/interface.py
@@ -114,6 +114,21 @@ class ChainInterface(ABC):
         Raises ValueError if `block` is negative or exceeds the current height.
         """
 
+    def commit_audit_root(self, sha256_hex: str) -> int:
+        """Anchor a per-epoch audit-report hash on-chain (validation-v2 Phase 1).
+
+        `sha256_hex` is the 64-char lowercase hex sha256 of the canonical
+        report_json. Backends MUST raise on failure (do NOT swallow) so an
+        audit-report block that can't anchor surfaces loudly to the caller,
+        which then logs-and-continues without breaking weight-setting.
+
+        Returns the block height the commitment landed at.
+
+        Default no-op for backends that don't anchor (returns the current
+        block) so the interface stays incrementally adoptable.
+        """
+        return self.get_current_block()
+
     def blacklist(self, hotkey: str, reason: str = "") -> None:
         """Mark a miner-hotkey as blacklisted. Subsequent set_weights MUST
         zero its weight regardless of round_scores. Default no-op so

--- a/chain_layer/local.py
+++ b/chain_layer/local.py
@@ -112,6 +112,29 @@ class LocalChain(ChainInterface):
     def append_event(self, event: dict) -> None:
         _locked_append(self.chain_dir / "events.jsonl", json.dumps(event) + "\n")
 
+    def commit_audit_root(self, sha256_hex: str) -> int:
+        """File-write parity for the audit-root commitment (validation-v2 P1).
+
+        No real chain here — record the commit as an event + write a
+        last_audit_root.json so a local auditor / test can read it back.
+        Returns the (event-count) block height like get_current_block().
+        """
+        sha = sha256_hex.lower()
+        if len(sha) != 64 or any(c not in "0123456789abcdef" for c in sha):
+            raise ValueError(
+                f"commit_audit_root expects 64-hex sha256, got {sha256_hex!r}"
+            )
+        self.append_event({
+            "type": "audit_root_committed",
+            "timestamp": time.time(),
+            "report_sha256": sha,
+        })
+        block = self.get_current_block()
+        (self.chain_dir / "last_audit_root.json").write_text(
+            json.dumps({"report_sha256": sha, "block": block}, sort_keys=True)
+        )
+        return block
+
     def blacklist(self, hotkey: str, reason: str = "") -> None:
         path = self.chain_dir / "blacklist.json"
         current = {}

--- a/eval/hidden_eval.py
+++ b/eval/hidden_eval.py
@@ -52,19 +52,34 @@ class HiddenEvalResult:
     # B1-D12 forward-compat slot. When set, the v0.11+ chain consumer
     # reads the Cross-Scale Downstream Pareto verdict via this field.
     downstream: DownstreamReport | None = None
+    # validation-v2 Phase 1 audit-reproducibility slots. These let an auditor
+    # re-run the exact eval the validator scored against:
+    #   val_seq_len                 — context length the hidden-eval used
+    #   sealed_stream_manifest_hash — content hash identifying the sealed eval set
+    #   tail_val_bpb                — long-context tail probe (BPB over the
+    #                                 positions [val_seq_len//2 :]); recorded only,
+    #                                 the scorer does not consume it yet.
+    # All default None so old serialized dicts deserialize cleanly and the
+    # legacy-dict contract (below) stays byte-stable when they're unset.
+    val_seq_len: int | None = None
+    sealed_stream_manifest_hash: str | None = None
+    tail_val_bpb: float | None = None
 
     def to_legacy_dict(self) -> dict:
-        """Serialize, omitting `downstream` when it's None.
+        """Serialize, omitting forward-compat slots when they're None.
 
-        When `downstream is None` (the common case during the v0.10 →
-        v0.11 transition), the output is byte-identical to the
-        pre-v0.11 `dataclasses.asdict(self)` shape. When `downstream`
-        is populated, it's included as a nested dict (consumers that
-        don't know about it simply ignore the extra key).
+        When the optional forward-compat slots (`downstream`, `val_seq_len`,
+        `sealed_stream_manifest_hash`, `tail_val_bpb`) are all None — the common
+        case during the transition — the output is byte-identical to the
+        pre-v0.11 `dataclasses.asdict(self)` shape, preserving the B1-D12
+        contract for old chain consumers. When any is populated it's included
+        (consumers that don't know about it simply ignore the extra key).
         """
         d = asdict(self)
-        if d.get("downstream") is None:
-            d.pop("downstream", None)
+        for k in ("downstream", "val_seq_len", "sealed_stream_manifest_hash",
+                  "tail_val_bpb"):
+            if d.get(k) is None:
+                d.pop(k, None)
         return d
 
 
@@ -72,6 +87,34 @@ def _stable_hash(obj) -> str:
     import hashlib
     payload = json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
+
+
+def _sealed_stream_manifest_hash(
+    tokens_path: Path,
+    eval_tokens: np.ndarray,
+    examples: list,
+) -> str:
+    """Stable content hash identifying the EXACT sealed eval set the validator
+    scored against — the audit-reproducibility anchor (validation-v2 Phase 1).
+
+    An auditor re-running the eval needs to confirm it scored against the same
+    held-out data. We hash the full sealed token stream (the bytes on disk when
+    available, else the synthesized fallback stream) together with the benchmark
+    mix. Computed over the FULL content — not a 100-token prefix — so it pins
+    the whole sealed stream, not just its head.
+    """
+    import hashlib
+
+    if tokens_path.exists():
+        tokens_digest = hashlib.sha256(tokens_path.read_bytes()).hexdigest()
+    else:
+        tokens_digest = hashlib.sha256(
+            np.ascontiguousarray(eval_tokens).tobytes()
+        ).hexdigest()
+    return _stable_hash({
+        "tokens_sha256": tokens_digest,
+        "benchmark_sha256": _stable_hash(examples),
+    })
 
 
 def run_hidden_eval(
@@ -110,10 +153,18 @@ def run_hidden_eval(
         "benchmark_sha256": _stable_hash(examples),
     })
 
+    # Audit-reproducibility anchors (validation-v2 Phase 1).
+    sealed_manifest_hash = _sealed_stream_manifest_hash(
+        tokens_path, np.asarray(eval_tokens), examples
+    )
+
     return HiddenEvalResult(
         val_bpb=bpb_result["val_bpb"],
         benchmark_accuracy=bench_result["benchmark_accuracy"],
         tokens_evaluated=bpb_result["tokens_evaluated"],
         benchmark_examples=bench_result["n_examples"],
         eval_set_hash=eval_set_hash,
+        val_seq_len=seq_len,
+        sealed_stream_manifest_hash=sealed_manifest_hash,
+        tail_val_bpb=bpb_result.get("tail_val_bpb"),
     )

--- a/eval/val_bpb.py
+++ b/eval/val_bpb.py
@@ -75,6 +75,14 @@ def compute_val_bpb(
     model.eval()
     total_nats = 0.0
     total_tokens = 0
+    # Long-context tail probe (mirrors recipe/train.py's tail_val_bpb): the SAME
+    # cross-entropy, normalized by the SAME bytes_per_token, but accumulated only
+    # over the tail positions [seq_len//2 :] of each window. Penalizes recipes
+    # that shorten effective training context (the 250M-transfer blind spot).
+    # Recorded only — not yet consumed by the scorer.
+    tail_start = seq_len // 2
+    tail_nats = 0.0
+    tail_tokens = 0
 
     # Pack into non-overlapping windows of (seq_len + 1).
     n = len(eval_tokens)
@@ -101,14 +109,31 @@ def compute_val_bpb(
                 )
                 total_nats += loss_sum.item()
                 total_tokens += tgt.numel()
+                # Tail slice: positions [tail_start:] along the sequence axis.
+                # logits/tgt are (batch, seq_len, vocab) / (batch, seq_len).
+                if tail_start < tgt.size(1):
+                    tail_logits = logits[:, tail_start:, :]
+                    tail_tgt = tgt[:, tail_start:]
+                    tail_loss_sum = F.cross_entropy(
+                        tail_logits.reshape(-1, tail_logits.size(-1)),
+                        tail_tgt.reshape(-1),
+                        reduction="sum",
+                    )
+                    tail_nats += tail_loss_sum.item()
+                    tail_tokens += tail_tgt.numel()
                 batch_inp.clear()
                 batch_tgt.clear()
 
     total_bytes = total_tokens * bytes_per_token
     bpb = total_nats / (math.log(2) * total_bytes) if total_bytes > 0 else float("inf")
     nll_per_token = total_nats / max(total_tokens, 1)
+    tail_bytes = tail_tokens * bytes_per_token
+    tail_bpb = (
+        tail_nats / (math.log(2) * tail_bytes) if tail_bytes > 0 else None
+    )
     return {
         "val_bpb": bpb,
+        "tail_val_bpb": tail_bpb,
         "nll_per_token": nll_per_token,
         "tokens_evaluated": total_tokens,
         "bytes_per_token": bytes_per_token,

--- a/tests/test_audit_report.py
+++ b/tests/test_audit_report.py
@@ -1,0 +1,417 @@
+"""Tests for validator.audit_report — validation-v2 Phase 1.
+
+Covers:
+  * canonical_json determinism — same dict in any key order -> identical bytes.
+  * report_sha256 stability across key orderings.
+  * sign_report -> verify round-trip with a throwaway Keypair (incl. the
+    auditor's ss58-only reconstruction path).
+  * build_report_json shape from a couple of fake scored results + a snapshot.
+  * write_report writes <out>/audit_reports/<epoch_id>.json + upserts index.json.
+
+A fixed `generated_at` is used everywhere so the report is deterministic.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import ralph_bootstrap  # noqa: F401
+from validator.audit_report import (
+    AUDIT_REPORT_SCHEMA_VERSION,
+    build_envelope,
+    build_report_json,
+    canonical_json,
+    report_sha256,
+    sign_report,
+    write_report,
+)
+
+FIXED_GENERATED_AT = "2026-06-18T00:00:00Z"
+
+
+# --- a couple of fake scored results (shape mirrors score_and_decide()) ---
+
+def _scored_king() -> dict:
+    return {
+        "status": "accepted",
+        "classification": "king_change",
+        "weight_credit": 1.0,
+        "miner_hotkey": "5Hkingalpha",
+        "miner_github": "alice",
+        "pr_url": "https://github.com/x/y/pull/1",
+        "bundle_hash": "a" * 64,
+        "val_bpb": 1.2345,
+        "benchmark_accuracy": 0.42,
+        "quality_gain": 0.05,
+        "score": 0.9,
+        "tier": "verified",
+        "decisive": True,
+        "accepted": True,
+        "is_first": False,
+        "parent_king_attestation_hash": "b" * 64,
+        "attestation_hash": "c" * 64,
+        # validation-v2 Phase 1 reproducibility fields (now surfaced for real).
+        "val_seq_len": 512,
+        "sealed_stream_manifest_hash": "e" * 64,
+        "tail_val_bpb": 1.3001,
+    }
+
+
+def _scored_mf() -> dict:
+    return {
+        "status": "meaningful_failure",
+        "classification": "meaningful_failure",
+        "weight_credit": 0.1,
+        "miner_hotkey": "5Hmfbeta",
+        "miner_github": "bob",
+        "pr_url": "",
+        "bundle_hash": "d" * 64,
+        "val_bpb": 1.2400,
+        "benchmark_accuracy": 0.41,
+        "quality_gain": -0.005,
+        "score": 0.0,
+        "tier": "verified",
+        "decisive": False,
+        "accepted": False,
+        "is_first": False,
+        "parent_king_attestation_hash": None,
+        "attestation_hash": None,
+        "val_seq_len": 512,
+        "sealed_stream_manifest_hash": "f" * 64,
+        "tail_val_bpb": 1.3050,
+    }
+
+
+# --------------------------------------------------------------------------
+# canonical_json / report_sha256 determinism
+# --------------------------------------------------------------------------
+
+
+def test_canonical_json_is_key_order_independent():
+    a = {"z": 1, "a": {"y": 2, "x": 3}, "m": [3, 2, 1]}
+    b = {"a": {"x": 3, "y": 2}, "m": [3, 2, 1], "z": 1}
+    assert canonical_json(a) == canonical_json(b)
+
+
+def test_canonical_json_exact_encoding():
+    # Frozen separators (no spaces) + sorted keys + utf-8. The auditor depends
+    # on this byte-for-byte.
+    obj = {"b": 2, "a": "ünïcode"}
+    out = canonical_json(obj)
+    assert out == b'{"a":"\xc3\xbcn\xc3\xafcode","b":2}'
+
+
+def test_report_sha256_stable_across_key_order():
+    a = {"z": 1, "a": 2, "nested": {"q": 9, "p": 8}}
+    b = {"a": 2, "nested": {"p": 8, "q": 9}, "z": 1}
+    assert report_sha256(a) == report_sha256(b)
+    # 64-hex
+    h = report_sha256(a)
+    assert len(h) == 64 and all(c in "0123456789abcdef" for c in h)
+
+
+def test_report_sha256_changes_on_content_change():
+    assert report_sha256({"a": 1}) != report_sha256({"a": 2})
+
+
+# --------------------------------------------------------------------------
+# sign -> verify round-trip
+# --------------------------------------------------------------------------
+
+
+def test_sign_report_verify_roundtrip():
+    from bittensor_wallet import Keypair
+
+    kp = Keypair.create_from_uri("//AuditTestSigner")
+    report = build_report_json(
+        epoch_id="40-100",
+        netuid=40,
+        start_block=90,
+        end_block=100,
+        generated_at=FIXED_GENERATED_AT,
+        scored=[_scored_king()],
+        weight_snapshot={"5Hkingalpha": 1.0},
+    )
+    cbytes = canonical_json(report)
+    sig_hex = sign_report(cbytes, kp)
+
+    # signer verifies directly
+    assert kp.verify(cbytes, bytes.fromhex(sig_hex))
+    # tampered bytes fail
+    assert not kp.verify(cbytes + b"x", bytes.fromhex(sig_hex))
+
+    # auditor path: reconstruct a verifier Keypair from ONLY the ss58 hotkey.
+    verifier = Keypair(ss58_address=kp.ss58_address)
+    assert verifier.verify(cbytes, bytes.fromhex(sig_hex))
+
+
+# --------------------------------------------------------------------------
+# build_report_json shape
+# --------------------------------------------------------------------------
+
+
+def test_build_report_json_shape():
+    snapshot = {"5Hkingalpha": 0.9, "5Hmfbeta": 0.1}
+    report = build_report_json(
+        epoch_id="40-200",
+        netuid=40,
+        start_block=190,
+        end_block=200,
+        generated_at=FIXED_GENERATED_AT,
+        scored=[_scored_king(), _scored_mf()],
+        weight_snapshot=snapshot,
+        seed=7,
+    )
+
+    # top-level
+    assert report["schema_version"] == AUDIT_REPORT_SCHEMA_VERSION
+    assert report["epoch_id"] == "40-200"
+    assert report["netuid"] == 40
+    assert report["epoch_start_block"] == 190
+    assert report["epoch_end_block"] == 200
+    assert report["generated_at"] == FIXED_GENERATED_AT
+
+    # submissions
+    assert len(report["submissions"]) == 2
+    s0 = report["submissions"][0]
+    assert s0["miner_hotkey"] == "5Hkingalpha"
+    assert s0["submission_hash"] == "a" * 64
+    assert s0["bundle_sha256"] == "a" * 64
+    assert s0["parent_king_attestation_hash"] == "b" * 64
+    assert s0["attestation_hash"] == "c" * 64
+
+    ei = s0["eval_input"]
+    assert ei["seed"] == 7
+    assert ei["bundle_sha256"] == "a" * 64
+    # ladder rung dims carried for reproduction
+    labels = [r["scale_label"] for r in ei["ladder_rungs"]]
+    assert labels == ["S1", "S2", "S3"]
+    assert ei["ladder_rungs"][2] == {"scale_label": "S3", "dim": 768, "n_layers": 12}
+    # validation-v2 Phase 1: these are now populated for REAL (were GAP/None).
+    assert ei["val_seq_len"] == 512
+    assert ei["sealed_stream_manifest_hash"] == "e" * 64
+
+    eo = s0["eval_output"]
+    assert eo["val_bpb"] == 1.2345
+    assert eo["decisive_vs_king"] is True
+    assert eo["gate"] == "king_change"
+    assert eo["tail_val_bpb"] == 1.3001  # now populated for real
+
+    # scorecards: final_score from scorer, weight from snapshot
+    assert len(report["scorecards"]) == 2
+    sc0 = report["scorecards"][0]
+    assert sc0["miner_hotkey"] == "5Hkingalpha"
+    assert sc0["final_score"] == 0.9
+    assert sc0["weight"] == 0.9
+
+    # weight_snapshot embedded verbatim
+    assert report["weight_snapshot"]["netuid"] == 40
+    assert report["weight_snapshot"]["weights"] == snapshot
+    assert report["weight_snapshot"]["created_at"] == FIXED_GENERATED_AT
+
+
+def test_reproducibility_fields_populated_in_report():
+    """validation-v2 Phase 1: the three Gate-4 reproducibility fields
+    (val_seq_len, sealed_stream_manifest_hash, tail_val_bpb) flow from a scored
+    result into eval_input / eval_output with REAL values (not None)."""
+    report = build_report_json(
+        epoch_id="40-210",
+        netuid=40,
+        start_block=200,
+        end_block=210,
+        generated_at=FIXED_GENERATED_AT,
+        scored=[_scored_king()],
+        weight_snapshot={"5Hkingalpha": 1.0},
+        seed=3,
+    )
+    s0 = report["submissions"][0]
+    ei = s0["eval_input"]
+    eo = s0["eval_output"]
+
+    # Keys still present (auditors branch on them) AND now non-None.
+    assert "val_seq_len" in ei and ei["val_seq_len"] == 512
+    assert ei["val_seq_len"] is not None
+    assert "sealed_stream_manifest_hash" in ei
+    assert ei["sealed_stream_manifest_hash"] == "e" * 64
+    assert ei["sealed_stream_manifest_hash"] is not None
+    assert "tail_val_bpb" in eo and eo["tail_val_bpb"] == 1.3001
+    assert eo["tail_val_bpb"] is not None
+
+
+def test_build_envelope_records_weights_set():
+    """The envelope carries weights_set (decision-vs-landed) OUTSIDE the signed
+    report_json, so the hash is identical regardless of whether the extrinsic
+    landed."""
+    report = build_report_json(
+        epoch_id="40-220",
+        netuid=40,
+        start_block=210,
+        end_block=220,
+        generated_at=FIXED_GENERATED_AT,
+        scored=[_scored_king()],
+        weight_snapshot={"5Hkingalpha": 1.0},
+    )
+    env_landed = build_envelope(
+        report, signature="", signer_hotkey="",
+        chain_commitment_block=1, weights_set=True,
+    )
+    env_ratelimited = build_envelope(
+        report, signature="", signer_hotkey="",
+        chain_commitment_block=1, weights_set=False,
+    )
+    assert env_landed["weights_set"] is True
+    assert env_ratelimited["weights_set"] is False
+    # weights_set lives in the envelope only — the signed/hashed report_json is
+    # identical either way.
+    assert env_landed["report_sha256"] == env_ratelimited["report_sha256"]
+    # default (omitted) is False
+    env_default = build_envelope(
+        report, signature="", signer_hotkey="", chain_commitment_block=None,
+    )
+    assert env_default["weights_set"] is False
+
+
+def test_build_report_json_is_canonicalizable_deterministic():
+    # Same inputs -> identical canonical bytes (no hidden datetime.now()).
+    kwargs = dict(
+        epoch_id="40-300",
+        netuid=40,
+        start_block=290,
+        end_block=300,
+        generated_at=FIXED_GENERATED_AT,
+        scored=[_scored_king()],
+        weight_snapshot={"5Hkingalpha": 1.0},
+    )
+    r1 = build_report_json(**kwargs)
+    r2 = build_report_json(**kwargs)
+    assert canonical_json(r1) == canonical_json(r2)
+    assert report_sha256(r1) == report_sha256(r2)
+
+
+# --------------------------------------------------------------------------
+# _generate_audit_report ordering — report is written + records weights_set
+# regardless of whether set_weights landed (Task 1 ordering fix).
+# --------------------------------------------------------------------------
+
+
+class _StubChain:
+    """Minimal chain for _generate_audit_report: no wallet (unsigned, local
+    parity), a fixed end block, and a commit_audit_root that records the sha."""
+
+    def __init__(self, chain_dir: Path):
+        self.chain_dir = chain_dir
+        self.committed_sha: str | None = None
+
+    def get_current_block(self) -> int:
+        return 999
+
+    def commit_audit_root(self, sha: str) -> int:
+        self.committed_sha = sha
+        return 999
+
+
+@pytest.mark.parametrize("weights_set", [True, False])
+def test_generate_audit_report_records_weights_set(tmp_path, weights_set):
+    """The audit report is built + anchored + written and stamps weights_set —
+    in particular weights_set=False (a rate-limited epoch where set_weights
+    returned early) STILL produces a full report. This is the Task-1 ordering
+    contract: the report documents the DECISION, independent of the extrinsic."""
+    from validator.service import _generate_audit_report
+
+    chain = _StubChain(tmp_path)
+    _generate_audit_report(
+        chain,
+        scored_results=[_scored_king()],
+        weight_snapshot={"5Hkingalpha": 1.0},
+        epoch_start_block=990,
+        netuid=40,
+        eval_seed=0,
+        weights_set=weights_set,
+    )
+
+    # On-chain anchor happened.
+    assert chain.committed_sha is not None
+    # Report written to chain_dir/audit_reports/40-999.json.
+    report_path = tmp_path / "audit_reports" / "40-999.json"
+    assert report_path.exists()
+    env = json.loads(report_path.read_text())
+    assert env["weights_set"] is weights_set
+    assert env["report_sha256"] == chain.committed_sha
+    # Reproducibility fields flowed through to the persisted report.
+    ei = env["report_json"]["submissions"][0]["eval_input"]
+    assert ei["val_seq_len"] == 512
+    assert ei["sealed_stream_manifest_hash"] == "e" * 64
+    eo = env["report_json"]["submissions"][0]["eval_output"]
+    assert eo["tail_val_bpb"] == 1.3001
+    # index records weights_set too.
+    index = json.loads((tmp_path / "audit_reports" / "index.json").read_text())
+    assert index[0]["weights_set"] is weights_set
+
+
+# --------------------------------------------------------------------------
+# write_report + index upsert
+# --------------------------------------------------------------------------
+
+
+def test_write_report_and_index(tmp_path):
+    from bittensor_wallet import Keypair
+
+    kp = Keypair.create_from_uri("//WriteTest")
+    report = build_report_json(
+        epoch_id="40-400",
+        netuid=40,
+        start_block=390,
+        end_block=400,
+        generated_at=FIXED_GENERATED_AT,
+        scored=[_scored_king()],
+        weight_snapshot={"5Hkingalpha": 1.0},
+    )
+    sig = sign_report(canonical_json(report), kp)
+    env = build_envelope(
+        report,
+        signature=sig,
+        signer_hotkey=kp.ss58_address,
+        chain_commitment_block=12345,
+        weights_set=True,
+    )
+    assert env["report_sha256"] == report_sha256(report)
+
+    path = write_report(env, tmp_path)
+    assert path == tmp_path / "audit_reports" / "40-400.json"
+    assert path.exists()
+    loaded = json.loads(path.read_text())
+    assert loaded["report_sha256"] == env["report_sha256"]
+    assert loaded["chain_commitment_block"] == 12345
+    assert loaded["weights_set"] is True
+
+    index = json.loads((tmp_path / "audit_reports" / "index.json").read_text())
+    assert len(index) == 1
+    assert index[0]["epoch_id"] == "40-400"
+    assert index[0]["report_sha256"] == env["report_sha256"]
+    assert index[0]["signer_hotkey"] == kp.ss58_address
+    assert index[0]["chain_commitment_block"] == 12345
+    assert index[0]["weights_set"] is True
+
+    # second epoch appends; re-writing same epoch_id replaces (idempotent).
+    report2 = build_report_json(
+        epoch_id="40-500",
+        netuid=40,
+        start_block=490,
+        end_block=500,
+        generated_at=FIXED_GENERATED_AT,
+        scored=[_scored_mf()],
+        weight_snapshot={"5Hmfbeta": 1.0},
+    )
+    env2 = build_envelope(
+        report2, signature="", signer_hotkey="", chain_commitment_block=500,
+    )
+    write_report(env2, tmp_path)
+    write_report(env, tmp_path)  # re-write 40-400 -> must NOT duplicate
+    index = json.loads((tmp_path / "audit_reports" / "index.json").read_text())
+    epoch_ids = sorted(e["epoch_id"] for e in index)
+    assert epoch_ids == ["40-400", "40-500"]

--- a/tests/test_hidden_eval_schema_versioning.py
+++ b/tests/test_hidden_eval_schema_versioning.py
@@ -309,3 +309,90 @@ class TestDataclassSemantics:
         d = asdict(result)
         assert "downstream" in d
         assert d["downstream"] is None
+
+
+# ============================================================================
+# validation-v2 Phase 1 reproducibility fields
+# (val_seq_len / sealed_stream_manifest_hash / tail_val_bpb)
+# ============================================================================
+
+
+class TestReproducibilityFields:
+    def test_default_none_and_dropped_from_legacy_dict(self):
+        """Unset → all three default None AND are dropped from to_legacy_dict
+        so the pre-v0.11 byte-shape is preserved."""
+        result = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=1000,
+            benchmark_examples=50,
+            eval_set_hash="abc",
+        )
+        assert result.val_seq_len is None
+        assert result.sealed_stream_manifest_hash is None
+        assert result.tail_val_bpb is None
+        d = result.to_legacy_dict()
+        for k in ("val_seq_len", "sealed_stream_manifest_hash", "tail_val_bpb"):
+            assert k not in d
+        # byte-shape unchanged from legacy
+        assert set(d) == {
+            "val_bpb", "benchmark_accuracy", "tokens_evaluated",
+            "benchmark_examples", "eval_set_hash",
+        }
+
+    def test_populated_included_in_legacy_dict(self):
+        result = HiddenEvalResult(
+            val_bpb=1.0,
+            benchmark_accuracy=0.5,
+            tokens_evaluated=1000,
+            benchmark_examples=50,
+            eval_set_hash="abc",
+            val_seq_len=512,
+            sealed_stream_manifest_hash="d" * 64,
+            tail_val_bpb=1.31,
+        )
+        d = result.to_legacy_dict()
+        assert d["val_seq_len"] == 512
+        assert d["sealed_stream_manifest_hash"] == "d" * 64
+        assert d["tail_val_bpb"] == 1.31
+
+    def test_old_dict_without_new_keys_deserializes(self):
+        """A pre-Phase-1 serialized dict still round-trips via kwargs."""
+        old = {
+            "val_bpb": 1.0,
+            "benchmark_accuracy": 0.5,
+            "tokens_evaluated": 1000,
+            "benchmark_examples": 50,
+            "eval_set_hash": "abc",
+        }
+        r = HiddenEvalResult(**old)
+        assert r.val_seq_len is None
+        assert r.sealed_stream_manifest_hash is None
+        assert r.tail_val_bpb is None
+
+    def test_run_hidden_eval_surfaces_fields(self, tmp_path):
+        """End-to-end: run_hidden_eval on a tiny model populates val_seq_len,
+        sealed_stream_manifest_hash, and tail_val_bpb (Phase-0 fallback path,
+        no on-disk shard needed)."""
+        import torch
+
+        from eval.hidden_eval import run_hidden_eval
+
+        class _Tiny(torch.nn.Module):
+            def __init__(self, vocab=50257, dim=8):
+                super().__init__()
+                self.embed = torch.nn.Embedding(vocab, dim)
+                self.out = torch.nn.Linear(dim, vocab)
+
+            def forward(self, x):
+                return self.out(self.embed(x)), None
+
+        torch.manual_seed(0)
+        model = _Tiny()
+        # tmp_path has no active_tokens.bin → Phase-0 synthesized stream fires.
+        res = run_hidden_eval(model, tmp_path, seq_len=32)
+        assert res.val_seq_len == 32
+        assert isinstance(res.sealed_stream_manifest_hash, str)
+        assert len(res.sealed_stream_manifest_hash) == 64
+        assert res.tail_val_bpb is not None
+        assert res.tail_val_bpb > 0

--- a/tests/test_val_bpb_per_stream.py
+++ b/tests/test_val_bpb_per_stream.py
@@ -225,3 +225,85 @@ class TestComputeValBpbOnStream:
         result_b = compute_val_bpb_on_stream(model, batch_b, seq_len=16)
         # Halved bytes_per_token → doubled val_bpb.
         assert result_b["val_bpb"] == pytest.approx(2 * result_a["val_bpb"])
+
+
+# ============================================================================
+# tail_val_bpb — long-context tail probe (validation-v2 Phase 1)
+# ============================================================================
+
+
+class TestTailValBpb:
+    """The tail probe mirrors recipe/train.py: BPB over the tail positions
+    [seq_len//2 :] of each window, same cross-entropy + bytes_per_token
+    normalization as val_bpb. Recorded only; the scorer does not use it."""
+
+    def test_tail_val_bpb_present(self):
+        torch.manual_seed(0)
+        model = _TinyModel()
+        tokens = _make_tokens(256)
+        result = compute_val_bpb(model, tokens, seq_len=16)
+        assert "tail_val_bpb" in result
+        assert result["tail_val_bpb"] is not None
+        assert result["tail_val_bpb"] > 0
+
+    def test_tail_val_bpb_matches_manual_tail_slice(self):
+        """tail_val_bpb equals val_bpb recomputed over only positions
+        [seq_len//2:] — proving it's the long-context tail, not the full
+        window. We verify by computing the tail BPB independently."""
+        import math
+
+        import numpy as np
+        import torch.nn.functional as F
+
+        torch.manual_seed(0)
+        model = _TinyModel()
+        model.eval()
+        seq_len = 16
+        bpt = 4.0
+        tokens = _make_tokens(256)
+        result = compute_val_bpb(model, tokens, seq_len=seq_len, bytes_per_token=bpt)
+
+        # Independent recompute of the tail half.
+        tail_start = seq_len // 2
+        n = len(tokens)
+        n_windows = max(1, (n - 1) // seq_len)
+        tail_nats = 0.0
+        tail_tokens = 0
+        with torch.no_grad():
+            for w in range(n_windows):
+                start = w * seq_len
+                ids = tokens[start : start + seq_len + 1]
+                if len(ids) < seq_len + 1:
+                    break
+                inp = torch.from_numpy(ids[:-1].astype(np.int64)).unsqueeze(0)
+                tgt = torch.from_numpy(ids[1:].astype(np.int64)).unsqueeze(0)
+                logits, _ = model(inp)
+                tl = logits[:, tail_start:, :]
+                tt = tgt[:, tail_start:]
+                tail_nats += F.cross_entropy(
+                    tl.reshape(-1, tl.size(-1)), tt.reshape(-1), reduction="sum"
+                ).item()
+                tail_tokens += tt.numel()
+        expected = tail_nats / (math.log(2) * tail_tokens * bpt)
+        assert result["tail_val_bpb"] == pytest.approx(expected, rel=1e-5)
+
+    def test_tail_val_bpb_normalizes_with_bytes_per_token(self):
+        """Halving bytes_per_token doubles tail_val_bpb, same as val_bpb."""
+        torch.manual_seed(0)
+        model = _TinyModel()
+        tokens = _make_tokens(256)
+        a = compute_val_bpb(model, tokens, seq_len=16, bytes_per_token=4.0)
+        b = compute_val_bpb(model, tokens, seq_len=16, bytes_per_token=2.0)
+        assert b["tail_val_bpb"] == pytest.approx(2 * a["tail_val_bpb"])
+
+    def test_tail_val_bpb_none_when_window_too_short(self):
+        """seq_len=1 → tail_start=0 means the whole window IS the tail, so the
+        probe is still defined. A degenerate seq that yields no full windows
+        leaves tail tokens at zero → None (guarded division)."""
+        torch.manual_seed(0)
+        model = _TinyModel()
+        # Only enough tokens for a single (seq_len+1) window; tail still defined.
+        tokens = _make_tokens(17)
+        result = compute_val_bpb(model, tokens, seq_len=16)
+        # tail_start = 8 < 16, so the tail slice exists.
+        assert result["tail_val_bpb"] is not None

--- a/validator/audit_report.py
+++ b/validator/audit_report.py
@@ -1,8 +1,8 @@
 """Owner-validator audit report — validation-v2 Phase 1.
 
-The owner validator (H200) is the single node that does the heavy hidden-eval
-scoring, sets weights, and — added here — anchors a per-epoch **audit
-commitment** on-chain so anyone can re-derive its decisions from published data.
+Ralph validators run the GPU hidden-eval scoring and set weights; this module
+anchors a per-epoch **audit commitment** on-chain so anyone can re-derive a
+validator's decisions from published data — auditors run on CPU, no GPU needed.
 
 This module builds that per-epoch report:
 
@@ -19,7 +19,7 @@ This module builds that per-epoch report:
   4. `write_report(...)` writes `<out_dir>/audit_reports/<epoch_id>.json` and
      upserts an `index.json` so an auditor can enumerate epochs.
 
-The owner cannot lie two ways: (a) commit a hash != raw report -> caught by
+A scoring validator cannot lie two ways: (a) commit a hash != raw report -> caught by
 re-hash; (b) commit a report whose weights != scorer(raw data) -> caught by
 replay. See docs/rearch_2026_06/childkey_owner_auditor_architecture.md.
 

--- a/validator/audit_report.py
+++ b/validator/audit_report.py
@@ -1,0 +1,346 @@
+"""Owner-validator audit report — validation-v2 Phase 1.
+
+The owner validator (H200) is the single node that does the heavy hidden-eval
+scoring, sets weights, and — added here — anchors a per-epoch **audit
+commitment** on-chain so anyone can re-derive its decisions from published data.
+
+This module builds that per-epoch report:
+
+  1. `build_report_json(...)` assembles a deterministic dict from the epoch's
+     scored submissions + the weight snapshot the validator just set.
+  2. `canonical_json(...)` / `report_sha256(...)` produce the byte-exact
+     canonicalization + hash. THE AUDITOR DEPENDS ON THIS BEING
+     BYTE-IDENTICAL — `json.dumps(obj, sort_keys=True,
+     separators=(",",":"), ensure_ascii=False).encode("utf-8")`. Do not
+     change the separators / sort / encoding without a coordinated auditor
+     bump.
+  3. `sign_report(...)` ed25519-signs the canonical bytes with the validator
+     hotkey `Keypair`.
+  4. `write_report(...)` writes `<out_dir>/audit_reports/<epoch_id>.json` and
+     upserts an `index.json` so an auditor can enumerate epochs.
+
+The owner cannot lie two ways: (a) commit a hash != raw report -> caught by
+re-hash; (b) commit a report whose weights != scorer(raw data) -> caught by
+replay. See docs/rearch_2026_06/childkey_owner_auditor_architecture.md.
+
+Design note — field availability: the three Gate-4 reproducibility fields
+(`val_seq_len`, `sealed_stream_manifest_hash`, `tail_val_bpb`) are now populated
+for REAL — the hidden-eval surfaces the context length it used, a content hash
+of the sealed eval set it scored against, and a long-context tail probe (BPB
+over the tail positions `[val_seq_len//2 :]`, recorded only — the scorer does
+not consume it yet). A few idealized-schema fields the current scorer still does
+not emit (`downstream_acc`, `fraud_penalty`, standalone `recipe_diff_sha256`)
+remain `None` (clearly stubbed) so the schema shape is stable and an auditor can
+rely on the keys existing; they get filled in as the pipeline grows. Everything
+the current scorer DOES emit (bundle/submission sha256, miner hotkey,
+parent_king_attestation_hash, val_bpb, tail_val_bpb, val_seq_len,
+sealed_stream_manifest_hash, decision/gate, decisive_vs_king, seed, ladder rung
+dims, final score/weight) is populated for real.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Schema / format constants — frozen. A unilateral change to any of these is
+# an intended divergence from the auditor and must be coordinated.
+# ---------------------------------------------------------------------------
+
+AUDIT_REPORT_SCHEMA_VERSION = "v1"
+
+# The canonical ladder rung dimensions the validator pins (mirrors
+# validator/ladder.py _STANDARD_RUNGS_DEFAULT). Carried in eval_input so an
+# auditor can reproduce the eval at any tier without guessing the geometry.
+STANDARD_LADDER_RUNGS: tuple[dict[str, int], ...] = (
+    {"scale_label_index": 0, "dim": 256, "n_layers": 4},   # S1 ~1.5M
+    {"scale_label_index": 1, "dim": 512, "n_layers": 12},  # S2 ~18M
+    {"scale_label_index": 2, "dim": 768, "n_layers": 12},  # S3 ~124M
+)
+_STANDARD_LADDER_RUNGS_LABELED: tuple[dict[str, Any], ...] = (
+    {"scale_label": "S1", "dim": 256, "n_layers": 4},
+    {"scale_label": "S2", "dim": 512, "n_layers": 12},
+    {"scale_label": "S3", "dim": 768, "n_layers": 12},
+)
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization + hashing — MUST stay byte-identical validator <-> auditor.
+# ---------------------------------------------------------------------------
+
+
+def canonical_json(obj: Any) -> bytes:
+    """Deterministic, byte-exact JSON encoding.
+
+    The auditor re-hashes the published report and compares to the on-chain
+    commitment; if this encoding drifts even by a separator the hash check
+    fails. Keep this EXACTLY:
+
+        json.dumps(obj, sort_keys=True, separators=(",",":"),
+                   ensure_ascii=False).encode("utf-8")
+    """
+    return json.dumps(
+        obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def report_sha256(obj: Any) -> str:
+    """Return the 64-hex sha256 of `canonical_json(obj)`."""
+    return hashlib.sha256(canonical_json(obj)).hexdigest()
+
+
+def sign_report(canonical_bytes: bytes, keypair: Any) -> str:
+    """ed25519-sign `canonical_bytes` with a bittensor `Keypair`.
+
+    Returns the signature as lowercase hex. `keypair.sign(bytes)` returns raw
+    signature bytes (64 for sr25519/ed25519); an auditor reconstructs the
+    `Keypair` from the signer's ss58 hotkey and calls `.verify(bytes, sig)`.
+    """
+    sig = keypair.sign(canonical_bytes)
+    # bittensor Keypair.sign returns bytes; be defensive about a hex-str impl.
+    if isinstance(sig, bytes):
+        return sig.hex()
+    if isinstance(sig, str):
+        return sig[2:] if sig.startswith("0x") else sig
+    return bytes(sig).hex()
+
+
+# ---------------------------------------------------------------------------
+# Report construction
+# ---------------------------------------------------------------------------
+
+
+def _eval_input_for(scored: dict, seed: int) -> dict:
+    """Build the `eval_input` block — everything an auditor needs to reproduce
+    the eval. `val_seq_len` and `sealed_stream_manifest_hash` are now surfaced
+    by the hidden-eval (Gate-4 reproducibility); the bundle_hash remains the
+    submission anchor."""
+    return {
+        "bundle_sha256": scored.get("bundle_hash"),
+        # Content hash of the sealed eval set the validator scored against —
+        # lets an auditor confirm it re-runs over the identical held-out data.
+        "sealed_stream_manifest_hash": scored.get("sealed_stream_manifest_hash"),
+        "seed": seed,
+        # The context length the hidden-eval used (RalphConfig.max_seq_len//2).
+        "val_seq_len": scored.get("val_seq_len"),
+        "ladder_rungs": list(_STANDARD_LADDER_RUNGS_LABELED),
+    }
+
+
+def _eval_output_for(scored: dict) -> dict:
+    """Build the `eval_output` block from the scorer's result dict."""
+    return {
+        "val_bpb": scored.get("val_bpb"),
+        # Long-context tail probe: BPB over the tail positions [val_seq_len//2:].
+        # Recorded only — the scorer does not consume it yet.
+        "tail_val_bpb": scored.get("tail_val_bpb"),
+        "benchmark_accuracy": scored.get("benchmark_accuracy"),
+        "quality_gain": scored.get("quality_gain"),
+        "score": scored.get("score"),
+        "tier": scored.get("tier"),
+        # gate / decision: the scorer's classification + the decisive flag.
+        "gate": scored.get("classification"),
+        "status": scored.get("status"),
+        "decisive_vs_king": bool(scored.get("decisive", False)),
+        "accepted": bool(scored.get("accepted", False)),
+        "is_first": bool(scored.get("is_first", False)),
+    }
+
+
+def _submission_entry(scored: dict, seed: int, observed_at: Any) -> dict:
+    """One `submissions[]` entry from a single score_and_decide result dict."""
+    return {
+        "submission_hash": scored.get("bundle_hash"),
+        "bundle_sha256": scored.get("bundle_hash"),
+        "miner_hotkey": scored.get("miner_hotkey"),
+        "miner_github": scored.get("miner_github", ""),
+        # recipe diff identity. The scorer dict doesn't carry a standalone
+        # recipe_diff_sha256 yet (the bundle_hash folds the patch sha in), so
+        # we surface whatever was passed alongside, else None.
+        "recipe_diff_sha256": scored.get("recipe_diff_sha256"),  # GAP if not threaded
+        "parent_king_attestation_hash": scored.get("parent_king_attestation_hash"),
+        "eval_input": _eval_input_for(scored, seed),
+        "eval_output": _eval_output_for(scored),
+        # the submission's own attestation hash (king_attestation_hash once crowned).
+        "attestation_hash": scored.get("attestation_hash"),
+        "observed_at": observed_at,
+    }
+
+
+def build_report_json(
+    epoch_id: str,
+    netuid: int,
+    start_block: int,
+    end_block: int,
+    generated_at: Any,
+    scored: list[dict],
+    weight_snapshot: dict[str, float],
+    *,
+    seed: int = 0,
+    created_at: Any = None,
+) -> dict:
+    """Assemble the per-epoch `report_json` from the epoch's scored submissions.
+
+    Args:
+      epoch_id:   stable id, e.g. "40-<end_block>".
+      netuid:     subnet uid (40 on mainnet).
+      start_block/end_block: epoch block range.
+      generated_at: timestamp string. Passed IN (not computed) so the report
+        is deterministic / testable. Do NOT call datetime.now() here.
+      scored:     list of score_and_decide() result dicts (the per-submission
+        view). Rejected/non-scored entries are tolerated — they contribute a
+        thin entry (no eval_output fields) rather than being dropped, so the
+        history stays append-only and complete.
+      weight_snapshot: {hotkey: weight} the validator set this epoch (round_scores).
+      seed:       the eval seed (carried into each eval_input for reproduction).
+      created_at: optional timestamp for the embedded weight_snapshot /
+        scorecards; defaults to `generated_at` when None (keeps it injectable).
+
+    Returns a plain dict — hash/sign/serialize it via the other helpers.
+    """
+    if created_at is None:
+        created_at = generated_at
+
+    submissions = [_submission_entry(s, seed, generated_at) for s in scored]
+
+    # scorecards: final_score + weight per hotkey. final_score comes from the
+    # scorer dict; weight comes from the snapshot the validator actually set
+    # (round_scores after the 90/10 pool split).
+    scorecards = []
+    for s in scored:
+        hk = s.get("miner_hotkey")
+        scorecards.append({
+            "miner_hotkey": hk,
+            "final_score": s.get("score"),
+            "quality_gain": s.get("quality_gain"),
+            "fraud_penalty": s.get("fraud_penalty"),  # GAP: not yet emitted
+            "weight": weight_snapshot.get(hk),
+            "classification": s.get("classification"),
+            "computed_at": created_at,
+        })
+
+    return {
+        "schema_version": AUDIT_REPORT_SCHEMA_VERSION,
+        "epoch_id": epoch_id,
+        "netuid": netuid,
+        "epoch_start_block": start_block,
+        "epoch_end_block": end_block,
+        "generated_at": generated_at,
+        "submissions": submissions,
+        "scorecards": scorecards,
+        "weight_snapshot": {
+            "netuid": netuid,
+            "weights": dict(weight_snapshot),
+            "created_at": created_at,
+        },
+    }
+
+
+def build_envelope(
+    report_json: dict,
+    *,
+    signature: str,
+    signer_hotkey: str,
+    chain_commitment_block: Optional[int],
+    weights_set: bool = False,
+) -> dict:
+    """Wrap `report_json` with its hash, signature, signer, and commit block.
+
+    `weights_set` is an ENVELOPE-level field (deliberately NOT inside the signed
+    `report_json`): the report records what the validator DECIDED this epoch,
+    while `weights_set` records whether the weight extrinsic actually landed
+    on-chain (set_weights can rate-limit and return early). Keeping it out of
+    `report_json` means the signed/hashed decision record is identical whether
+    or not the extrinsic landed, and an auditor reads decision-vs-landed from
+    the two separate places.
+    """
+    return {
+        "report_json": report_json,
+        "report_sha256": report_sha256(report_json),
+        "signature": signature,
+        "signer_hotkey": signer_hotkey,
+        "chain_commitment_block": chain_commitment_block,
+        "weights_set": bool(weights_set),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def write_report(report_envelope: dict, out_dir: Path) -> Path:
+    """Write the signed report envelope + upsert the epoch index.
+
+    Layout:
+      <out_dir>/audit_reports/<epoch_id>.json   — the full signed envelope
+      <out_dir>/audit_reports/index.json        — append-only epoch index
+
+    Returns the path to the written per-epoch report.
+    """
+    out_dir = Path(out_dir)
+    reports_dir = out_dir / "audit_reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    report_json = report_envelope["report_json"]
+    epoch_id = report_json["epoch_id"]
+
+    report_path = reports_dir / f"{epoch_id}.json"
+    report_path.write_text(
+        json.dumps(report_envelope, indent=2, sort_keys=True, ensure_ascii=False)
+    )
+
+    # Upsert index.json. Append (or replace-by-epoch_id) the index entry.
+    index_path = reports_dir / "index.json"
+    index: list[dict] = []
+    if index_path.exists():
+        try:
+            loaded = json.loads(index_path.read_text())
+            if isinstance(loaded, list):
+                index = loaded
+        except (json.JSONDecodeError, OSError):
+            index = []
+
+    entry = {
+        "epoch_id": epoch_id,
+        "epoch_start_block": report_json.get("epoch_start_block"),
+        "epoch_end_block": report_json.get("epoch_end_block"),
+        "report_sha256": report_envelope.get("report_sha256"),
+        "signer_hotkey": report_envelope.get("signer_hotkey"),
+        "chain_commitment_block": report_envelope.get("chain_commitment_block"),
+        "weights_set": report_envelope.get("weights_set"),
+    }
+    # Replace any existing entry for the same epoch_id (idempotent re-run),
+    # else append.
+    index = [e for e in index if e.get("epoch_id") != epoch_id]
+    index.append(entry)
+    index_path.write_text(
+        json.dumps(index, indent=2, sort_keys=True, ensure_ascii=False)
+    )
+
+    # TODO Phase 2: publish to HF — upload `report_path` + `index.json` to
+    # RalphLabsAI/audit-reports so auditors pull from the Hub. The on-chain
+    # commitment remains the trust anchor; HF is just the off-chain store.
+    # e.g. huggingface_hub.upload_file(path_or_fileobj=report_path,
+    #          path_in_repo=f"audit_reports/{epoch_id}.json",
+    #          repo_id="RalphLabsAI/audit-reports", repo_type="dataset")
+
+    return report_path
+
+
+__all__ = [
+    "AUDIT_REPORT_SCHEMA_VERSION",
+    "STANDARD_LADDER_RUNGS",
+    "build_envelope",
+    "build_report_json",
+    "canonical_json",
+    "report_sha256",
+    "sign_report",
+    "write_report",
+]

--- a/validator/eval_in_workdir.py
+++ b/validator/eval_in_workdir.py
@@ -108,12 +108,19 @@ def main() -> int:
         print(f"ERROR: hidden_eval crashed: {e}", file=sys.stderr)
         return 2
 
+    # tail_val_bpb may be None (eval window too short for a tail slice); emit a
+    # sentinel the parent maps back to None rather than a bogus float.
+    tail = result.tail_val_bpb
+    tail_str = f"{tail:.6f}" if isinstance(tail, (int, float)) else "none"
     print(
         f"RALPH_EVAL_RESULT val_bpb={result.val_bpb:.6f} "
         f"benchmark_acc={result.benchmark_accuracy:.6f} "
         f"tokens_evaluated={result.tokens_evaluated} "
         f"benchmark_examples={result.benchmark_examples} "
-        f"eval_set_hash={result.eval_set_hash}"
+        f"eval_set_hash={result.eval_set_hash} "
+        f"val_seq_len={result.val_seq_len if result.val_seq_len is not None else 'none'} "
+        f"sealed_stream_manifest_hash={result.sealed_stream_manifest_hash or 'none'} "
+        f"tail_val_bpb={tail_str}"
     )
     return 0
 

--- a/validator/service.py
+++ b/validator/service.py
@@ -323,6 +323,13 @@ def score_and_decide(
         "bundle_hash": result.bundle_hash,
         "val_bpb": result.hidden_eval.val_bpb,
         "benchmark_accuracy": result.hidden_eval.benchmark_accuracy,
+        # validation-v2 Phase 1 audit-reproducibility fields, surfaced from the
+        # hidden-eval result so the per-epoch audit report can pin the exact
+        # eval an auditor must reproduce. tail_val_bpb is recorded only — the
+        # scorer does not consume it yet.
+        "val_seq_len": result.hidden_eval.val_seq_len,
+        "sealed_stream_manifest_hash": result.hidden_eval.sealed_stream_manifest_hash,
+        "tail_val_bpb": result.hidden_eval.tail_val_bpb,
         "quality_gain": score.quality_gain,
         "score": score.score,
         "tier": score.tier,
@@ -418,6 +425,9 @@ def run_epoch(
     hf_token: str | None = None,
     hf_limit: int = 10,
     audit_random_rate: float = 0.10,
+    audit_reports_enabled: bool = True,
+    netuid: int = 40,
+    eval_seed: int = 0,
 ) -> dict:
     """Process all pending submissions in one epoch.
 
@@ -459,11 +469,23 @@ def run_epoch(
     log_info(f"found {len(bundles)} pending submission(s)")
     epoch_results = {"submissions": len(bundles), "accepted": 0, "rejected": 0}
 
+    # Block height at epoch start — recorded into the audit report's block
+    # range. Best-effort; never fatal.
+    try:
+        epoch_start_block = chain.get_current_block()
+    except Exception:
+        epoch_start_block = 0
+
     # Track classifications per-hotkey so the pool split at end of epoch is
     # correct (and so two king_changes in one epoch — rare but legal —
     # don't double-share the king pool).
     king_change_hotkey: str | None = None
     meaningful_failure_hotkeys: list[str] = []
+    # Accumulate every scored (non-rejected) submission's result dict for the
+    # end-of-epoch audit report (validation-v2 Phase 1). Strictly additive —
+    # this list is only consumed by the audit-report block, which is wrapped
+    # in try/except so it can never affect scoring or weight-setting.
+    scored_results: list[dict] = []
     # Audit dispatcher needs chain_dir to enqueue jobs. Both BittensorChain
     # and LocalChain expose .chain_dir.
     chain_dir = getattr(chain, "chain_dir", None)
@@ -556,6 +578,31 @@ def run_epoch(
             "decisive": result["decisive"],
             "accepted": result["accepted"],
         })
+
+        # Accumulate a JSON-safe view of this scored submission for the
+        # end-of-epoch audit report. We strip the non-serializable `result`
+        # (ValidatorResult) and `score_report` (ScoreReport) objects and pull
+        # the lineage/attestation fields the report wants off the underlying
+        # ValidatorResult before discarding it.
+        try:
+            vr = result.get("result")
+            parent_hash = None
+            attestation_hash = None
+            if vr is not None:
+                ops = getattr(vr, "operations", {}) or {}
+                # parent lineage hash is carried in the submission_received
+                # preflight; the ValidatorResult doesn't surface it directly,
+                # so leave None unless a future scorer threads it through.
+                attestation_hash = (ops.get("op2_attestation") or {}).get("attestation_hash")
+            scored_view = {
+                k: v for k, v in result.items()
+                if k not in ("result", "score_report")
+            }
+            scored_view.setdefault("parent_king_attestation_hash", parent_hash)
+            scored_view.setdefault("attestation_hash", attestation_hash)
+            scored_results.append(scored_view)
+        except Exception as e:  # never let report bookkeeping affect scoring
+            log_debug(f"audit-report accumulation skipped for {bundle_id}: {e}")
 
         # Meaningful-failure branch: didn't crown a new king, but the work was
         # informative. Track for the 90/10 pool split; archive the bundle.
@@ -797,6 +844,12 @@ def run_epoch(
     for hk, w in recovered.items():
         round_scores[hk] = max(round_scores.get(hk, 0.0), w)
 
+    # weights_set records whether the weight extrinsic actually landed this
+    # epoch. It is INDEPENDENT of whether we build the audit report: the report
+    # documents what the validator DECIDED (round_scores), and set_weights can
+    # return early on rate-limit. We capture the bool here and stamp it into the
+    # report envelope so an auditor can see decision-vs-landed separately.
+    weights_set = False
     if round_scores:
         # Persist BEFORE attempting set_weights so a crash / rate-limit
         # mid-flight doesn't lose this epoch's credits.
@@ -804,6 +857,7 @@ def run_epoch(
         log_info(f"setting weights for {len(round_scores)} miners (split: king 90% / mf 10%)...")
         ok = chain.set_weights(round_scores)
         if ok:
+            weights_set = True
             _clear_pending_weights(chain)
         else:
             log_warn(
@@ -811,7 +865,122 @@ def run_epoch(
                 "next-epoch retry. No credit was lost."
             )
 
+    # validation-v2 Phase 1: owner-validator audit report + on-chain anchor.
+    # Build report_json from this epoch's scored results, hash + sign, anchor
+    # the hash on-chain, and write the signed envelope locally.
+    #
+    # ORDERING (the fix): this block runs UNCONDITIONALLY after round_scores /
+    # weight_snapshot are computed, regardless of whether set_weights() above
+    # succeeded or rate-limited. A rate-limited epoch still produces a full
+    # audit report (the validator's DECISION is what auditors replay; whether
+    # the extrinsic landed is recorded separately via weights_set). set_weights
+    # has no early-return that can reach here — we never return between the
+    # weight block and this block.
+    #
+    # CRITICAL: the entire block is wrapped in try/except — an audit-report
+    # failure (commit rate-limit, signing error, disk full, ...) must NEVER
+    # break scoring or weight-setting, both of which have already completed
+    # above. We log and continue. Gated behind `audit_reports_enabled`.
+    if audit_reports_enabled and scored_results:
+        try:
+            _generate_audit_report(
+                chain,
+                scored_results=scored_results,
+                weight_snapshot=round_scores,
+                epoch_start_block=epoch_start_block,
+                netuid=netuid,
+                eval_seed=eval_seed,
+                weights_set=weights_set,
+            )
+        except Exception as e:
+            log_warn(f"audit-report generation failed (scoring/weights unaffected): {e}")
+            log_debug(traceback.format_exc())
+
     return epoch_results
+
+
+def _generate_audit_report(
+    chain,
+    *,
+    scored_results: list[dict],
+    weight_snapshot: dict[str, float],
+    epoch_start_block: int,
+    netuid: int,
+    eval_seed: int,
+    weights_set: bool = False,
+) -> None:
+    """Build, hash, sign, on-chain-anchor, and persist the per-epoch audit
+    report (validation-v2 Phase 1).
+
+    Order (per the design's audit-anchor section): hash + sign the canonical
+    report, anchor the hash on-chain BEFORE serving the report, record the
+    commitment block into the envelope, then write the signed envelope locally.
+
+    `weights_set` records whether the weight extrinsic landed this epoch; it is
+    stamped into the envelope (NOT the signed report_json) so the report stays a
+    pure record of the validator's decision while auditors can still see whether
+    the on-chain weights matched it.
+
+    Raises on any failure — the single caller wraps this in try/except so a
+    failure here can't affect the already-completed scoring/weight-setting.
+    """
+    from validator.audit_report import (
+        build_envelope,
+        build_report_json,
+        canonical_json,
+        report_sha256,
+        sign_report,
+    )
+
+    end_block = chain.get_current_block()
+    epoch_id = f"{netuid}-{end_block}"
+    generated_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    report_json = build_report_json(
+        epoch_id=epoch_id,
+        netuid=netuid,
+        start_block=epoch_start_block,
+        end_block=end_block,
+        generated_at=generated_at,
+        scored=scored_results,
+        weight_snapshot=weight_snapshot,
+        seed=eval_seed,
+    )
+
+    sha = report_sha256(report_json)
+
+    # Sign with the validator hotkey Keypair when available (BittensorChain).
+    # LocalChain has no wallet → signature is empty (local-write parity).
+    signature = ""
+    signer_hotkey = ""
+    wallet = getattr(chain, "wallet", None)
+    if wallet is not None:
+        try:
+            keypair = wallet.hotkey
+            signature = sign_report(canonical_json(report_json), keypair)
+            signer_hotkey = keypair.ss58_address
+        except Exception as e:
+            log_warn(f"audit-report signing failed (continuing unsigned): {e}")
+
+    # Anchor on-chain BEFORE writing/serving the report (design: the commitment
+    # is the trust anchor). commit_audit_root raises on failure.
+    commitment_block = chain.commit_audit_root(sha)
+
+    envelope = build_envelope(
+        report_json,
+        signature=signature,
+        signer_hotkey=signer_hotkey,
+        chain_commitment_block=commitment_block,
+        weights_set=weights_set,
+    )
+
+    from validator.audit_report import write_report
+    out_dir = getattr(chain, "chain_dir", None) or RALPH_ROOT
+    report_path = write_report(envelope, Path(out_dir))
+    log_info(
+        f"audit report committed: epoch={epoch_id} sha={sha[:16]}... "
+        f"block={commitment_block} ({len(scored_results)} submissions) -> {report_path}"
+    )
 
 
 def main():

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -494,6 +494,31 @@ def _patched_hidden_eval(
         if not all(k in fields for k in required):
             return False, f"patched-eval: malformed result line: {line!r}", None
 
+        # Optional audit-reproducibility fields (validation-v2 Phase 1). Older
+        # helper versions don't emit them; "none" maps to None. Parse
+        # defensively so a malformed optional field never fails the eval.
+        def _opt_float(key: str) -> float | None:
+            v = fields.get(key)
+            if v is None or v == "none":
+                return None
+            try:
+                return float(v)
+            except ValueError:
+                return None
+
+        def _opt_int(key: str) -> int | None:
+            v = fields.get(key)
+            if v is None or v == "none":
+                return None
+            try:
+                return int(v)
+            except ValueError:
+                return None
+
+        def _opt_str(key: str) -> str | None:
+            v = fields.get(key)
+            return None if (v is None or v == "none") else v
+
         try:
             result = HiddenEvalResult(
                 val_bpb=float(fields["val_bpb"]),
@@ -501,6 +526,9 @@ def _patched_hidden_eval(
                 tokens_evaluated=int(fields["tokens_evaluated"]),
                 benchmark_examples=int(fields["benchmark_examples"]),
                 eval_set_hash=fields["eval_set_hash"],
+                val_seq_len=_opt_int("val_seq_len"),
+                sealed_stream_manifest_hash=_opt_str("sealed_stream_manifest_hash"),
+                tail_val_bpb=_opt_float("tail_val_bpb"),
             )
         except ValueError as e:
             return False, f"patched-eval: result line parse error: {e}", None


### PR DESCRIPTION
- validator/audit_report.py: canonical-json + sha256 + ed25519 sign + write
- run_epoch: build + anchor + write an audit report every epoch (unconditional; weights_set recorded in the envelope, outside the signed report_json)
- chain_layer: commit_audit_root via subtensor.set_commitment (raises on fail; local-chain file parity)
- eval: tail_val_bpb probe + val_seq_len + sealed_stream_manifest_hash surfaced for auditor reproducibility (Gate-4)
- additive, behind audit_reports_enabled flag; 741 tests pass