### PR TITLE
fix: load real DCLM bundle format in CORE-22 loader

### DIFF
--- a/eval/downstream/core22.py
+++ b/eval/downstream/core22.py
@@ -361,22 +361,38 @@ def _parse_mc_row(row: dict, line_no: int) -> MCRawRow:
 
 
 def _parse_schema_row(row: dict, line_no: int) -> SchemaRawRow:
-    """Parse one canonical schema JSONL row.
+    """Parse one schema JSONL row.
 
-    Schema: {"id": str, "contexts": [str, ...], "continuations": [str, ...],
-             "gold": int}
+    DCLM/OLMES bundle form (what's actually on disk for winograd_wsc /
+    winogrande): {"context_options": [str, ...], "continuation": str,
+    "gold": int} — N candidate contexts sharing ONE continuation; the
+    model scores the shared continuation under each context and the
+    argmax is compared to `gold` (winograd-schema scoring).
 
-    Each variant has its own (context, continuation) pair. `contexts` and
-    `continuations` must have the same length (one entry per variant).
+    Legacy form (kept for back-compat with hand-built fixtures):
+    {"contexts": [str, ...], "continuations": [str, ...], "gold": int}
+    with one continuation per variant.
+
+    Either form is normalised into `SchemaRawRow` (parallel contexts /
+    continuations lists); the DCLM form broadcasts its single
+    continuation across every context option.
     """
     try:
-        contexts = list(row["contexts"])
-        continuations = list(row["continuations"])
+        if "context_options" in row:  # real DCLM/OLMES schema format
+            contexts = list(row["context_options"])
+            continuation = row["continuation"]
+            if not isinstance(continuation, str):
+                raise TypeError("'continuation' must be a string")
+            continuations = [continuation] * len(contexts)
+        else:  # legacy canonical form (one continuation per variant)
+            contexts = list(row["contexts"])
+            continuations = list(row["continuations"])
         gold = int(row["gold"])
     except (KeyError, TypeError, ValueError) as e:
         raise ValueError(
-            f"row {line_no}: expected canonical schema "
-            f"{{contexts, continuations, gold}}; got error: {e}"
+            f"row {line_no}: expected schema "
+            f"{{context_options, continuation, gold}} "
+            f"(or legacy {{contexts, continuations, gold}}); got error: {e}"
         ) from e
     if len(contexts) != len(continuations):
         raise ValueError(
@@ -402,23 +418,28 @@ def _parse_schema_row(row: dict, line_no: int) -> SchemaRawRow:
 
 
 def _parse_lm_row(row: dict, line_no: int) -> LMRawRow:
-    """Parse one canonical LM JSONL row.
+    """Parse one LM JSONL row.
 
-    Schema: {"id": str, "context": str, "target": str,
-             "accept_set": [str, ...] | optional}
+    DCLM bundle form (what's actually on disk for lambada / squad / coqa /
+    jeopardy / bigbench_* lm tasks): {"context": str, "continuation": str}
+    — the gold completion is keyed `continuation`. Extra keys (e.g.
+    `category`) are ignored.
+
+    Legacy form (kept for back-compat with hand-built fixtures):
+    {"context": str, "target": str, "accept_set": [str, ...] | optional}.
 
     `accept_set` is the set of accepted completions for LM tasks that
-    allow multiple gold answers (e.g., a question whose answer can be
-    phrased several ways). Optional — defaults to () for LAMBADA-style
-    tasks with a single target.
+    allow multiple gold answers. Optional — defaults to () for
+    LAMBADA-style tasks with a single target.
     """
     try:
         context = str(row["context"])
-        target = str(row["target"])
+        # DCLM keys the gold completion `continuation`; legacy fixtures use `target`.
+        target = str(row["continuation"] if "continuation" in row else row["target"])
     except (KeyError, TypeError) as e:
         raise ValueError(
-            f"row {line_no}: expected canonical LM schema "
-            f"{{context, target}}; got error: {e}"
+            f"row {line_no}: expected LM schema {{context, continuation}} "
+            f"(or legacy {{context, target}}); got error: {e}"
         ) from e
     accept_raw = row.get("accept_set", [])
     if not isinstance(accept_raw, list):
@@ -434,31 +455,44 @@ def _parse_lm_row(row: dict, line_no: int) -> LMRawRow:
     )
 
 
+# CORE-22 task names whose DCLM bundle filename stem differs from the task
+# name (same underlying data). Resolved in `load_task_examples`:
+#   * winograd          → winograd_wsc.jsonl  (upstream WSC file name)
+#   * hellaswag_zeroshot → hellaswag.jsonl    (same data, 0-shot rendering)
+#   * jeopardy          → jeopardy_all.jsonl  (full 2117-item set, not _small)
+_BUNDLE_FILE_ALIASES: dict[str, str] = {
+    "winograd": "winograd_wsc",
+    "hellaswag_zeroshot": "hellaswag",
+    "jeopardy": "jeopardy_all",
+}
+
+
 def load_task_examples(
     bundle_dir: Path | str,
     task_name: str,
 ) -> list[MCRawRow | SchemaRawRow | LMRawRow]:
     """Load raw rows for a CORE-22 task from a local DCLM bundle copy.
 
-    Reads `{bundle_dir}/{task_name}.jsonl` and parses each line per
+    Reads `{bundle_dir}/{file_stem}.jsonl` (where `file_stem` is the task
+    name, or its `_BUNDLE_FILE_ALIASES` override) and parses each line per
     the task's mode (per `TASK_SPECS[task_name].mode`):
-      * mode == "mc"     → MCRawRow
-      * mode == "schema" → SchemaRawRow
-      * mode == "lm"     → LMRawRow
+      * mode == "mc"     → MCRawRow   ({query, choices, gold})
+      * mode == "schema" → SchemaRawRow ({context_options, continuation, gold})
+      * mode == "lm"     → LMRawRow   ({context, continuation})
 
-    The JSONL schema is the canonical Ralph form documented in
-    `_parse_mc_row` / `_parse_schema_row` / `_parse_lm_row`. If the
-    DCLM bundle's per-task JSONLs use different keys, the
-    downloader / mirror script (separate follow-up) is responsible for
-    re-keying into this canonical schema during the bundle-prep step.
+    Parses the DCLM/OLMES bundle's on-disk key layout directly (see the
+    per-mode parsers); `bundle_dir` may be the flat per-task mirror or the
+    raw upstream bundle root (category subdirs are walked). The parsers
+    also accept the legacy canonical keys for hand-built fixtures.
 
     Args:
-      bundle_dir: directory containing per-task `<task>.jsonl` files.
+      bundle_dir: directory containing per-task `<task>.jsonl` files
+        (flat) or the raw bundle root (nested category subdirs).
       task_name: one of `DCLM_CORE_22_TASKS`.
 
     Raises:
       ValueError if `task_name` is unknown.
-      FileNotFoundError if `{bundle_dir}/{task_name}.jsonl` doesn't exist.
+      FileNotFoundError if the task's JSONL isn't found (flat or recursive).
       ValueError if any row in the JSONL fails per-mode parsing, with a
         message naming the line number and the missing/invalid field.
     """
@@ -467,26 +501,29 @@ def load_task_examples(
             f"unknown task {task_name!r}; not in DCLM_CORE_22_TASKS"
         )
     bundle_dir = Path(bundle_dir)
-    path = bundle_dir / f"{task_name}.jsonl"
+    # A few CORE-22 task names differ from the bundle's on-disk filename stem
+    # (same underlying data; different upstream naming or eval config).
+    file_stem = _BUNDLE_FILE_ALIASES.get(task_name, task_name)
+    path = bundle_dir / f"{file_stem}.jsonl"
     if not path.exists():
         # DCLM bundle layout nests tasks in category subdirs
         # (eval_bundle/eval_data/{category}/{task}.jsonl). Walk the tree
         # so callers can pass either the flat-mirror dir or the raw
         # upstream bundle root and have lookups still resolve.
-        candidates = sorted(bundle_dir.rglob(f"{task_name}.jsonl"))
+        candidates = sorted(bundle_dir.rglob(f"{file_stem}.jsonl"))
         if len(candidates) == 1:
             path = candidates[0]
         elif len(candidates) > 1:
             raise ValueError(
-                f"ambiguous task file location for {task_name!r}: "
-                f"{[str(c) for c in candidates]}. Flatten the bundle "
-                "or pass a more specific bundle_dir."
+                f"ambiguous task file location for {task_name!r} "
+                f"(stem {file_stem!r}): {[str(c) for c in candidates]}. "
+                "Flatten the bundle or pass a more specific bundle_dir."
             )
         else:
             raise FileNotFoundError(
-                f"CORE-22 task file {task_name}.jsonl not found under "
-                f"{bundle_dir} (searched flat + recursive). The bundle "
-                f"download (URL {DCLM_EVAL_BUNDLE_URL}) must place "
+                f"CORE-22 task file {file_stem}.jsonl (task {task_name!r}) "
+                f"not found under {bundle_dir} (searched flat + recursive). "
+                f"The bundle download (URL {DCLM_EVAL_BUNDLE_URL}) must place "
                 f"per-task JSONLs under the supplied bundle_dir."
             )
 

--- a/tests/test_downstream_core22.py
+++ b/tests/test_downstream_core22.py
@@ -418,6 +418,81 @@ def test_load_task_examples_lm_happy_path(tmp_path):
     assert rows[1].accept_set == (" fox", " Fox")
 
 
+def test_load_task_examples_schema_dclm_format(tmp_path):
+    """The real DCLM/OLMES schema layout — N context_options sharing ONE
+    continuation — parses, broadcasting the continuation across options."""
+    _write_jsonl(tmp_path / "winogrande.jsonl", [
+        {"context_options": ["Sarah was a better surgeon than Maria so Sarah",
+                             "Sarah was a better surgeon than Maria so Maria"],
+         "continuation": "always got the easier cases.",
+         "gold": 1},
+    ])
+    rows = load_task_examples(tmp_path, "winogrande")
+    assert len(rows) == 1
+    row = rows[0]
+    assert isinstance(row, SchemaRawRow)
+    assert len(row.contexts) == 2
+    # shared continuation broadcast to one entry per context option
+    assert row.continuations == ["always got the easier cases."] * 2
+    assert row.gold == 1
+
+
+def test_load_task_examples_lm_dclm_format(tmp_path):
+    """The real DCLM LM layout keys the gold completion `continuation`
+    (not `target`); extra keys like `category` are ignored."""
+    _write_jsonl(tmp_path / "jeopardy_all.jsonl", [
+        {"context": "This planet is the largest", "continuation": "Jupiter",
+         "category": "Science"},
+    ])
+    rows = load_task_examples(tmp_path, "jeopardy")  # alias → jeopardy_all
+    assert len(rows) == 1
+    assert isinstance(rows[0], LMRawRow)
+    assert rows[0].context == "This planet is the largest"
+    assert rows[0].target == "Jupiter"
+    assert rows[0].accept_set == ()
+
+
+def test_load_task_examples_bundle_file_alias(tmp_path):
+    """Task names whose on-disk stem differs (winograd→winograd_wsc,
+    hellaswag_zeroshot→hellaswag) resolve via _BUNDLE_FILE_ALIASES."""
+    _write_jsonl(tmp_path / "winograd_wsc.jsonl", [
+        {"context_options": ["The councilmen refused a permit because the councilmen",
+                             "The councilmen refused a permit because the demonstrators"],
+         "continuation": "feared violence.", "gold": 0},
+    ])
+    rows = load_task_examples(tmp_path, "winograd")
+    assert len(rows) == 1
+    assert isinstance(rows[0], SchemaRawRow)
+
+
+_REAL_BUNDLE = (
+    Path(__file__).resolve().parent.parent
+    / "eval/private/downstream_pool/bundle_v1/eval_bundle/eval_data"
+)
+
+
+@pytest.mark.skipif(
+    not _REAL_BUNDLE.exists(),
+    reason="DCLM eval bundle not present (gitignored; download via "
+    "scripts/download_dclm_bundle.py)",
+)
+def test_load_all_core22_from_real_bundle():
+    """Every CORE-22 task loads from the actual on-disk DCLM bundle.
+
+    Regression guard for the parser/alias fix: before it, the 2 schema +
+    9 lm tasks crashed (wrong field names) and winograd/hellaswag_zeroshot/
+    jeopardy failed file resolution — only the 11 mc tasks loaded.
+    """
+    for task_name in DCLM_CORE_22_TASKS:
+        rows = load_task_examples(_REAL_BUNDLE, task_name)
+        assert len(rows) > 0, f"{task_name}: loaded zero rows"
+        mode = TASK_SPECS[task_name].mode
+        expected = {"mc": MCRawRow, "schema": SchemaRawRow, "lm": LMRawRow}[mode]
+        assert all(isinstance(r, expected) for r in rows), (
+            f"{task_name} (mode={mode}): wrong row type"
+        )
+
+
 def test_load_task_examples_skips_blank_lines(tmp_path):
     """Blank lines in the JSONL are skipped, not parsed as bad JSON."""
     path = tmp_path / "arc_easy.jsonl"
@@ -478,7 +553,7 @@ def test_load_task_examples_lm_missing_context_raises(tmp_path):
     _write_jsonl(tmp_path / "lambada_openai.jsonl", [
         {"id": "l", "target": " time"},  # missing 'context'
     ])
-    with pytest.raises(ValueError, match=r"canonical LM schema"):
+    with pytest.raises(ValueError, match=r"expected LM schema"):
         load_task_examples(tmp_path, "lambada_openai")
 
 


### PR DESCRIPTION
- schema parser reads {context_options, continuation, gold}, broadcasting the shared continuation across options (winograd-schema scoring)
- lm parser reads the `continuation` key (bundle uses it, not `target`)
- both keep legacy {contexts,continuations}/{context,target} for fixtures
- add task->file aliases: winograd->winograd_wsc, hellaswag_zeroshot->
  hellaswag, jeopardy->jeopardy_all
- before: 2 schema + 9 lm tasks crashed the parser + 3 failed file resolution -> downstream eval was effectively mc-only (11/22)
- now all 22 CORE-22 tasks load from the real bundle
- tests: real-format schema/lm rows, alias resolution, skip-if-absent real-bundle smoke (loads all 22)