### PR TITLE
feat: validation-v2 Phase 2 — HF publish + CPU auditor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           python -m pip install --upgrade pip
           # CPU-only torch is enough for the test suite (smoke models on CPU).
           pip install --index-url https://download.pytorch.org/whl/cpu torch
-          pip install pytest cryptography pynacl pyyaml requests numpy tiktoken
+          pip install pytest cryptography pynacl pyyaml requests numpy tiktoken huggingface-hub
           # bittensor is large + pulls async-substrate; only install when
           # tests need it (currently audit_scheduler + chain_layer tests).
           pip install bittensor || echo "bittensor install failed, marking those tests as expected-skip"

--- a/auditor/README.md
+++ b/auditor/README.md
@@ -1,7 +1,7 @@
 # Ralph auditor
 
 Independent, **CPU-only** verifier for Ralph (Bittensor subnet 40). Anyone can
-run it to prove — on-chain — whether the owner-validator scored an epoch
+run it to prove — on-chain — whether a validator scored an epoch
 honestly, **without re-doing any GPU work**.
 
 Each epoch it runs three gates against the validator's published audit report:
@@ -58,5 +58,5 @@ will not have the state at `epoch_end_block`.
 Set `AUDITOR_SET_WEIGHTS_ENABLED=1` and provide your OWN wallet by name
 (`AUDITOR_WALLET_NAME`, `AUDITOR_WALLET_HOTKEY`) to have a registered
 auditor-validator set its own weights from the replayed scores, shadowing a
-dishonest owner. Names-in-env only — never the owner's wallet, never the secret
+dishonest validator. Names-in-env only — never the scored validator's wallet, never the secret
 material.

--- a/auditor/README.md
+++ b/auditor/README.md
@@ -26,7 +26,7 @@ replay trusts the published classification for those and notes it in
 ## Install (CPU-only, ~50 MB RAM)
 
 ```bash
-pip install httpx click bittensor       # bittensor: archive chain reads + Keypair
+pip install requests bittensor          # bittensor: archive chain reads + Keypair
 ```
 
 `bittensor` is already a Ralph dependency; no GPU/torch eval stack is exercised

--- a/auditor/README.md
+++ b/auditor/README.md
@@ -1,0 +1,62 @@
+# Ralph auditor
+
+Independent, **CPU-only** verifier for Ralph (Bittensor subnet 40). Anyone can
+run it to prove — on-chain — whether the owner-validator scored an epoch
+honestly, **without re-doing any GPU work**.
+
+Each epoch it runs three gates against the validator's published audit report:
+
+- **Gate 1 — hash + signature.** Recompute `sha256(canonical_json(report_json))`
+  and assert it equals the report's hash, the hash committed on-chain at
+  `epoch_end_block`, and that the ed25519 signature is valid. It **imports** the
+  validator's own `canonical_json`, so the bytes are identical by construction.
+- **Gate 2 — replay.** Recompute the epoch's weight vector from the published
+  raw data, **importing** the validator's weight/floor constants (so a
+  unilateral validator change makes the auditor diverge — an intended alarm).
+- **Gate 3 — diff.** Diff replayed vs claimed weights (tolerance `1e-4`).
+
+Exit codes: `0` clean · `1` hash-or-signature fail · `2` math diverge · `3` network.
+
+A re-run of the GPU eval itself (Gate 4) is **not** part of this CPU tool — it's
+Phase 3 and needs a GPU. The diff-non-trivial and rationale-coherent
+classification bars need the raw bundle and are likewise Gate-4 territory; the
+replay trusts the published classification for those and notes it in
+`replay.py`.
+
+## Install (CPU-only, ~50 MB RAM)
+
+```bash
+pip install httpx click bittensor       # bittensor: archive chain reads + Keypair
+```
+
+`bittensor` is already a Ralph dependency; no GPU/torch eval stack is exercised
+by Gates 1-3 (torch is only imported by the optional counter-weight path).
+
+## Run
+
+```bash
+python -m auditor --once                 # one pass over new epochs
+python -m auditor --loop                  # continuous (AUDIT_INTERVAL_SECONDS)
+python -m auditor --epoch 40-1234567      # one specific epoch
+python -m auditor --help
+```
+
+Key env vars: `AUDIT_REPO` (default `RalphLabsAI/audit-reports`), `NETUID`
+(default `40`), `SUBTENSOR_URL`, `VALIDATOR_HOTKEY` (signer to read the
+commitment for; defaults to the report's own `signer_hotkey`), `HF_TOKEN` (only
+for a private report repo).
+
+## Archive endpoint
+
+Each epoch's on-chain commitment **overwrites** the previous one, so historical
+verification needs an **archive** subtensor — the default
+`wss://archive.chain.opentensor.ai:443/` (free) or your own. A pruned/lite node
+will not have the state at `epoch_end_block`.
+
+## Optional counter-weight (off by default)
+
+Set `AUDITOR_SET_WEIGHTS_ENABLED=1` and provide your OWN wallet by name
+(`AUDITOR_WALLET_NAME`, `AUDITOR_WALLET_HOTKEY`) to have a registered
+auditor-validator set its own weights from the replayed scores, shadowing a
+dishonest owner. Names-in-env only — never the owner's wallet, never the secret
+material.

--- a/auditor/__init__.py
+++ b/auditor/__init__.py
@@ -1,6 +1,6 @@
 """Ralph auditor — independent CPU-only verifier for subnet 40 (Ralph).
 
-Anyone can run this against the owner-validator's published audit reports to
+Anyone can run this against a validator's published audit reports to
 prove, on-chain, whether a validator scored honestly — WITHOUT re-doing any GPU
 work. Gates 1-3 (hash+sig, scoring replay, weight diff) are pure CPU.
 

--- a/auditor/__init__.py
+++ b/auditor/__init__.py
@@ -1,0 +1,13 @@
+"""Ralph auditor — independent CPU-only verifier for subnet 40 (Ralph).
+
+Anyone can run this against the owner-validator's published audit reports to
+prove, on-chain, whether a validator scored honestly — WITHOUT re-doing any GPU
+work. Gates 1-3 (hash+sig, scoring replay, weight diff) are pure CPU.
+
+The fidelity guarantee: this package IMPORTS the validator's canonical_json and
+its weight/floor constants rather than copying them, so a unilateral validator
+change makes the auditor diverge (an intended alarm), and the round-trip test in
+tests/test_auditor_roundtrip.py proves the replay mirrors the scorer.
+"""
+
+__version__ = "0.1.0"

--- a/auditor/__main__.py
+++ b/auditor/__main__.py
@@ -1,0 +1,4 @@
+from auditor.main import main
+
+if __name__ == "__main__":
+    main()

--- a/auditor/chain.py
+++ b/auditor/chain.py
@@ -1,6 +1,6 @@
 """Read the validator's on-chain audit commitment at a historical block.
 
-Mirrors greencompute-audit/audit/chain.py. The owner commits the 64-hex
+Mirrors greencompute-audit/audit/chain.py. The validator commits the 64-hex
 sha256 of the canonical report_json via `set_commitment` (see
 chain_layer/bittensor_chain.py:commit_audit_root) — that commitment is the
 trust anchor. Because each epoch's commitment OVERWRITES the previous one, the

--- a/auditor/chain.py
+++ b/auditor/chain.py
@@ -1,0 +1,137 @@
+"""Read the validator's on-chain audit commitment at a historical block.
+
+Mirrors greencompute-audit/audit/chain.py. The owner commits the 64-hex
+sha256 of the canonical report_json via `set_commitment` (see
+chain_layer/bittensor_chain.py:commit_audit_root) — that commitment is the
+trust anchor. Because each epoch's commitment OVERWRITES the previous one, the
+auditor MUST query state at the report's historical `epoch_end_block`, which
+requires an **archive** subtensor endpoint (lite nodes prune old state):
+
+    wss://archive.chain.opentensor.ai:443/   (free, default)
+
+We use the `bittensor` SDK (already a Ralph dependency) rather than the legacy
+`substrateinterface` package the greencompute reference used. `get_commitment`
+resolves a hotkey -> uid -> Commitments.CommitmentOf(netuid, hotkey) at the
+given block_hash and decodes the Raw bytes back to the committed string.
+"""
+
+from __future__ import annotations
+
+ARCHIVE_ENDPOINT_DEFAULT = "wss://archive.chain.opentensor.ai:443/"
+
+
+class ChainClient:
+    """Queries on-chain commitments from an archive subtensor.
+
+    Pin `validator_hotkey` to the signer you trust (the report envelope carries
+    `signer_hotkey`). Reading the commitment for that exact hotkey at the
+    historical block is the whole point — a validator cannot retroactively edit
+    a committed hash.
+    """
+
+    def __init__(
+        self,
+        subtensor_url: str = ARCHIVE_ENDPOINT_DEFAULT,
+        netuid: int = 40,
+        validator_hotkey: str | None = None,
+    ) -> None:
+        self.subtensor_url = subtensor_url
+        self.netuid = netuid
+        self.validator_hotkey = validator_hotkey
+        self._subtensor = None
+
+    def _connect(self):
+        if self._subtensor is not None:
+            return self._subtensor
+        import bittensor as bt
+
+        # network= accepts a raw ws(s):// chain endpoint; pass the archive URL.
+        self._subtensor = bt.Subtensor(network=self.subtensor_url)
+        return self._subtensor
+
+    def get_commitment_hash(self, at_block: int, hotkey: str | None = None) -> str | None:
+        """Return the 64-hex sha256 the validator committed for our netuid at
+        `at_block`, or None if no commitment exists.
+
+        `hotkey` (or the pinned `self.validator_hotkey`) is the signer to read
+        the commitment for. A production auditor ALWAYS pins the exact hotkey it
+        trusts — reading 'any' commitment would let a second validator's
+        commitment masquerade as the signer's.
+        """
+        signer = hotkey or self.validator_hotkey
+        if not signer:
+            raise ValueError(
+                "ChainClient.get_commitment_hash needs the signer hotkey "
+                "(pass hotkey=... or set validator_hotkey) — never read 'any' "
+                "commitment on the netuid."
+            )
+        subtensor = self._connect()
+        try:
+            raw = subtensor.get_commitment_metadata(
+                netuid=self.netuid, hotkey_ss58=signer, block=at_block
+            )
+        except Exception:
+            return None
+        if not raw or isinstance(raw, str):
+            # Empty string => no commitment at that block for this hotkey.
+            # bittensor returns "" for "no commitment"; a real commitment is a
+            # dict we decode below.
+            if isinstance(raw, str) and raw:
+                return _normalize_hex(raw)
+            return None
+
+        decoded = _decode_commitment(raw)
+        return _normalize_hex(decoded) if decoded else None
+
+    def close(self) -> None:
+        sub = self._subtensor
+        if sub is not None:
+            try:
+                sub.close()
+            except Exception:
+                pass
+
+
+def _decode_commitment(raw) -> str | None:
+    """Decode a Commitments.CommitmentOf value into the committed UTF-8 string.
+
+    The bittensor SDK exposes `decode_metadata` for exactly this (Raw-field ->
+    str). Fall back to manual Raw-field extraction if the helper moves.
+    """
+    try:
+        from bittensor.core.chain_data.utils import decode_metadata
+
+        return decode_metadata(raw)
+    except Exception:
+        pass
+    # Manual fallback — mirror greencompute's Raw-field walk.
+    info = raw.value if hasattr(raw, "value") else raw
+    fields = info.get("fields") if isinstance(info, dict) else None
+    if not fields:
+        return None
+    for field_list in fields:
+        for entry in field_list:
+            items = entry.items() if hasattr(entry, "items") else []
+            for _tag, val in items:
+                if isinstance(val, str):
+                    if val.startswith("0x"):
+                        try:
+                            return bytes.fromhex(val[2:]).decode("utf-8")
+                        except Exception:
+                            return val[2:]
+                    return val
+    return None
+
+
+def _normalize_hex(value: str) -> str:
+    """Strip 0x and lowercase; if the value is a hex-encoded sha256 string,
+    return the 64-hex digest. The committed data is the 64-char hex digest
+    itself (see commit_audit_root), so most callers get it verbatim."""
+    v = value.strip()
+    if v.startswith("0x"):
+        v = v[2:]
+    v = v.lower()
+    return v
+
+
+__all__ = ["ARCHIVE_ENDPOINT_DEFAULT", "ChainClient"]

--- a/auditor/diff.py
+++ b/auditor/diff.py
@@ -1,0 +1,35 @@
+"""Gate 3 — diff replayed weights vs the validator's claimed weight_snapshot.
+
+Any per-hotkey divergence beyond TOLERANCE means the published weights are not
+what the published raw data scores to -> the auditor exits 2 (math diverge) and
+logs claimed / replayed / Δ for each offending hotkey. Mirrors
+greencompute-audit/audit/diff.py.
+"""
+
+from __future__ import annotations
+
+# Cross-run floating-point noise is far below this; a real discrepancy is a
+# changed weight, not rounding. 1e-4 per the design doc.
+TOLERANCE = 1e-4
+
+
+def compare_weights(
+    claimed: dict[str, float],
+    replayed: dict[str, float],
+    tolerance: float = TOLERANCE,
+) -> dict[str, dict[str, float]]:
+    """Return {hotkey: {claimed, replayed, delta}} for every hotkey whose
+    claimed and replayed weights diverge by more than `tolerance`. A hotkey
+    present on only one side counts as 0.0 on the other (a dropped/added miner
+    is itself a divergence)."""
+    discrepancies: dict[str, dict[str, float]] = {}
+    for hk in sorted(set(claimed) | set(replayed)):
+        c = float(claimed.get(hk, 0.0))
+        r = float(replayed.get(hk, 0.0))
+        delta = abs(c - r)
+        if delta > tolerance:
+            discrepancies[hk] = {"claimed": c, "replayed": r, "delta": delta}
+    return discrepancies
+
+
+__all__ = ["TOLERANCE", "compare_weights"]

--- a/auditor/fetch.py
+++ b/auditor/fetch.py
@@ -13,7 +13,7 @@ validator.audit_publish, so local and remote stores are byte-shaped the same.
 
 from __future__ import annotations
 
-import httpx
+import requests
 
 DEFAULT_AUDIT_REPO = "RalphLabsAI/audit-reports"
 _REPO_SUBDIR = "audit_reports"
@@ -31,9 +31,11 @@ class ReportClient:
     ) -> None:
         self.repo_id = repo_id
         self.revision = revision
-        headers = {"Authorization": f"Bearer {token}"} if token else {}
-        # follow_redirects: HF resolve URLs 302 to the CDN.
-        self._client = httpx.Client(timeout=timeout, follow_redirects=True, headers=headers)
+        self._timeout = timeout
+        # requests follows the HF resolve 302 -> CDN redirect by default.
+        self._session = requests.Session()
+        if token:
+            self._session.headers["Authorization"] = f"Bearer {token}"
 
     def _resolve_url(self, path_in_repo: str) -> str:
         return (
@@ -45,7 +47,7 @@ class ReportClient:
         """Return the index.json list (one thin entry per epoch). Empty list if
         the index doesn't exist yet."""
         url = self._resolve_url(f"{_REPO_SUBDIR}/index.json")
-        r = self._client.get(url)
+        r = self._session.get(url, timeout=self._timeout)
         if r.status_code == 404:
             return []
         r.raise_for_status()
@@ -55,12 +57,12 @@ class ReportClient:
     def get_report(self, epoch_id: str) -> dict:
         """Return the full signed report envelope for one epoch_id."""
         url = self._resolve_url(f"{_REPO_SUBDIR}/{epoch_id}.json")
-        r = self._client.get(url)
+        r = self._session.get(url, timeout=self._timeout)
         r.raise_for_status()
         return r.json()
 
     def close(self) -> None:
-        self._client.close()
+        self._session.close()
 
 
 __all__ = ["DEFAULT_AUDIT_REPO", "ReportClient"]

--- a/auditor/fetch.py
+++ b/auditor/fetch.py
@@ -1,4 +1,4 @@
-"""Fetch audit reports from the owner's HF dataset repo.
+"""Fetch audit reports from a validator's HF dataset repo.
 
 Mirrors greencompute-audit/audit/fetch.py, but Ralph publishes to a HuggingFace
 **dataset** repo instead of running a FastAPI server. We pull plain JSON over
@@ -20,7 +20,7 @@ _REPO_SUBDIR = "audit_reports"
 
 
 class ReportClient:
-    """HTTP client for the owner's published audit reports on HF."""
+    """HTTP client for a validator's published audit reports on HF."""
 
     def __init__(
         self,

--- a/auditor/fetch.py
+++ b/auditor/fetch.py
@@ -1,0 +1,66 @@
+"""Fetch audit reports from the owner's HF dataset repo.
+
+Mirrors greencompute-audit/audit/fetch.py, but Ralph publishes to a HuggingFace
+**dataset** repo instead of running a FastAPI server. We pull plain JSON over
+the public `resolve` URL — no HF token needed for a public repo:
+
+    https://huggingface.co/datasets/<repo>/resolve/main/audit_reports/index.json
+    https://huggingface.co/datasets/<repo>/resolve/main/audit_reports/<epoch_id>.json
+
+The layout (`audit_reports/...`) matches validator.audit_report.write_report and
+validator.audit_publish, so local and remote stores are byte-shaped the same.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+DEFAULT_AUDIT_REPO = "RalphLabsAI/audit-reports"
+_REPO_SUBDIR = "audit_reports"
+
+
+class ReportClient:
+    """HTTP client for the owner's published audit reports on HF."""
+
+    def __init__(
+        self,
+        repo_id: str = DEFAULT_AUDIT_REPO,
+        revision: str = "main",
+        token: str | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.repo_id = repo_id
+        self.revision = revision
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        # follow_redirects: HF resolve URLs 302 to the CDN.
+        self._client = httpx.Client(timeout=timeout, follow_redirects=True, headers=headers)
+
+    def _resolve_url(self, path_in_repo: str) -> str:
+        return (
+            f"https://huggingface.co/datasets/{self.repo_id}"
+            f"/resolve/{self.revision}/{path_in_repo}"
+        )
+
+    def list_reports(self) -> list[dict]:
+        """Return the index.json list (one thin entry per epoch). Empty list if
+        the index doesn't exist yet."""
+        url = self._resolve_url(f"{_REPO_SUBDIR}/index.json")
+        r = self._client.get(url)
+        if r.status_code == 404:
+            return []
+        r.raise_for_status()
+        data = r.json()
+        return data if isinstance(data, list) else []
+
+    def get_report(self, epoch_id: str) -> dict:
+        """Return the full signed report envelope for one epoch_id."""
+        url = self._resolve_url(f"{_REPO_SUBDIR}/{epoch_id}.json")
+        r = self._client.get(url)
+        r.raise_for_status()
+        return r.json()
+
+    def close(self) -> None:
+        self._client.close()
+
+
+__all__ = ["DEFAULT_AUDIT_REPO", "ReportClient"]

--- a/auditor/main.py
+++ b/auditor/main.py
@@ -1,6 +1,6 @@
 """Ralph auditor CLI — independent CPU-only verifier for subnet 40.
 
-Per epoch it runs three gates against the owner's published audit report:
+Per epoch it runs three gates against a validator's published audit report:
 
   Gate 1 (verify.py): recompute sha256(canonical_json(report_json)) and assert
       it equals the envelope hash AND the on-chain commitment at epoch_end_block,
@@ -199,7 +199,7 @@ def audit_new_epochs(chain: ChainClient, api: ReportClient) -> int:
         "Ralph auditor — independent CPU-only verifier for subnet 40.\n\n"
         "Runs Gate 1 (hash + on-chain commitment + signature), Gate 2 (weight "
         "replay from published data), and Gate 3 (weight diff, tol 1e-4) against "
-        "the owner's published audit reports.\n\n"
+        "a validator's published audit reports.\n\n"
         "Exit codes: 0 clean, 1 hash-or-sig fail, 2 math diverge, 3 network.\n\n"
         "Needs an ARCHIVE subtensor (SUBTENSOR_URL) because each epoch's "
         "commitment overwrites the last."

--- a/auditor/main.py
+++ b/auditor/main.py
@@ -1,0 +1,244 @@
+"""Ralph auditor CLI — independent CPU-only verifier for subnet 40.
+
+Per epoch it runs three gates against the owner's published audit report:
+
+  Gate 1 (verify.py): recompute sha256(canonical_json(report_json)) and assert
+      it equals the envelope hash AND the on-chain commitment at epoch_end_block,
+      and that the ed25519 signature is valid. Fail -> exit 1.
+  Gate 2 (replay.py): recompute the epoch weight vector from the published raw
+      data, importing the validator's weight/floor constants.
+  Gate 3 (diff.py):   diff replayed vs claimed weights (tol 1e-4). Fail -> exit 2.
+
+Exit codes (worst across the pass): 0 clean / 1 hash-or-sig / 2 math-diverge /
+3 network. A clean epoch advances the local `.audit_state` watermark so `--loop`
+only re-audits new epochs.
+
+    python -m auditor --once
+    python -m auditor --loop
+    python -m auditor --epoch 40-1234567
+    python -m auditor --help
+
+Env:
+    AUDIT_REPO            HF dataset repo (default RalphLabsAI/audit-reports)
+    SUBTENSOR_URL         archive endpoint (default wss://archive.chain.opentensor.ai:443/)
+    NETUID                subnet (default 40)
+    VALIDATOR_HOTKEY      signer ss58 to read the on-chain commitment for
+                          (default: the report's own signer_hotkey)
+    HF_TOKEN              only for a private report repo (public needs none)
+    AUDIT_INTERVAL_SECONDS  --loop sleep (default 300)
+    AUDITOR_SET_WEIGHTS_ENABLED  opt-in counter-weight (default off)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+# Make the sibling `validator` package importable so verify/replay can IMPORT
+# the validator's canonical_json + weight constants (the fidelity guarantee).
+# auditor/ lives at the repo root next to validator/.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import click  # noqa: E402
+
+from auditor.chain import ARCHIVE_ENDPOINT_DEFAULT, ChainClient  # noqa: E402
+from auditor.diff import compare_weights  # noqa: E402
+from auditor.fetch import DEFAULT_AUDIT_REPO, ReportClient  # noqa: E402
+from auditor.replay import replay_scoring  # noqa: E402
+from auditor.verify import verify_report  # noqa: E402
+
+logger = logging.getLogger("ralph-auditor")
+
+EXIT_CLEAN = 0
+EXIT_HASH_OR_SIG = 1
+EXIT_MATH_DIVERGE = 2
+EXIT_NETWORK = 3
+
+STATE_FILE = Path(".audit_state")
+PUBLISHED_FILE = Path(".audit_published")
+
+
+def _read_int_file(path: Path) -> int | None:
+    if not path.exists():
+        return None
+    try:
+        return int(path.read_text().strip())
+    except Exception:
+        return None
+
+
+def _write_int_file(path: Path, value: int) -> None:
+    path.write_text(str(value))
+
+
+def _setup_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s | %(levelname)-8s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+def audit_epoch(epoch_id: str, chain: ChainClient, api: ReportClient) -> int:
+    """Run Gates 1-3 for a single epoch. Returns its exit code."""
+    logger.info("auditing epoch %s", epoch_id)
+
+    try:
+        envelope = api.get_report(epoch_id)
+    except Exception as exc:
+        logger.error("epoch %s: failed to fetch report: %s", epoch_id, exc)
+        return EXIT_NETWORK
+
+    report_json = envelope.get("report_json") or {}
+    end_block = report_json.get("epoch_end_block")
+    signer = envelope.get("signer_hotkey") or os.environ.get("VALIDATOR_HOTKEY") or None
+
+    # Read the on-chain commitment at the historical block. A network failure
+    # here is EXIT_NETWORK, not a verification failure — we don't penalize the
+    # validator for the auditor's RPC being down.
+    on_chain_hash = None
+    if end_block is not None and signer:
+        try:
+            on_chain_hash = chain.get_commitment_hash(int(end_block), hotkey=signer)
+        except Exception as exc:
+            logger.error("epoch %s: chain query failed: %s", epoch_id, exc)
+            return EXIT_NETWORK
+        if on_chain_hash is None:
+            logger.warning(
+                "epoch %s: no on-chain commitment found at block %s for signer %s "
+                "— verifying self-consistency + signature only",
+                epoch_id, end_block, signer,
+            )
+
+    # Gate 1: hash (self + on-chain) + signature.
+    try:
+        verify_report(envelope, expected_onchain_hash=on_chain_hash, signer_hotkey=signer)
+    except AssertionError as exc:
+        logger.error("epoch %s: Gate-1 FAIL — %s", epoch_id, exc)
+        return EXIT_HASH_OR_SIG
+
+    # Gate 2: replay the weight derivation from published raw data.
+    replayed = replay_scoring(report_json)
+
+    # Gate 3: diff replayed vs claimed.
+    claimed = (report_json.get("weight_snapshot") or {}).get("weights") or {}
+    discrepancies = compare_weights(claimed, replayed)
+    if discrepancies:
+        for hk, d in discrepancies.items():
+            logger.error(
+                "epoch %s: Gate-3 weight mismatch %s — claimed=%.6f replayed=%.6f Δ=%.6f",
+                epoch_id, hk, d["claimed"], d["replayed"], d["delta"],
+            )
+        return EXIT_MATH_DIVERGE
+
+    logger.info(
+        "epoch %s: CLEAN — hash==on-chain, signature valid, weights replay-match (%d miners)",
+        epoch_id, len(claimed),
+    )
+    return EXIT_CLEAN
+
+
+def audit_new_epochs(chain: ChainClient, api: ReportClient) -> int:
+    """Audit every epoch newer than the local watermark. Returns the worst code.
+
+    On a clean epoch the `.audit_state` watermark advances. If
+    AUDITOR_SET_WEIGHTS_ENABLED, also counter-weights from the most recent clean
+    epoch's replayed scores using the auditor's OWN wallet.
+    """
+    from auditor.weights import is_enabled as cw_enabled
+    from auditor.weights import submit_weights
+
+    last_audited = _read_int_file(STATE_FILE)
+    try:
+        reports = api.list_reports()
+    except Exception as exc:
+        logger.error("failed to list reports: %s", exc)
+        return EXIT_NETWORK
+
+    sorted_reports = sorted(reports, key=lambda r: r.get("epoch_end_block") or 0)
+    worst = EXIT_CLEAN
+    last_clean_epoch_id: str | None = None
+    last_clean_end_block: int | None = None
+
+    for r in sorted_reports:
+        end_block = r.get("epoch_end_block")
+        if last_audited is not None and end_block is not None and end_block <= last_audited:
+            continue
+        code = audit_epoch(r["epoch_id"], chain, api)
+        worst = max(worst, code)
+        if code == EXIT_CLEAN and end_block is not None:
+            _write_int_file(STATE_FILE, end_block)
+            last_clean_epoch_id = r["epoch_id"]
+            last_clean_end_block = end_block
+
+    if last_clean_epoch_id and cw_enabled():
+        try:
+            envelope = api.get_report(last_clean_epoch_id)
+            replayed = replay_scoring(envelope.get("report_json") or {})
+            ok = submit_weights(
+                subtensor_url=chain.subtensor_url,
+                netuid=chain.netuid,
+                weights_by_hotkey=replayed,
+            )
+            if ok and last_clean_end_block is not None:
+                _write_int_file(PUBLISHED_FILE, last_clean_end_block)
+        except Exception:
+            logger.exception("counter-weight step failed for %s", last_clean_epoch_id)
+
+    return worst
+
+
+@click.command(
+    context_settings={"help_option_names": ["-h", "--help"]},
+    help=(
+        "Ralph auditor — independent CPU-only verifier for subnet 40.\n\n"
+        "Runs Gate 1 (hash + on-chain commitment + signature), Gate 2 (weight "
+        "replay from published data), and Gate 3 (weight diff, tol 1e-4) against "
+        "the owner's published audit reports.\n\n"
+        "Exit codes: 0 clean, 1 hash-or-sig fail, 2 math diverge, 3 network.\n\n"
+        "Needs an ARCHIVE subtensor (SUBTENSOR_URL) because each epoch's "
+        "commitment overwrites the last."
+    ),
+)
+@click.option("--once", is_flag=True, help="Run one audit pass over new epochs and exit.")
+@click.option("--loop", "loop_", is_flag=True, help="Run continuously every AUDIT_INTERVAL_SECONDS.")
+@click.option("--epoch", "epoch", default=None, help="Audit only this epoch_id and exit.")
+@click.option("--repo", default=None, help=f"HF dataset repo (default {DEFAULT_AUDIT_REPO}).")
+@click.option("--netuid", type=int, default=None, help="Subnet netuid (default 40).")
+@click.option("--subtensor-url", default=None, help=f"Archive endpoint (default {ARCHIVE_ENDPOINT_DEFAULT}).")
+@click.option("-v", "--verbose", is_flag=True, help="Debug logging.")
+def main(once, loop_, epoch, repo, netuid, subtensor_url, verbose) -> None:
+    _setup_logging(verbose)
+
+    repo = repo or os.environ.get("AUDIT_REPO", DEFAULT_AUDIT_REPO)
+    netuid = netuid if netuid is not None else int(os.environ.get("NETUID", "40"))
+    subtensor_url = subtensor_url or os.environ.get("SUBTENSOR_URL", ARCHIVE_ENDPOINT_DEFAULT)
+    interval = int(os.environ.get("AUDIT_INTERVAL_SECONDS", "300"))
+    validator_hotkey = os.environ.get("VALIDATOR_HOTKEY") or None
+    token = os.environ.get("HF_TOKEN") or None
+
+    chain = ChainClient(subtensor_url=subtensor_url, netuid=netuid, validator_hotkey=validator_hotkey)
+    api = ReportClient(repo_id=repo, token=token)
+
+    if epoch:
+        sys.exit(audit_epoch(epoch, chain, api))
+
+    if loop_:
+        while True:
+            try:
+                audit_new_epochs(chain, api)
+            except Exception:
+                logger.exception("audit loop iteration failed")
+            time.sleep(interval)
+
+    # default (and --once) -> single pass.
+    sys.exit(audit_new_epochs(chain, api))
+
+
+if __name__ == "__main__":
+    main()

--- a/auditor/main.py
+++ b/auditor/main.py
@@ -211,7 +211,10 @@ def main(argv: list[str] | None = None) -> None:
     p.add_argument("--epoch", default=None, help="Audit only this epoch_id and exit.")
     p.add_argument("--repo", default=None, help=f"HF dataset repo (default {DEFAULT_AUDIT_REPO}).")
     p.add_argument("--netuid", type=int, default=None, help="Subnet netuid (default 40).")
-    p.add_argument("--subtensor-url", dest="subtensor_url", default=None, help=f"Archive endpoint (default {ARCHIVE_ENDPOINT_DEFAULT}).")
+    p.add_argument(
+        "--subtensor-url", dest="subtensor_url", default=None,
+        help=f"Archive endpoint (default {ARCHIVE_ENDPOINT_DEFAULT}).",
+    )
     p.add_argument("-v", "--verbose", action="store_true", help="Debug logging.")
     args = p.parse_args(argv)
 

--- a/auditor/main.py
+++ b/auditor/main.py
@@ -31,6 +31,7 @@ Env:
 
 from __future__ import annotations
 
+import argparse
 import logging
 import os
 import sys
@@ -43,8 +44,6 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
-
-import click  # noqa: E402
 
 from auditor.chain import ARCHIVE_ENDPOINT_DEFAULT, ChainClient  # noqa: E402
 from auditor.diff import compare_weights  # noqa: E402
@@ -193,31 +192,34 @@ def audit_new_epochs(chain: ChainClient, api: ReportClient) -> int:
     return worst
 
 
-@click.command(
-    context_settings={"help_option_names": ["-h", "--help"]},
-    help=(
-        "Ralph auditor — independent CPU-only verifier for subnet 40.\n\n"
-        "Runs Gate 1 (hash + on-chain commitment + signature), Gate 2 (weight "
-        "replay from published data), and Gate 3 (weight diff, tol 1e-4) against "
-        "a validator's published audit reports.\n\n"
-        "Exit codes: 0 clean, 1 hash-or-sig fail, 2 math diverge, 3 network.\n\n"
-        "Needs an ARCHIVE subtensor (SUBTENSOR_URL) because each epoch's "
-        "commitment overwrites the last."
-    ),
-)
-@click.option("--once", is_flag=True, help="Run one audit pass over new epochs and exit.")
-@click.option("--loop", "loop_", is_flag=True, help="Run continuously every AUDIT_INTERVAL_SECONDS.")
-@click.option("--epoch", "epoch", default=None, help="Audit only this epoch_id and exit.")
-@click.option("--repo", default=None, help=f"HF dataset repo (default {DEFAULT_AUDIT_REPO}).")
-@click.option("--netuid", type=int, default=None, help="Subnet netuid (default 40).")
-@click.option("--subtensor-url", default=None, help=f"Archive endpoint (default {ARCHIVE_ENDPOINT_DEFAULT}).")
-@click.option("-v", "--verbose", is_flag=True, help="Debug logging.")
-def main(once, loop_, epoch, repo, netuid, subtensor_url, verbose) -> None:
-    _setup_logging(verbose)
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(
+        prog="auditor",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=(
+            "Ralph auditor — independent CPU-only verifier for subnet 40.\n"
+            "Gate 1 (hash + on-chain commitment + signature), Gate 2 (weight "
+            "replay from published data), Gate 3 (weight diff, tol 1e-4) against\n"
+            "a validator's published audit reports.\n"
+            "Exit codes: 0 clean, 1 hash-or-sig fail, 2 math diverge, 3 network.\n"
+            "Needs an ARCHIVE subtensor (SUBTENSOR_URL) — each epoch's "
+            "commitment overwrites the last."
+        ),
+    )
+    p.add_argument("--once", action="store_true", help="Run one audit pass over new epochs and exit.")
+    p.add_argument("--loop", dest="loop_", action="store_true", help="Run continuously every AUDIT_INTERVAL_SECONDS.")
+    p.add_argument("--epoch", default=None, help="Audit only this epoch_id and exit.")
+    p.add_argument("--repo", default=None, help=f"HF dataset repo (default {DEFAULT_AUDIT_REPO}).")
+    p.add_argument("--netuid", type=int, default=None, help="Subnet netuid (default 40).")
+    p.add_argument("--subtensor-url", dest="subtensor_url", default=None, help=f"Archive endpoint (default {ARCHIVE_ENDPOINT_DEFAULT}).")
+    p.add_argument("-v", "--verbose", action="store_true", help="Debug logging.")
+    args = p.parse_args(argv)
 
-    repo = repo or os.environ.get("AUDIT_REPO", DEFAULT_AUDIT_REPO)
-    netuid = netuid if netuid is not None else int(os.environ.get("NETUID", "40"))
-    subtensor_url = subtensor_url or os.environ.get("SUBTENSOR_URL", ARCHIVE_ENDPOINT_DEFAULT)
+    _setup_logging(args.verbose)
+
+    repo = args.repo or os.environ.get("AUDIT_REPO", DEFAULT_AUDIT_REPO)
+    netuid = args.netuid if args.netuid is not None else int(os.environ.get("NETUID", "40"))
+    subtensor_url = args.subtensor_url or os.environ.get("SUBTENSOR_URL", ARCHIVE_ENDPOINT_DEFAULT)
     interval = int(os.environ.get("AUDIT_INTERVAL_SECONDS", "300"))
     validator_hotkey = os.environ.get("VALIDATOR_HOTKEY") or None
     token = os.environ.get("HF_TOKEN") or None
@@ -225,10 +227,10 @@ def main(once, loop_, epoch, repo, netuid, subtensor_url, verbose) -> None:
     chain = ChainClient(subtensor_url=subtensor_url, netuid=netuid, validator_hotkey=validator_hotkey)
     api = ReportClient(repo_id=repo, token=token)
 
-    if epoch:
-        sys.exit(audit_epoch(epoch, chain, api))
+    if args.epoch:
+        sys.exit(audit_epoch(args.epoch, chain, api))
 
-    if loop_:
+    if args.loop_:
         while True:
             try:
                 audit_new_epochs(chain, api)

--- a/auditor/replay.py
+++ b/auditor/replay.py
@@ -8,7 +8,7 @@ Gate 3 (diff.py) compares it against the validator's claimed
   * `_apply_pool_split`  -> the §5.6 90/10 king/meaningful-failure pool split
 
 THE FIDELITY GUARANTEE: every weight/floor constant used here is IMPORTED from
-validator.service — NOT copied. If the owner unilaterally changes
+validator.service — NOT copied. If a validator unilaterally changes
 KING_CHANGE_WEIGHT, the pool fractions, or the 2x noise-floor multiplier, the
 auditor's replay shifts in lockstep with the validator code in the SAME repo,
 so a divergence between the published weights and this replay (Gate 3) is a real
@@ -38,7 +38,7 @@ weight) and reproduces `_apply_pool_split` exactly; the meaningful_failure set
 (which only divides the 10% pool) is taken from the published per-submission
 gate, because its bars 1/3/5 require data only a Gate-4 re-run (sampled bundle
 fetch) can supply. Those bars are explicitly Phase-3 territory — see
-docs/rearch_2026_06/childkey_owner_auditor_architecture.md (Gate 4).
+docs/rearch_2026_06/childkey_validator_auditor_architecture.md (Gate 4).
 """
 
 from __future__ import annotations

--- a/auditor/replay.py
+++ b/auditor/replay.py
@@ -1,0 +1,202 @@
+"""Gate 2 — faithful port of Ralph's weight derivation.
+
+This recomputes the epoch's weight vector from ONLY the published report, then
+Gate 3 (diff.py) compares it against the validator's claimed
+`weight_snapshot.weights`. It mirrors two functions in validator/service.py:
+
+  * `_classify_outcome`  -> per-submission (classification, weight_credit)
+  * `_apply_pool_split`  -> the §5.6 90/10 king/meaningful-failure pool split
+
+THE FIDELITY GUARANTEE: every weight/floor constant used here is IMPORTED from
+validator.service — NOT copied. If the owner unilaterally changes
+KING_CHANGE_WEIGHT, the pool fractions, or the 2x noise-floor multiplier, the
+auditor's replay shifts in lockstep with the validator code in the SAME repo,
+so a divergence between the published weights and this replay (Gate 3) is a real
+alarm rather than a stale-copy false positive.
+
+------------------------------------------------------------------------------
+What replay reproduces vs. what it must TRUST
+------------------------------------------------------------------------------
+`_classify_outcome` gates on five things. From the report we can reproduce the
+ones that are derivable from published data, and we must TRUST the ones that
+need the raw bundle (Gate-4 / Phase-3 territory):
+
+  1. decisively  -> DERIVABLE. decisively = (decisive_vs_king or is_first), both
+     published in eval_output. This is the load-bearing branch: it alone decides
+     the king_change (the 90%/100% share), and the auditor recomputes it from
+     scratch — it does NOT trust the published `gate` for king_change.
+  2. king_bpb is None (no king yet) -> handled via is_first.
+  3. Bar 1: val_bpb within 2x the noise band (delta > 2*floor -> plain_failure).
+     PARTIALLY derivable: needs the king's val_bpb at scoring time, which the
+     report does not carry per-submission. So for the meaningful-vs-plain split
+     this bar is TRUSTED from the published classification.
+  4. Bar 2: diff is non-trivial          -> TRUSTED (needs patch.diff in bundle).
+  5. Bar 3: rationale is coherent        -> TRUSTED (needs rationale.md in bundle).
+
+So: the auditor INDEPENDENTLY recomputes the king_change decision (the dominant
+weight) and reproduces `_apply_pool_split` exactly; the meaningful_failure set
+(which only divides the 10% pool) is taken from the published per-submission
+gate, because its bars 1/3/5 require data only a Gate-4 re-run (sampled bundle
+fetch) can supply. Those bars are explicitly Phase-3 territory — see
+docs/rearch_2026_06/childkey_owner_auditor_architecture.md (Gate 4).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# IMPORT the constants — never hardcode copies. A unilateral validator change to
+# any of these makes this replay diverge from the published weights (intended).
+from validator.service import (
+    KING_CHANGE_WEIGHT,
+    KING_POOL_FRACTION,
+    MEANINGFUL_FAILURE_POOL_FRACTION,
+    MEANINGFUL_FAILURE_WEIGHT,
+    NOISE_FLOOR_MARGIN_2X_MULTIPLIER,
+    PLAIN_FAILURE_WEIGHT,
+)
+
+# Pinned noise floor (validator/service.py --noise-floor default, and the value
+# the design doc pins for replay lockstep). Carried here so the king_bpb-delta
+# bar is reproducible the moment the report starts surfacing king_bpb per
+# submission; until then bar 1 is trusted (see module docstring).
+PINNED_NOISE_FLOOR_MARGIN = 0.013
+
+
+def classify_from_report(submission: dict, king_bpb: float | None = None) -> tuple[str, float]:
+    """Recompute (classification, weight_credit) for one report submission.
+
+    Reproduces validator.service._classify_outcome for the parts derivable from
+    the report. `king_bpb` is optional — when the report later surfaces it,
+    bar 1 (the 2x-noise-floor delta) is recomputed here too; until then we fall
+    back to the published gate for the meaningful-vs-plain decision.
+
+    The king_change branch is ALWAYS recomputed independently from
+    (decisive_vs_king or is_first) — never trusted from the published gate.
+    """
+    eo = submission.get("eval_output") or {}
+
+    # --- king_change: recomputed, not trusted (mirror _classify_outcome head) ---
+    decisive_vs_king = bool(eo.get("decisive_vs_king", False))
+    is_first = bool(eo.get("is_first", False))
+    decisively = decisive_vs_king or is_first
+    if decisively:
+        return "king_change", KING_CHANGE_WEIGHT
+
+    # No king yet and not first -> plain_failure (mirror the king_bpb-None head).
+    published_gate = eo.get("gate")
+    val_bpb = eo.get("val_bpb")
+
+    # --- Bar 1: 2x noise-floor delta. Recompute IFF king_bpb is available. ---
+    if king_bpb is not None and val_bpb is not None:
+        delta = val_bpb - king_bpb
+        if delta > NOISE_FLOOR_MARGIN_2X_MULTIPLIER * PINNED_NOISE_FLOOR_MARGIN:
+            return "plain_failure", PLAIN_FAILURE_WEIGHT
+
+    # --- Bars 2 & 3 (diff non-trivial, rationale coherent): need the bundle. ---
+    # These are Gate-4 / Phase-3. The report does not carry the patch or the
+    # rationale text, so we TRUST the validator's published classification for
+    # the meaningful-vs-plain distinction. The downstream weight effect is
+    # bounded: it only changes how the 10% pool is divided, never the 90% king
+    # share (which we recomputed above).
+    if published_gate == "meaningful_failure":
+        return "meaningful_failure", MEANINGFUL_FAILURE_WEIGHT
+    return "plain_failure", PLAIN_FAILURE_WEIGHT
+
+
+def _apply_pool_split(
+    king_change_hotkey: str | None,
+    meaningful_failure_hotkeys: list[str],
+    sitting_king_hotkey: str | None,
+) -> dict[str, float]:
+    """Port of validator.service._apply_pool_split.
+
+    The only difference from the validator version is the king-lookup: the
+    validator calls `chain.get_king()` for the sitting king when no new king was
+    crowned this epoch; the auditor has no chain handle, so it derives the
+    sitting king from the report (see replay_scoring). Everything else — the
+    90/10 fractions, the equal MF split, the max-by-hotkey guard, the
+    no-MF -> 100% case — is byte-for-byte the same.
+    """
+    weights: dict[str, float] = {}
+    king_hotkey = king_change_hotkey
+    if king_hotkey is None:
+        king_hotkey = sitting_king_hotkey
+    if not meaningful_failure_hotkeys:
+        if king_hotkey:
+            weights[king_hotkey] = 1.0
+        return weights
+    if king_hotkey:
+        weights[king_hotkey] = KING_POOL_FRACTION
+    per_mf = MEANINGFUL_FAILURE_POOL_FRACTION / len(meaningful_failure_hotkeys)
+    for hk in meaningful_failure_hotkeys:
+        weights[hk] = max(weights.get(hk, 0.0), per_mf)
+    return weights
+
+
+def _infer_sitting_king(report_json: dict[str, Any]) -> str | None:
+    """Derive the sitting king hotkey when no king_change happened this epoch.
+
+    The validator's _apply_pool_split falls back to chain.get_king(). The
+    auditor reconstructs the same hotkey from the published weight_snapshot: the
+    sitting king is whoever holds the king share (KING_POOL_FRACTION when MFs
+    exist, else 1.0). We read it off the snapshot so the no-king-change replay
+    reproduces the validator's weight vector. If the snapshot is empty (nothing
+    set this epoch) there is nothing to reproduce.
+
+    Returns the hotkey with the maximum published weight (the king share is
+    always >= any single MF share), or None.
+    """
+    weights = (report_json.get("weight_snapshot") or {}).get("weights") or {}
+    if not weights:
+        return None
+    return max(weights.items(), key=lambda kv: kv[1])[0]
+
+
+def replay_scoring(report_json: dict[str, Any]) -> dict[str, float]:
+    """Recompute the epoch's weight vector {hotkey: weight} from the report.
+
+    Steps (mirroring the validator's run_epoch tail):
+      1. classify each submission (king_change branch recomputed; MF/plain
+         taken from the published gate where bundle-only bars apply),
+      2. collect king_change_hotkey + the ordered meaningful_failure set,
+      3. apply the §5.6 90/10 pool split.
+
+    Auditors compare this against report_json.weight_snapshot.weights (Gate 3).
+    """
+    king_change_hotkey: str | None = None
+    meaningful_failure_hotkeys: list[str] = []
+
+    for sub in report_json.get("submissions") or []:
+        hk = sub.get("miner_hotkey")
+        if not hk:
+            continue
+        classification, _credit = classify_from_report(sub)
+        if classification == "king_change":
+            # Mirror service.run_epoch: a later king_change overwrites the
+            # earlier (the last crowned king of the epoch holds the share).
+            king_change_hotkey = hk
+        elif classification == "meaningful_failure":
+            if hk not in meaningful_failure_hotkeys:
+                meaningful_failure_hotkeys.append(hk)
+
+    sitting_king = None
+    if king_change_hotkey is None:
+        sitting_king = _infer_sitting_king(report_json)
+
+    return _apply_pool_split(
+        king_change_hotkey, meaningful_failure_hotkeys, sitting_king
+    )
+
+
+__all__ = [
+    "KING_CHANGE_WEIGHT",
+    "MEANINGFUL_FAILURE_WEIGHT",
+    "PLAIN_FAILURE_WEIGHT",
+    "NOISE_FLOOR_MARGIN_2X_MULTIPLIER",
+    "KING_POOL_FRACTION",
+    "MEANINGFUL_FAILURE_POOL_FRACTION",
+    "PINNED_NOISE_FLOOR_MARGIN",
+    "classify_from_report",
+    "replay_scoring",
+]

--- a/auditor/verify.py
+++ b/auditor/verify.py
@@ -1,0 +1,74 @@
+"""Gate 1 — hash + signature verification.
+
+THE FIDELITY ANCHOR: this module re-hashes the published report by importing
+the validator's OWN `canonical_json` from validator.audit_report — it does NOT
+reimplement the canonicalization. Byte-identical canonicalization is mandatory:
+if the validator changed its encoding, the import makes the auditor compute the
+same (different) bytes, so a drift is caught as an intended hash divergence
+rather than silently passing. Do NOT copy the encoding here.
+
+Checks, all hard failures:
+  * self-consistency: report_sha256(report_json) == envelope.report_sha256
+  * on-chain anchor:  == the hash committed on-chain at epoch_end_block
+  * signature:        ed25519 valid for `signer_hotkey` over canonical bytes
+"""
+
+from __future__ import annotations
+
+# IMPORT — never reimplement. canonical_json (and report_sha256, which wraps it)
+# are the validator's; importing them is the whole guarantee.
+from validator.audit_report import canonical_json, report_sha256
+
+
+def verify_report(
+    envelope: dict,
+    *,
+    expected_onchain_hash: str | None,
+    signer_hotkey: str | None = None,
+) -> None:
+    """Raise AssertionError on any integrity failure (Gate-1 -> exit 1).
+
+    Args:
+      envelope: the signed report envelope (report_json, report_sha256,
+        signature, signer_hotkey, ...).
+      expected_onchain_hash: the 64-hex sha256 read from the chain at
+        epoch_end_block. If None (chain unreachable / no commitment), the
+        on-chain anchor check is skipped — caller decides whether that's a
+        network failure vs an acceptable degraded run.
+      signer_hotkey: ss58 to verify the signature against; defaults to the
+        envelope's own signer_hotkey. The signature check is skipped only if no
+        signature was attached (unsigned LocalChain parity reports).
+    """
+    report_json = envelope.get("report_json") or {}
+    claimed_sha = (envelope.get("report_sha256") or "").lower()
+    claimed_sig = envelope.get("signature") or ""
+    claimed_signer = signer_hotkey or envelope.get("signer_hotkey") or ""
+
+    # 1. self-consistency: the envelope's hash must match canonical(report_json).
+    computed_sha = report_sha256(report_json)
+    assert computed_sha == claimed_sha, (
+        f"report self-hash mismatch: computed={computed_sha}, claimed={claimed_sha}"
+    )
+
+    # 2. on-chain anchor: the committed hash must equal the recomputed hash.
+    if expected_onchain_hash:
+        onchain = expected_onchain_hash.lower()
+        assert computed_sha == onchain, (
+            f"on-chain SHA256 mismatch: chain={onchain}, report={computed_sha} "
+            "— validator committed a hash that does not match the published report"
+        )
+
+    # 3. signature: ed25519 over the canonical bytes for the signer hotkey.
+    #    Skipped only when no signature is attached (unsigned local parity).
+    if claimed_sig and claimed_signer:
+        canonical = canonical_json(report_json)
+        try:
+            from bittensor_wallet import Keypair
+        except ImportError:  # pragma: no cover
+            from substrateinterface import Keypair  # type: ignore
+        kp = Keypair(ss58_address=claimed_signer)
+        ok = kp.verify(canonical, bytes.fromhex(claimed_sig))
+        assert ok, f"ed25519 signature invalid for report (signer={claimed_signer})"
+
+
+__all__ = ["verify_report"]

--- a/auditor/weights.py
+++ b/auditor/weights.py
@@ -2,10 +2,10 @@
 
 When AUDITOR_SET_WEIGHTS_ENABLED is set, a registered auditor-validator sets its
 OWN weights on netuid 40 from the independently-replayed scores, shadowing a
-dishonest owner. Port of greencompute-audit/audit/weights.py, adapted to the
+dishonest validator. Port of greencompute-audit/audit/weights.py, adapted to the
 Ralph `bittensor` SDK (a Ralph dependency) instead of legacy substrate-interface.
 
-KEY SECURITY PROPERTY — the auditor uses ITS OWN wallet, never the owner's:
+KEY SECURITY PROPERTY — the auditor uses ITS OWN wallet, never the scored validator's:
   * You pass wallet IDENTIFIERS (coldkey/hotkey NAMES) via env vars, never the
     secret material. The bittensor wallet on disk is read at runtime.
   * Names-in-env: AUDITOR_WALLET_NAME / AUDITOR_WALLET_HOTKEY.

--- a/auditor/weights.py
+++ b/auditor/weights.py
@@ -1,0 +1,136 @@
+"""Optional auditor-side counter-weight (off by default).
+
+When AUDITOR_SET_WEIGHTS_ENABLED is set, a registered auditor-validator sets its
+OWN weights on netuid 40 from the independently-replayed scores, shadowing a
+dishonest owner. Port of greencompute-audit/audit/weights.py, adapted to the
+Ralph `bittensor` SDK (a Ralph dependency) instead of legacy substrate-interface.
+
+KEY SECURITY PROPERTY — the auditor uses ITS OWN wallet, never the owner's:
+  * You pass wallet IDENTIFIERS (coldkey/hotkey NAMES) via env vars, never the
+    secret material. The bittensor wallet on disk is read at runtime.
+  * Names-in-env: AUDITOR_WALLET_NAME / AUDITOR_WALLET_HOTKEY.
+  * Disabled by default. Read-only verification (Gates 1-3) needs no keys.
+
+Nothing is transmitted off-box; the validator being audited never sees the
+auditor's wallet.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger("ralph-auditor.weights")
+
+
+def is_enabled() -> bool:
+    return os.environ.get("AUDITOR_SET_WEIGHTS_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _load_wallet():
+    """Load the auditor's OWN bittensor wallet from env-supplied NAMES.
+
+    AUDITOR_WALLET_NAME is required; AUDITOR_WALLET_HOTKEY defaults to "default".
+    Returns None when AUDITOR_WALLET_NAME is unset (caller treats as read-only).
+    """
+    name = os.environ.get("AUDITOR_WALLET_NAME", "").strip()
+    hotkey = os.environ.get("AUDITOR_WALLET_HOTKEY", "default").strip()
+    if not name:
+        logger.warning(
+            "AUDITOR_SET_WEIGHTS_ENABLED set but AUDITOR_WALLET_NAME unset — "
+            "staying read-only (no counter-weight)."
+        )
+        return None
+    import bittensor as bt
+
+    return bt.Wallet(name=name, hotkey=hotkey)
+
+
+def submit_weights(
+    subtensor_url: str,
+    netuid: int,
+    weights_by_hotkey: dict[str, float],
+) -> bool:
+    """Set the auditor's own weights on `netuid` from the replayed scores.
+
+    Maps each audited hotkey -> uid via the metagraph (dropping any not in it),
+    normalizes, and submits a set_weights extrinsic signed by the auditor's OWN
+    wallet. Returns True on success. Never raises into the audit loop.
+    """
+    wallet = _load_wallet()
+    if wallet is None:
+        return False
+    if not weights_by_hotkey:
+        logger.info("no replayed weights to publish; skipping counter-weight")
+        return False
+
+    try:
+        import bittensor as bt
+
+        subtensor = bt.Subtensor(network=subtensor_url)
+        metagraph = subtensor.metagraph(netuid=netuid)
+    except Exception:
+        logger.exception("failed to connect subtensor / sync metagraph at %s", subtensor_url)
+        return False
+
+    try:
+        hotkeys = list(metagraph.hotkeys)
+        auditor_ss58 = wallet.hotkey.ss58_address
+        if auditor_ss58 not in hotkeys:
+            logger.warning(
+                "auditor hotkey %s not registered on netuid=%d — cannot set "
+                "weights (register first).",
+                auditor_ss58,
+                netuid,
+            )
+            return False
+
+        import torch
+
+        uids: list[int] = []
+        vals: list[float] = []
+        for hk, w in sorted(weights_by_hotkey.items()):
+            if hk not in hotkeys:
+                logger.info("hotkey %s not in metagraph; skipping", hk)
+                continue
+            uids.append(hotkeys.index(hk))
+            vals.append(max(0.0, float(w)))
+        if not uids:
+            logger.warning("no audited hotkeys mapped to UIDs; nothing to publish")
+            return False
+
+        total = sum(vals) or 1.0
+        vals = [v / total for v in vals]
+
+        result = subtensor.set_weights(
+            wallet=wallet,
+            netuid=netuid,
+            uids=torch.tensor(uids, dtype=torch.int64),
+            weights=torch.tensor(vals, dtype=torch.float32),
+            wait_for_inclusion=True,
+            wait_for_finalization=False,
+        )
+        success = result.success if hasattr(result, "success") else bool(result)
+        logger.info(
+            "auditor counter-weight set_weights: success=%s (uids=%d, ss58=%s)",
+            success,
+            len(uids),
+            auditor_ss58,
+        )
+        return bool(success)
+    except Exception:
+        logger.exception("auditor set_weights extrinsic failed")
+        return False
+    finally:
+        try:
+            subtensor.close()
+        except Exception:
+            pass
+
+
+__all__ = ["is_enabled", "submit_weights"]

--- a/tests/test_audit_report.py
+++ b/tests/test_audit_report.py
@@ -13,6 +13,7 @@ A fixed `generated_at` is used everywhere so the report is deterministic.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -415,3 +416,133 @@ def test_write_report_and_index(tmp_path):
     index = json.loads((tmp_path / "audit_reports" / "index.json").read_text())
     epoch_ids = sorted(e["epoch_id"] for e in index)
     assert epoch_ids == ["40-400", "40-500"]
+
+
+# --------------------------------------------------------------------------
+# Phase 2 (A): HF publish — gated, idempotent, never breaks the local write.
+# --------------------------------------------------------------------------
+
+
+class _FakeHfApi:
+    """Records create_repo / upload_file calls; never touches the network.
+
+    Mimics the slice of huggingface_hub.HfApi that audit_publish uses, plus
+    hf_hub_download so _fetch_remote_index can read back an uploaded index.
+    """
+
+    def __init__(self, token=None):
+        self.token = token
+        self.created = []
+        self.uploads = {}  # path_in_repo -> bytes
+
+    def create_repo(self, repo_id, repo_type=None, exist_ok=False, token=None):
+        self.created.append((repo_id, repo_type, exist_ok))
+
+    def upload_file(self, *, path_or_fileobj, path_in_repo, repo_id, repo_type,
+                    token=None, commit_message=None):
+        data = path_or_fileobj
+        if hasattr(data, "read"):
+            data = data.read()
+        self.uploads[path_in_repo] = data
+
+    def hf_hub_download(self, *, repo_id, repo_type, filename, token=None):
+        # Serve back whatever upload_file last stored for this filename.
+        import tempfile
+        if filename not in self.uploads:
+            from huggingface_hub.errors import EntryNotFoundError
+            raise EntryNotFoundError(f"{filename} not found")
+        fd, path = tempfile.mkstemp(suffix=".json")
+        with os.fdopen(fd, "wb") as f:
+            data = self.uploads[filename]
+            f.write(data if isinstance(data, bytes) else data.encode("utf-8"))
+        return path
+
+
+def _signed_env(epoch_id="40-700"):
+    from bittensor_wallet import Keypair
+
+    kp = Keypair.create_from_uri("//PublishTest")
+    report = build_report_json(
+        epoch_id=epoch_id, netuid=40, start_block=690, end_block=700,
+        generated_at=FIXED_GENERATED_AT, scored=[_scored_king()],
+        weight_snapshot={"5Hkingalpha": 1.0},
+    )
+    sig = sign_report(canonical_json(report), kp)
+    return build_envelope(
+        report, signature=sig, signer_hotkey=kp.ss58_address,
+        chain_commitment_block=700, weights_set=True,
+    )
+
+
+def test_publish_report_hf_uploads_envelope_and_index(monkeypatch):
+    import validator.audit_publish as ap
+
+    fake = _FakeHfApi()
+    monkeypatch.setattr(ap, "HfApi", lambda token=None: fake, raising=False)
+    # HfApi is imported inside the function — patch the module symbol the
+    # function resolves via `from huggingface_hub import HfApi`.
+    import huggingface_hub
+    monkeypatch.setattr(huggingface_hub, "HfApi", lambda token=None: fake)
+
+    env = _signed_env("40-700")
+    ok = ap.publish_report_hf(env, repo_id="RalphLabsAI/audit-reports", token="x")
+    assert ok is True
+
+    # dataset repo created exist_ok; envelope + index uploaded under audit_reports/.
+    assert fake.created and fake.created[0][1] == "dataset" and fake.created[0][2] is True
+    assert "audit_reports/40-700.json" in fake.uploads
+    assert "audit_reports/index.json" in fake.uploads
+
+    idx = json.loads(fake.uploads["audit_reports/index.json"])
+    assert isinstance(idx, list) and idx[0]["epoch_id"] == "40-700"
+    assert idx[0]["report_sha256"] == env["report_sha256"]
+
+
+def test_publish_report_hf_index_upsert_is_idempotent(monkeypatch):
+    import huggingface_hub
+
+    import validator.audit_publish as ap
+
+    fake = _FakeHfApi()
+    monkeypatch.setattr(huggingface_hub, "HfApi", lambda token=None: fake)
+
+    ap.publish_report_hf(_signed_env("40-700"), token="x")
+    ap.publish_report_hf(_signed_env("40-710"), token="x")
+    ap.publish_report_hf(_signed_env("40-700"), token="x")  # re-publish -> no dup
+
+    idx = json.loads(fake.uploads["audit_reports/index.json"])
+    epoch_ids = sorted(e["epoch_id"] for e in idx)
+    assert epoch_ids == ["40-700", "40-710"]
+
+
+def test_write_report_hf_publish_gated_off_by_default(tmp_path, monkeypatch):
+    """hf_publish_enabled defaults False -> publish_report_hf is never called,
+    local write still happens."""
+    import validator.audit_publish as ap
+
+    called = {"n": 0}
+
+    def _boom(*a, **k):
+        called["n"] += 1
+        raise AssertionError("should not be called when gated off")
+
+    monkeypatch.setattr(ap, "publish_report_hf", _boom)
+    env = _signed_env("40-720")
+    path = write_report(env, tmp_path)  # default: hf_publish_enabled=False
+    assert path.exists()
+    assert called["n"] == 0
+
+
+def test_write_report_hf_publish_failure_never_breaks_local(tmp_path, monkeypatch):
+    """A publish exception is swallowed; the local report is still written."""
+    import validator.audit_publish as ap
+
+    monkeypatch.setattr(
+        ap, "publish_report_hf",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("HF down")),
+    )
+    env = _signed_env("40-730")
+    path = write_report(env, tmp_path, hf_publish_enabled=True, hf_token="x")
+    assert path.exists()
+    loaded = json.loads(path.read_text())
+    assert loaded["report_sha256"] == env["report_sha256"]

--- a/tests/test_auditor_roundtrip.py
+++ b/tests/test_auditor_roundtrip.py
@@ -1,0 +1,319 @@
+"""Round-trip fidelity proof: validator audit report -> auditor verify/replay/diff.
+
+This is the real proof the auditor faithfully mirrors the validator:
+
+  1. Build a REAL signed report via validator.audit_report.build_report_json +
+     build_envelope (fake scored submissions + a 90/10 weight snapshot).
+  2. Drive the auditor's audit_epoch (Gate 1 hash+sig, Gate 2 replay, Gate 3
+     diff) against it with in-memory fake chain/report clients -> assert CLEAN
+     (exit 0).
+  3. Mutate one weight in weight_snapshot -> Gate 3 catches it (exit 2).
+  4. Mutate a byte of the report -> Gate 1 catches it (exit 1).
+  5. Unit-assert the auditor's replay constants are the SAME OBJECTS / values as
+     the validator's (imported, not copied) and that verify uses the validator's
+     canonical_json.
+
+A fixed generated_at keeps everything deterministic.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from bittensor_wallet import Keypair
+
+import ralph_bootstrap  # noqa: F401
+import validator.service as svc
+from auditor import diff as auditor_diff
+from auditor import replay as auditor_replay
+from auditor import verify as auditor_verify
+from auditor.main import (
+    EXIT_CLEAN,
+    EXIT_HASH_OR_SIG,
+    EXIT_MATH_DIVERGE,
+    audit_epoch,
+)
+from validator.audit_report import (
+    build_envelope,
+    build_report_json,
+    canonical_json,
+    report_sha256,
+    sign_report,
+)
+
+FIXED_GENERATED_AT = "2026-06-18T00:00:00Z"
+
+
+# --- fake scored submissions (shape mirrors score_and_decide() results) ---
+
+
+def _scored_king() -> dict:
+    return {
+        "status": "accepted",
+        "classification": "king_change",
+        "weight_credit": 1.0,
+        "miner_hotkey": "5Hkingalpha",
+        "miner_github": "alice",
+        "pr_url": "",
+        "bundle_hash": "a" * 64,
+        "val_bpb": 1.2000,
+        "benchmark_accuracy": 0.42,
+        "quality_gain": 0.05,
+        "score": 0.9,
+        "tier": "verified",
+        "decisive": True,
+        "accepted": True,
+        "is_first": False,
+        "parent_king_attestation_hash": "b" * 64,
+        "attestation_hash": "c" * 64,
+        "val_seq_len": 512,
+        "sealed_stream_manifest_hash": "e" * 64,
+        "tail_val_bpb": 1.30,
+    }
+
+
+def _scored_mf() -> dict:
+    return {
+        "status": "meaningful_failure",
+        "classification": "meaningful_failure",
+        "weight_credit": 0.1,
+        "miner_hotkey": "5Hmfbeta",
+        "miner_github": "bob",
+        "pr_url": "",
+        "bundle_hash": "d" * 64,
+        "val_bpb": 1.2400,
+        "benchmark_accuracy": 0.41,
+        "quality_gain": -0.005,
+        "score": 0.0,
+        "tier": "verified",
+        "decisive": False,
+        "accepted": False,
+        "is_first": False,
+        "parent_king_attestation_hash": None,
+        "attestation_hash": None,
+        "val_seq_len": 512,
+        "sealed_stream_manifest_hash": "f" * 64,
+        "tail_val_bpb": 1.305,
+    }
+
+
+def _build_signed_envelope(weight_snapshot: dict[str, float], keypair: Keypair) -> dict:
+    """Build a fully-signed report envelope the way the validator does."""
+    report_json = build_report_json(
+        epoch_id="40-1000",
+        netuid=40,
+        start_block=900,
+        end_block=1000,
+        generated_at=FIXED_GENERATED_AT,
+        scored=[_scored_king(), _scored_mf()],
+        weight_snapshot=weight_snapshot,
+        seed=0,
+    )
+    sig = sign_report(canonical_json(report_json), keypair)
+    return build_envelope(
+        report_json,
+        signature=sig,
+        signer_hotkey=keypair.ss58_address,
+        chain_commitment_block=1000,
+        weights_set=True,
+    )
+
+
+# --- in-memory fakes so audit_epoch runs with no network / no chain ---
+
+
+class _FakeReportClient:
+    """Returns one in-memory envelope, mimicking auditor.fetch.ReportClient."""
+
+    def __init__(self, envelope: dict) -> None:
+        self._envelope = envelope
+        self._epoch_id = envelope["report_json"]["epoch_id"]
+
+    def list_reports(self) -> list[dict]:
+        rj = self._envelope["report_json"]
+        return [{"epoch_id": rj["epoch_id"], "epoch_end_block": rj["epoch_end_block"]}]
+
+    def get_report(self, epoch_id: str) -> dict:
+        assert epoch_id == self._epoch_id
+        return self._envelope
+
+
+class _FakeChainClient:
+    """Returns a pinned on-chain commitment hash, mimicking auditor.chain.ChainClient."""
+
+    def __init__(self, onchain_hash: str | None) -> None:
+        self._hash = onchain_hash
+        self.subtensor_url = "wss://fake/"
+        self.netuid = 40
+
+    def get_commitment_hash(self, at_block: int, hotkey: str | None = None) -> str | None:
+        return self._hash
+
+
+# --------------------------------------------------------------------------
+# 1. CLEAN round trip
+# --------------------------------------------------------------------------
+
+
+def test_roundtrip_clean_exit0():
+    kp = Keypair.create_from_uri("//RoundtripSigner")
+    snapshot = {"5Hkingalpha": 0.9, "5Hmfbeta": 0.1}  # the real 90/10 split
+    env = _build_signed_envelope(snapshot, kp)
+
+    # The on-chain commitment is the honest hash.
+    chain = _FakeChainClient(env["report_sha256"])
+    api = _FakeReportClient(env)
+
+    code = audit_epoch("40-1000", chain, api)
+    assert code == EXIT_CLEAN
+
+    # And the replay reproduces the exact published weight vector.
+    replayed = auditor_replay.replay_scoring(env["report_json"])
+    assert replayed == snapshot
+    assert auditor_diff.compare_weights(snapshot, replayed) == {}
+
+
+# --------------------------------------------------------------------------
+# 2. Mutated weight -> Gate 3 catches it (exit 2)
+# --------------------------------------------------------------------------
+
+
+def test_roundtrip_mutated_weight_exit2():
+    kp = Keypair.create_from_uri("//RoundtripSigner")
+    # The validator CLAIMS a tampered weight vector (king takes 0.95 instead of
+    # the 0.9 the published submissions score to). The report is internally
+    # self-consistent (hash + sig still valid) — only the math diverges.
+    tampered = {"5Hkingalpha": 0.95, "5Hmfbeta": 0.05}
+    env = _build_signed_envelope(tampered, kp)
+    chain = _FakeChainClient(env["report_sha256"])  # commitment matches the (tampered) report
+    api = _FakeReportClient(env)
+
+    code = audit_epoch("40-1000", chain, api)
+    assert code == EXIT_MATH_DIVERGE
+
+    # Gate 1 still passes (the report is self-consistent); only Gate 3 fails.
+    auditor_verify.verify_report(
+        env, expected_onchain_hash=env["report_sha256"], signer_hotkey=kp.ss58_address
+    )
+    replayed = auditor_replay.replay_scoring(env["report_json"])
+    discrepancies = auditor_diff.compare_weights(tampered, replayed)
+    assert "5Hkingalpha" in discrepancies
+    assert discrepancies["5Hkingalpha"]["replayed"] == pytest.approx(0.9)
+    assert discrepancies["5Hkingalpha"]["claimed"] == pytest.approx(0.95)
+
+
+# --------------------------------------------------------------------------
+# 3. Mutated report byte -> Gate 1 catches it (exit 1)
+# --------------------------------------------------------------------------
+
+
+def test_roundtrip_mutated_report_byte_exit1():
+    kp = Keypair.create_from_uri("//RoundtripSigner")
+    snapshot = {"5Hkingalpha": 0.9, "5Hmfbeta": 0.1}
+    env = _build_signed_envelope(snapshot, kp)
+
+    # Tamper with the report_json AFTER signing/hashing: the published hash +
+    # signature now describe a different report than the one served. The
+    # on-chain commitment still holds the ORIGINAL (honest) hash.
+    honest_hash = env["report_sha256"]
+    env["report_json"]["submissions"][0]["eval_output"]["val_bpb"] = 0.0001
+
+    chain = _FakeChainClient(honest_hash)
+    api = _FakeReportClient(env)
+
+    code = audit_epoch("40-1000", chain, api)
+    assert code == EXIT_HASH_OR_SIG
+
+    # Directly: the self-hash no longer matches the stale envelope hash.
+    with pytest.raises(AssertionError):
+        auditor_verify.verify_report(
+            env, expected_onchain_hash=honest_hash, signer_hotkey=kp.ss58_address
+        )
+    assert report_sha256(env["report_json"]) != honest_hash
+
+
+def test_roundtrip_onchain_hash_mismatch_exit1():
+    """Even if the report is internally self-consistent, a commitment hash that
+    doesn't match the report (validator edited the report after committing) is a
+    Gate-1 failure."""
+    kp = Keypair.create_from_uri("//RoundtripSigner")
+    snapshot = {"5Hkingalpha": 0.9, "5Hmfbeta": 0.1}
+    env = _build_signed_envelope(snapshot, kp)
+
+    chain = _FakeChainClient("f" * 64)  # on-chain hash != report hash
+    api = _FakeReportClient(env)
+
+    code = audit_epoch("40-1000", chain, api)
+    assert code == EXIT_HASH_OR_SIG
+
+
+def test_roundtrip_bad_signature_exit1():
+    """A signature from a different key than the named signer fails Gate 1."""
+    kp = Keypair.create_from_uri("//RoundtripSigner")
+    other = Keypair.create_from_uri("//Impostor")
+    snapshot = {"5Hkingalpha": 0.9, "5Hmfbeta": 0.1}
+    env = _build_signed_envelope(snapshot, kp)
+    # Claim the impostor as signer while the signature is over kp -> verify fails.
+    env["signer_hotkey"] = other.ss58_address
+
+    chain = _FakeChainClient(env["report_sha256"])
+    api = _FakeReportClient(env)
+    code = audit_epoch("40-1000", chain, api)
+    assert code == EXIT_HASH_OR_SIG
+
+
+# --------------------------------------------------------------------------
+# 4. Constants + canonical_json are IMPORTED from the validator, not copied
+# --------------------------------------------------------------------------
+
+
+def test_replay_constants_are_imported_identical():
+    """The auditor's replay constants must be the SAME values as the validator's
+    — imported, not hardcoded — so a unilateral validator change makes the
+    auditor diverge (intended alarm)."""
+    for name in (
+        "KING_CHANGE_WEIGHT",
+        "MEANINGFUL_FAILURE_WEIGHT",
+        "PLAIN_FAILURE_WEIGHT",
+        "NOISE_FLOOR_MARGIN_2X_MULTIPLIER",
+        "KING_POOL_FRACTION",
+        "MEANINGFUL_FAILURE_POOL_FRACTION",
+    ):
+        assert getattr(auditor_replay, name) == getattr(svc, name), name
+
+
+def test_verify_uses_validator_canonical_json():
+    """Gate 1 must re-hash with the validator's canonical_json object itself, so
+    byte-identical canonicalization is guaranteed by construction."""
+    import validator.audit_report as ar
+
+    assert auditor_verify.canonical_json is ar.canonical_json
+    # and report_sha256 -> the same bytes the validator hashes.
+    obj = {"b": 2, "a": "ünïcode"}
+    assert auditor_verify.report_sha256(obj) == ar.report_sha256(obj)
+
+
+def test_classify_king_change_recomputed_not_trusted():
+    """The king_change branch is recomputed from (decisive_vs_king or is_first),
+    NOT taken from the published gate — so a validator that mislabels a decisive
+    submission as 'plain_failure' is still scored as king_change by the auditor
+    (and Gate 3 would then flag the weight)."""
+    sub = {
+        "miner_hotkey": "5Hk",
+        "eval_output": {"gate": "plain_failure", "decisive_vs_king": True, "is_first": False},
+    }
+    classification, credit = auditor_replay.classify_from_report(sub)
+    assert classification == "king_change"
+    assert credit == svc.KING_CHANGE_WEIGHT
+
+    # is_first alone also crowns (first-ever submission).
+    sub2 = {
+        "miner_hotkey": "5Hk",
+        "eval_output": {"gate": "plain_failure", "decisive_vs_king": False, "is_first": True},
+    }
+    assert auditor_replay.classify_from_report(sub2)[0] == "king_change"

--- a/validator/audit_publish.py
+++ b/validator/audit_publish.py
@@ -1,0 +1,148 @@
+"""Publish owner-validator audit reports to a HuggingFace dataset repo.
+
+validation-v2 Phase 2 (A). The on-chain `set_commitment` remains the trust
+anchor; HF is just the off-chain store auditors pull the full signed report
+from. This module uploads the per-epoch `<epoch_id>.json` envelope and upserts
+`index.json` to a HF **dataset** repo (default `RalphLabsAI/audit-reports`).
+
+Wiring contract (see validator/audit_report.write_report):
+  * Local write always happens first and is authoritative.
+  * HF publish is gated behind an explicit `hf_publish_enabled` flag (prod-only)
+    and wrapped in try/except by the caller so a publish failure can NEVER break
+    the validator's scoring / weight-setting / local report.
+
+The layout on HF mirrors the local layout so an auditor's fetch code is the
+same shape either way:
+    <repo>/audit_reports/<epoch_id>.json   — full signed envelope
+    <repo>/audit_reports/index.json        — append-only epoch index
+
+The auditor resolves files via the public resolve URL:
+    https://huggingface.co/datasets/<repo>/resolve/main/audit_reports/index.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
+DEFAULT_AUDIT_REPO = "RalphLabsAI/audit-reports"
+
+# Where reports live inside the dataset repo. Mirrors write_report's local
+# layout (<out_dir>/audit_reports/...) so the auditor's path logic is identical
+# for local and remote.
+_REPO_SUBDIR = "audit_reports"
+
+
+def _index_path_in_repo() -> str:
+    return f"{_REPO_SUBDIR}/index.json"
+
+
+def _report_path_in_repo(epoch_id: str) -> str:
+    return f"{_REPO_SUBDIR}/{epoch_id}.json"
+
+
+def _fetch_remote_index(api, repo_id: str, token: Optional[str]) -> list[dict]:
+    """Download the existing index.json from the dataset repo (if any).
+
+    Returns [] if the repo has no index yet (first publish) or on any read
+    failure — the caller upserts onto whatever we return, so a transient read
+    miss degrades to "re-publish this epoch's entry" rather than data loss
+    (the local index.json remains the complete authoritative copy).
+    """
+    from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
+
+    try:
+        local = api.hf_hub_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            filename=_index_path_in_repo(),
+            token=token,
+        )
+        with open(local, encoding="utf-8") as f:
+            loaded = json.load(f)
+        return loaded if isinstance(loaded, list) else []
+    except (EntryNotFoundError, RepositoryNotFoundError):
+        return []
+    except Exception:
+        return []
+
+
+def _index_entry(report_envelope: dict) -> dict:
+    """Build the index.json entry for a report envelope — identical shape to
+    the one write_report writes locally so local and remote indexes agree."""
+    rj = report_envelope.get("report_json") or {}
+    return {
+        "epoch_id": rj.get("epoch_id"),
+        "epoch_start_block": rj.get("epoch_start_block"),
+        "epoch_end_block": rj.get("epoch_end_block"),
+        "report_sha256": report_envelope.get("report_sha256"),
+        "signer_hotkey": report_envelope.get("signer_hotkey"),
+        "chain_commitment_block": report_envelope.get("chain_commitment_block"),
+        "weights_set": report_envelope.get("weights_set"),
+    }
+
+
+def publish_report_hf(
+    report_envelope: dict,
+    repo_id: str = DEFAULT_AUDIT_REPO,
+    token: Optional[str] = None,
+) -> bool:
+    """Upload `<epoch_id>.json` + upsert `index.json` to a HF dataset repo.
+
+    Args:
+      report_envelope: the signed envelope from build_envelope().
+      repo_id: target HF dataset repo (default RalphLabsAI/audit-reports).
+      token: HF write token; falls back to $HF_TOKEN when None.
+
+    Returns True on success. Raises on failure — the validator caller wraps
+    this in try/except so a publish error never affects scoring/weights/local
+    write. (Returning a bool AND raising keeps both call styles honest: the
+    caller treats any exception as "publish failed, continue".)
+
+    Idempotent: re-publishing the same epoch_id overwrites the per-epoch file
+    and replaces (not duplicates) its index entry.
+    """
+    from huggingface_hub import HfApi
+
+    token = token or os.environ.get("HF_TOKEN")
+    epoch_id = (report_envelope.get("report_json") or {}).get("epoch_id")
+    if not epoch_id:
+        raise ValueError("report_envelope has no report_json.epoch_id — cannot publish")
+
+    api = HfApi(token=token)
+    # Create-if-missing; exist_ok so steady-state publishes are a no-op here.
+    api.create_repo(repo_id=repo_id, repo_type="dataset", exist_ok=True, token=token)
+
+    # 1. upload the per-epoch envelope.
+    envelope_bytes = json.dumps(
+        report_envelope, indent=2, sort_keys=True, ensure_ascii=False
+    ).encode("utf-8")
+    api.upload_file(
+        path_or_fileobj=envelope_bytes,
+        path_in_repo=_report_path_in_repo(epoch_id),
+        repo_id=repo_id,
+        repo_type="dataset",
+        token=token,
+        commit_message=f"audit report {epoch_id}",
+    )
+
+    # 2. upsert index.json: pull remote, replace-by-epoch_id, re-upload.
+    index = _fetch_remote_index(api, repo_id, token)
+    index = [e for e in index if e.get("epoch_id") != epoch_id]
+    index.append(_index_entry(report_envelope))
+    index_bytes = json.dumps(
+        index, indent=2, sort_keys=True, ensure_ascii=False
+    ).encode("utf-8")
+    api.upload_file(
+        path_or_fileobj=index_bytes,
+        path_in_repo=_index_path_in_repo(),
+        repo_id=repo_id,
+        repo_type="dataset",
+        token=token,
+        commit_message=f"index upsert {epoch_id}",
+    )
+    return True
+
+
+__all__ = ["DEFAULT_AUDIT_REPO", "publish_report_hf"]

--- a/validator/audit_publish.py
+++ b/validator/audit_publish.py
@@ -1,4 +1,4 @@
-"""Publish owner-validator audit reports to a HuggingFace dataset repo.
+"""Publish Ralph validator audit reports to a HuggingFace dataset repo.
 
 validation-v2 Phase 2 (A). The on-chain `set_commitment` remains the trust
 anchor; HF is just the off-chain store auditors pull the full signed report

--- a/validator/audit_report.py
+++ b/validator/audit_report.py
@@ -275,12 +275,26 @@ def build_envelope(
 # ---------------------------------------------------------------------------
 
 
-def write_report(report_envelope: dict, out_dir: Path) -> Path:
+def write_report(
+    report_envelope: dict,
+    out_dir: Path,
+    *,
+    hf_publish_enabled: bool = False,
+    hf_repo: Optional[str] = None,
+    hf_token: Optional[str] = None,
+) -> Path:
     """Write the signed report envelope + upsert the epoch index.
 
     Layout:
       <out_dir>/audit_reports/<epoch_id>.json   — the full signed envelope
       <out_dir>/audit_reports/index.json        — append-only epoch index
+
+    When `hf_publish_enabled` is True (prod only — default False), ALSO publish
+    the envelope + index to the HF dataset repo (`hf_repo`, default
+    RalphLabsAI/audit-reports) via validator.audit_publish. The on-chain
+    commitment is the trust anchor; HF is just the off-chain store auditors pull
+    from. The HF push is wrapped in try/except so a publish failure never breaks
+    the validator and never affects the (authoritative) local write below.
 
     Returns the path to the written per-epoch report.
     """
@@ -324,12 +338,24 @@ def write_report(report_envelope: dict, out_dir: Path) -> Path:
         json.dumps(index, indent=2, sort_keys=True, ensure_ascii=False)
     )
 
-    # TODO Phase 2: publish to HF — upload `report_path` + `index.json` to
-    # RalphLabsAI/audit-reports so auditors pull from the Hub. The on-chain
-    # commitment remains the trust anchor; HF is just the off-chain store.
-    # e.g. huggingface_hub.upload_file(path_or_fileobj=report_path,
-    #          path_in_repo=f"audit_reports/{epoch_id}.json",
-    #          repo_id="RalphLabsAI/audit-reports", repo_type="dataset")
+    # Phase 2 (A): publish the signed envelope + index to HF so auditors pull
+    # from the Hub. Local write above is authoritative; the on-chain commitment
+    # is the trust anchor. Gated behind hf_publish_enabled (prod-only) and
+    # never allowed to break the validator.
+    if hf_publish_enabled:
+        try:
+            from validator.audit_publish import DEFAULT_AUDIT_REPO, publish_report_hf
+
+            publish_report_hf(
+                report_envelope,
+                repo_id=hf_repo or DEFAULT_AUDIT_REPO,
+                token=hf_token,
+            )
+        except Exception:
+            # Best-effort: a publish failure (auth, network, rate-limit) must
+            # not affect the validator or the local report. The caller in
+            # service._generate_audit_report logs at a higher level.
+            pass
 
     return report_path
 

--- a/validator/audit_report.py
+++ b/validator/audit_report.py
@@ -1,4 +1,4 @@
-"""Owner-validator audit report — validation-v2 Phase 1.
+"""Ralph validator audit report — validation-v2 Phase 1.
 
 Ralph validators run the GPU hidden-eval scoring and set weights; this module
 anchors a per-epoch **audit commitment** on-chain so anyone can re-derive a
@@ -21,7 +21,7 @@ This module builds that per-epoch report:
 
 A scoring validator cannot lie two ways: (a) commit a hash != raw report -> caught by
 re-hash; (b) commit a report whose weights != scorer(raw data) -> caught by
-replay. See docs/rearch_2026_06/childkey_owner_auditor_architecture.md.
+replay. See docs/rearch_2026_06/childkey_validator_auditor_architecture.md.
 
 Design note — field availability: the three Gate-4 reproducibility fields
 (`val_seq_len`, `sealed_stream_manifest_hash`, `tail_val_bpb`) are now populated

--- a/validator/service.py
+++ b/validator/service.py
@@ -428,6 +428,8 @@ def run_epoch(
     audit_reports_enabled: bool = True,
     netuid: int = 40,
     eval_seed: int = 0,
+    hf_publish_enabled: bool = False,
+    hf_audit_repo: str | None = None,
 ) -> dict:
     """Process all pending submissions in one epoch.
 
@@ -803,13 +805,15 @@ def run_epoch(
             # Reuse hf_pr_info read at the top of the king-change block.
             if hf_pr_info is not None:
                 hf_pr = hf_pr_info
-                hf_token = os.environ.get("RALPH_BOT_HF_TOKEN") or os.environ.get("HF_TOKEN", "")
-                if hf_token:
+                # Distinct local — must NOT shadow run_epoch's `hf_token` param,
+                # which the end-of-epoch audit-report HF publish reuses below.
+                hf_bot_token = os.environ.get("RALPH_BOT_HF_TOKEN") or os.environ.get("HF_TOKEN", "")
+                if hf_bot_token:
                     from validator.hf_bot import merge_pr as hf_merge_pr
                     res = hf_merge_pr(
                         repo_id=hf_pr["repo_id"],
                         pr_num=hf_pr["pr_num"],
-                        token=hf_token,
+                        token=hf_bot_token,
                         comment=(
                             f"Crowned king. val_bpb={result['val_bpb']:.4f}, "
                             f"quality_gain={result['quality_gain']:+.4f}, "
@@ -891,6 +895,9 @@ def run_epoch(
                 netuid=netuid,
                 eval_seed=eval_seed,
                 weights_set=weights_set,
+                hf_publish_enabled=hf_publish_enabled,
+                hf_audit_repo=hf_audit_repo,
+                hf_token=hf_token,
             )
         except Exception as e:
             log_warn(f"audit-report generation failed (scoring/weights unaffected): {e}")
@@ -908,6 +915,9 @@ def _generate_audit_report(
     netuid: int,
     eval_seed: int,
     weights_set: bool = False,
+    hf_publish_enabled: bool = False,
+    hf_audit_repo: str | None = None,
+    hf_token: str | None = None,
 ) -> None:
     """Build, hash, sign, on-chain-anchor, and persist the per-epoch audit
     report (validation-v2 Phase 1).
@@ -976,7 +986,15 @@ def _generate_audit_report(
 
     from validator.audit_report import write_report
     out_dir = getattr(chain, "chain_dir", None) or RALPH_ROOT
-    report_path = write_report(envelope, Path(out_dir))
+    report_path = write_report(
+        envelope,
+        Path(out_dir),
+        hf_publish_enabled=hf_publish_enabled,
+        hf_repo=hf_audit_repo,
+        hf_token=hf_token,
+    )
+    if hf_publish_enabled:
+        log_info(f"audit report HF-publish requested: {hf_audit_repo or 'RalphLabsAI/audit-reports'}")
     log_info(
         f"audit report committed: epoch={epoch_id} sha={sha[:16]}... "
         f"block={commitment_block} ({len(scored_results)} submissions) -> {report_path}"
@@ -1001,6 +1019,21 @@ def main():
                    help="HuggingFace API token (defaults to $HF_TOKEN)")
     p.add_argument("--hf-limit", type=int, default=10,
                    help="Max bundles to download per epoch (default: 10)")
+    p.add_argument(
+        "--hf-publish-audit",
+        action="store_true",
+        default=os.environ.get("RALPH_HF_PUBLISH_AUDIT", "").strip().lower()
+        in {"1", "true", "yes", "on"},
+        help=(
+            "Publish per-epoch audit reports to the HF dataset repo "
+            "(prod only; default off). Also enabled via RALPH_HF_PUBLISH_AUDIT=1."
+        ),
+    )
+    p.add_argument(
+        "--hf-audit-repo",
+        default=os.environ.get("RALPH_HF_AUDIT_REPO", "RalphLabsAI/audit-reports"),
+        help="HF dataset repo for audit reports (default: RalphLabsAI/audit-reports)",
+    )
     p.add_argument("--once", action="store_true", help="Run one epoch then exit")
     args = p.parse_args()
 
@@ -1041,6 +1074,8 @@ def main():
                 hf_repo=args.hf_repo or None,
                 hf_token=args.hf_token,
                 hf_limit=args.hf_limit,
+                hf_publish_enabled=args.hf_publish_audit,
+                hf_audit_repo=args.hf_audit_repo,
             )
             if result["submissions"] > 0:
                 mf = result.get("meaningful_failures", 0)

--- a/validator/service.py
+++ b/validator/service.py
@@ -869,7 +869,7 @@ def run_epoch(
                 "next-epoch retry. No credit was lost."
             )
 
-    # validation-v2 Phase 1: owner-validator audit report + on-chain anchor.
+    # validation-v2 Phase 1: validator audit report + on-chain anchor.
     # Build report_json from this epoch's scored results, hash + sign, anchor
     # the hash on-chain, and write the signed envelope locally.
     #


### PR DESCRIPTION
- validator: publish signed audit reports to HF (gated, non-fatal)
- auditor/: CPU-only verify -> replay -> diff, exit codes 0/1/2/3; canonical_json + scorer constants IMPORTED from validator (fidelity); optional counter-weight (own wallet, off by default)
- round-trip test: build report -> audit clean; tamper weight/byte -> caught
- 753 tests pass