### PR TITLE
feat: Gate-4 GPU re-eval decision spine (Phase 3)

### DIFF
--- a/auditor/README.md
+++ b/auditor/README.md
@@ -15,13 +15,22 @@ Each epoch it runs three gates against the validator's published audit report:
   unilateral validator change makes the auditor diverge — an intended alarm).
 - **Gate 3 — diff.** Diff replayed vs claimed weights (tolerance `1e-4`).
 
-Exit codes: `0` clean · `1` hash-or-signature fail · `2` math diverge · `3` network.
+Exit codes: `0` clean · `1` hash-or-signature fail · `2` math diverge · `3` network · `4` eval diverged (Gate 4).
 
-A re-run of the GPU eval itself (Gate 4) is **not** part of this CPU tool — it's
-Phase 3 and needs a GPU. The diff-non-trivial and rationale-coherent
-classification bars need the raw bundle and are likewise Gate-4 territory; the
-replay trusts the published classification for those and notes it in
-`replay.py`.
+**Gate 4 — GPU re-eval (Phase 3, in progress).** Gates 1-3 trust the published
+`val_bpb` — the one number a GPU produced. Gate 4 re-runs that eval on the sealed
+stream the validator committed to and asserts the recomputed `val_bpb` matches the
+claim (same checkpoint + same stream → deterministic modulo cross-GPU FP drift, far
+below the 0.0064 noise floor). It is **tiered** so the expensive re-run focuses where
+weight rides on it: king-change candidates (the 90-100% share) get a full re-eval,
+meaningful-failures a cheap sampled pass, plain-failures none. The decision spine
+(tiering, sampling, tolerance, verdict) lives in `auditor/gate4.py` and is CPU-only
+/ torch-free at import; the actual re-eval imports the validator's own
+`eval.val_bpb.compute_val_bpb` lazily and needs a GPU. Still to land: wiring it into
+the `python -m auditor` loop, bundle fetch + manifest-hash verification, and
+**calibrating the tolerance against measured cross-GPU drift**. The diff-non-trivial
+and rationale-coherent classification bars likewise need the raw bundle (Gate-4
+territory); the replay trusts the published classification for those (see `replay.py`).
 
 ## Install (CPU-only, ~50 MB RAM)
 

--- a/auditor/gate4.py
+++ b/auditor/gate4.py
@@ -1,0 +1,235 @@
+"""Gate 4 — GPU re-eval (Phase 3).
+
+Gates 1-3 (hash/sig, weight-replay, diff) prove a validator did the *scoring
+math* honestly on CPU, but they TRUST the published `val_bpb` — the one number
+a GPU actually produced. Gate 4 closes that: a GPU-equipped auditor re-runs the
+val_bpb eval on the sealed stream the validator committed to and asserts the
+recomputed number matches the claim within tolerance. Same checkpoint, same
+sealed stream → the result is deterministic modulo cross-GPU floating-point
+drift, which is far below the 0.0064 val_bpb noise floor.
+
+This module is the **decision spine** — tiering, sampling, tolerance, verdict —
+and is pure/CPU-importable (no torch at import time). The actual re-eval
+(`reeval_val_bpb_on_sample`) lazily imports torch + the validator's OWN
+`eval.val_bpb.compute_val_bpb` (fidelity by construction, exactly as Gate 2
+imports the scorer constants), so it only pulls the GPU stack when invoked.
+
+Tiering (focus the expensive re-run where it matters — see 00_v0_11_master §6):
+
+    plain_failure      → NONE   (CPU Gates 1-3 + the recomputed king decision
+                                  already cover it; its weight is in the 10% pool
+                                  only and it lost — re-eval buys nothing)
+    meaningful_failure → CHEAP  (modest GPU, sampled — only divides the 10% pool)
+    king_change cand.  → H200   (decisive_vs_king or is_first — the 90-100% share
+                                  rides on this number; full re-eval, max scrutiny)
+
+H100_FULL is the escalation rung: a CHEAP sampled pass that lands inside an
+escalation band (near tolerance) gets re-run in full on bigger iron before a
+divergence is called.
+
+Exit code (extends auditor/main.py): 4 = eval diverged (claim not reproduced).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+# Exit code, continuing auditor/main.py's ladder (0 clean / 1 hash-sig / 2 math
+# diverge / 3 network).
+EXIT_EVAL_DIVERGE = 4
+
+# --- tiers ---------------------------------------------------------------
+TIER_NONE = "none"          # no GPU re-eval; CPU gates suffice
+TIER_CHEAP = "cheap_gpu"    # sampled re-eval on a modest GPU
+TIER_H100_FULL = "h100_full"  # full re-eval (escalation rung)
+TIER_H200_KINGCHANGE = "h200_kingchange"  # full re-eval, king-change candidates
+
+# Fraction of eval windows to re-run per tier. King-change is load-bearing →
+# full; meaningful-failure only divides the 10% pool → sampled.
+_TIER_SAMPLE_FRACTION = {
+    TIER_NONE: 0.0,
+    TIER_CHEAP: 0.25,
+    TIER_H100_FULL: 1.0,
+    TIER_H200_KINGCHANGE: 1.0,
+}
+
+# Default pass band for |recomputed - claimed| val_bpb. The val_bpb noise floor
+# (B5 calibration) is σ≈0.0064 and the win threshold is ≈0.013; an honest
+# re-eval of the SAME checkpoint+stream drifts only by cross-GPU FP error (≪σ),
+# while a validator inflating its score must move val_bpb by ≥ the win
+# threshold. We default to half the noise floor — comfortably above honest drift,
+# comfortably below a score-changing lie.
+#
+# ⚠️ CALIBRATE before trusting in production: measure real cross-GPU val_bpb
+# drift (same ckpt+stream across the GPU SKUs auditors actually run) and set this
+# to a few× the observed max. Passed explicitly so a calibration run can override.
+VAL_BPB_NOISE_FLOOR = 0.0064
+DEFAULT_GATE4_TOLERANCE = VAL_BPB_NOISE_FLOOR / 2  # 0.0032
+
+# Re-eval landing within [tolerance, tolerance × ESCALATION_BAND] of the claim is
+# "borderline" → escalate a sampled CHEAP pass to a full H100 pass before calling
+# divergence (a sampled subset is noisier than the full set).
+ESCALATION_BAND = 2.0
+
+
+def _is_king_change_candidate(eval_output: dict[str, Any]) -> bool:
+    """A submission the king decision rides on: it decisively beat the king, or
+    it is the genesis (first) submission. Both are published in eval_output and
+    independently recomputed by the replay gate — Gate 4 re-verifies the number
+    underneath that decision."""
+    return bool(
+        eval_output.get("decisive_vs_king")
+        or eval_output.get("is_first")
+        or eval_output.get("gate") == "king_change"
+    )
+
+
+def select_tier(eval_output: dict[str, Any]) -> str:
+    """Map one submission's published eval_output to its Gate-4 re-eval tier."""
+    if _is_king_change_candidate(eval_output):
+        return TIER_H200_KINGCHANGE
+    if eval_output.get("gate") == "meaningful_failure":
+        return TIER_CHEAP
+    return TIER_NONE
+
+
+def sample_fraction(tier: str) -> float:
+    """Fraction of eval windows to re-run for `tier`."""
+    try:
+        return _TIER_SAMPLE_FRACTION[tier]
+    except KeyError:
+        raise ValueError(f"unknown Gate-4 tier {tier!r}") from None
+
+
+@dataclass(frozen=True)
+class Gate4Verdict:
+    """Outcome of a Gate-4 val_bpb re-eval for one submission."""
+
+    tier: str
+    claimed_val_bpb: Optional[float]
+    recomputed_val_bpb: Optional[float]
+    delta: Optional[float]            # recomputed - claimed (None if not re-run)
+    tolerance: float
+    passed: bool
+    escalate: bool                    # borderline → re-run fuller before calling it
+    reason: str
+
+    @property
+    def exit_code(self) -> int:
+        return EXIT_EVAL_DIVERGE if not self.passed else 0
+
+
+def evaluate_val_bpb_match(
+    claimed_val_bpb: Optional[float],
+    recomputed_val_bpb: Optional[float],
+    *,
+    tier: str,
+    tolerance: float = DEFAULT_GATE4_TOLERANCE,
+) -> Gate4Verdict:
+    """Compare a re-run val_bpb against the validator's claim.
+
+    A TIER_NONE submission is not re-run → passes by deferral to Gates 1-3.
+    Otherwise the absolute delta must be within `tolerance`; landing in the
+    escalation band (≤ tolerance × ESCALATION_BAND) sets `escalate` so a sampled
+    pass can be re-run in full before a hard divergence is declared.
+    """
+    if tolerance <= 0:
+        raise ValueError(f"tolerance must be > 0; got {tolerance}")
+
+    if tier == TIER_NONE:
+        return Gate4Verdict(
+            tier=tier, claimed_val_bpb=claimed_val_bpb, recomputed_val_bpb=None,
+            delta=None, tolerance=tolerance, passed=True, escalate=False,
+            reason="tier=none: CPU gates 1-3 cover this submission; no re-eval",
+        )
+
+    if claimed_val_bpb is None or recomputed_val_bpb is None:
+        return Gate4Verdict(
+            tier=tier, claimed_val_bpb=claimed_val_bpb,
+            recomputed_val_bpb=recomputed_val_bpb, delta=None,
+            tolerance=tolerance, passed=False, escalate=False,
+            reason="missing val_bpb (claimed or recomputed) — cannot verify",
+        )
+
+    delta = recomputed_val_bpb - claimed_val_bpb
+    abs_delta = abs(delta)
+    passed = abs_delta <= tolerance
+    escalate = (
+        tier in (TIER_CHEAP, TIER_H100_FULL)
+        and tolerance < abs_delta <= tolerance * ESCALATION_BAND
+    )
+    if passed:
+        reason = f"val_bpb reproduced: |Δ|={abs_delta:.6f} ≤ tol {tolerance:.6f}"
+    elif escalate:
+        reason = (
+            f"borderline: |Δ|={abs_delta:.6f} in escalation band "
+            f"({tolerance:.6f}, {tolerance * ESCALATION_BAND:.6f}] — re-run fuller"
+        )
+    else:
+        reason = (
+            f"DIVERGED: |Δ|={abs_delta:.6f} > tol {tolerance:.6f} "
+            f"(claimed {claimed_val_bpb:.6f}, recomputed {recomputed_val_bpb:.6f})"
+        )
+    return Gate4Verdict(
+        tier=tier, claimed_val_bpb=claimed_val_bpb,
+        recomputed_val_bpb=recomputed_val_bpb, delta=delta, tolerance=tolerance,
+        passed=passed, escalate=escalate, reason=reason,
+    )
+
+
+def reeval_val_bpb_on_sample(
+    model: Any,
+    batch: Any,
+    seq_len: int,
+    *,
+    fraction: float,
+    batch_size: int = 8,
+    device: Any = None,
+) -> float:
+    """Re-run val_bpb on `fraction` of a sealed stream's windows (GPU path).
+
+    Lazily imports the validator's OWN `eval.val_bpb.compute_val_bpb` so the
+    recomputation is byte-for-byte the scoring code (Gate-2-style fidelity), and
+    torch is only touched here. `model`/`batch` are the loaded checkpoint and a
+    `SealedStreamBatch` (see eval/sealed_streams.load_stream); the caller owns
+    fetching + manifest-hash verification of the bundle and stream.
+
+    Sampling takes the first `ceil(fraction · n_windows)` windows so the subset
+    is deterministic and reproducible across auditors (no RNG to agree on).
+    """
+    import math
+
+    import numpy as np
+
+    from eval.val_bpb import compute_val_bpb
+
+    if not 0.0 < fraction <= 1.0:
+        raise ValueError(f"fraction must be in (0, 1]; got {fraction}")
+
+    tokens = np.asarray(batch.tokens)
+    n_windows = max(1, tokens.shape[0] // seq_len)
+    keep = max(1, math.ceil(n_windows * fraction))
+    sampled = tokens[: keep * seq_len]
+
+    result = compute_val_bpb(
+        model, sampled, seq_len, batch_size, device,
+        bytes_per_token=batch.spec.bytes_per_token,
+    )
+    return float(result["val_bpb"])
+
+
+__all__ = [
+    "EXIT_EVAL_DIVERGE",
+    "TIER_NONE",
+    "TIER_CHEAP",
+    "TIER_H100_FULL",
+    "TIER_H200_KINGCHANGE",
+    "VAL_BPB_NOISE_FLOOR",
+    "DEFAULT_GATE4_TOLERANCE",
+    "ESCALATION_BAND",
+    "Gate4Verdict",
+    "select_tier",
+    "sample_fraction",
+    "evaluate_val_bpb_match",
+    "reeval_val_bpb_on_sample",
+]

--- a/tests/test_auditor_gate4.py
+++ b/tests/test_auditor_gate4.py
@@ -17,8 +17,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import ralph_bootstrap  # noqa: F401
 from auditor.gate4 import (
     DEFAULT_GATE4_TOLERANCE,
-    EXIT_EVAL_DIVERGE,
     ESCALATION_BAND,
+    EXIT_EVAL_DIVERGE,
     TIER_CHEAP,
     TIER_H100_FULL,
     TIER_H200_KINGCHANGE,

--- a/tests/test_auditor_gate4.py
+++ b/tests/test_auditor_gate4.py
@@ -1,0 +1,186 @@
+"""Gate-4 (GPU re-eval) decision-spine tests — pure CPU, no torch/GPU.
+
+Covers tier selection, sampling fractions, the val_bpb match verdict (pass /
+diverge / escalation band / tier-none deferral), exit codes, and the
+re-eval sampling math (with compute_val_bpb mocked so no model/GPU is needed).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import ralph_bootstrap  # noqa: F401
+from auditor.gate4 import (
+    DEFAULT_GATE4_TOLERANCE,
+    EXIT_EVAL_DIVERGE,
+    ESCALATION_BAND,
+    TIER_CHEAP,
+    TIER_H100_FULL,
+    TIER_H200_KINGCHANGE,
+    TIER_NONE,
+    Gate4Verdict,
+    evaluate_val_bpb_match,
+    reeval_val_bpb_on_sample,
+    sample_fraction,
+    select_tier,
+)
+
+
+# --- select_tier ---------------------------------------------------------
+@pytest.mark.parametrize("eo", [
+    {"decisive_vs_king": True},
+    {"is_first": True},
+    {"gate": "king_change"},
+])
+def test_select_tier_king_change_candidates_get_h200(eo):
+    assert select_tier(eo) == TIER_H200_KINGCHANGE
+
+
+def test_select_tier_meaningful_failure_is_cheap():
+    assert select_tier({"gate": "meaningful_failure"}) == TIER_CHEAP
+
+
+def test_select_tier_plain_failure_is_none():
+    assert select_tier({"gate": "plain_failure"}) == TIER_NONE
+
+
+def test_select_tier_king_change_beats_gate_label():
+    # decisive flag wins even if the gate string says otherwise
+    assert select_tier({"gate": "meaningful_failure", "decisive_vs_king": True}) \
+        == TIER_H200_KINGCHANGE
+
+
+# --- sample_fraction -----------------------------------------------------
+def test_sample_fraction_per_tier():
+    assert sample_fraction(TIER_NONE) == 0.0
+    assert sample_fraction(TIER_CHEAP) == 0.25
+    assert sample_fraction(TIER_H100_FULL) == 1.0
+    assert sample_fraction(TIER_H200_KINGCHANGE) == 1.0
+
+
+def test_sample_fraction_unknown_tier_raises():
+    with pytest.raises(ValueError, match="unknown Gate-4 tier"):
+        sample_fraction("quantum_gpu")
+
+
+# --- evaluate_val_bpb_match ----------------------------------------------
+def test_verdict_pass_within_tolerance():
+    v = evaluate_val_bpb_match(1.5000, 1.5010, tier=TIER_H200_KINGCHANGE,
+                               tolerance=0.0032)
+    assert v.passed and not v.escalate
+    assert v.delta == pytest.approx(0.0010)
+    assert v.exit_code == 0
+
+
+def test_verdict_diverged_beyond_band():
+    v = evaluate_val_bpb_match(1.5000, 1.5200, tier=TIER_H200_KINGCHANGE,
+                               tolerance=0.0032)
+    assert not v.passed and not v.escalate
+    assert v.exit_code == EXIT_EVAL_DIVERGE
+    assert "DIVERGED" in v.reason
+
+
+def test_verdict_escalation_band_for_sampled_tier():
+    # |Δ|=0.005 is in (0.0032, 0.0064] → escalate (cheap sampled pass is noisier)
+    v = evaluate_val_bpb_match(1.5000, 1.5050, tier=TIER_CHEAP, tolerance=0.0032)
+    assert not v.passed and v.escalate
+    assert "escalation band" in v.reason
+
+
+def test_verdict_no_escalation_for_full_king_change_tier():
+    # H200 is already a full pass — no escalation rung above it
+    v = evaluate_val_bpb_match(1.5000, 1.5050, tier=TIER_H200_KINGCHANGE,
+                               tolerance=0.0032)
+    assert not v.passed and not v.escalate
+
+
+def test_verdict_tier_none_passes_by_deferral():
+    v = evaluate_val_bpb_match(1.5, None, tier=TIER_NONE)
+    assert v.passed and v.recomputed_val_bpb is None
+    assert "no re-eval" in v.reason
+
+
+def test_verdict_missing_val_bpb_fails():
+    v = evaluate_val_bpb_match(None, 1.5, tier=TIER_CHEAP)
+    assert not v.passed
+    assert v.exit_code == EXIT_EVAL_DIVERGE
+
+
+def test_verdict_nonpositive_tolerance_raises():
+    with pytest.raises(ValueError, match="tolerance must be > 0"):
+        evaluate_val_bpb_match(1.5, 1.5, tier=TIER_CHEAP, tolerance=0.0)
+
+
+def test_escalation_band_boundary_is_inclusive():
+    # exactly tolerance × ESCALATION_BAND is still escalate, not hard-diverge
+    tol = DEFAULT_GATE4_TOLERANCE
+    edge = tol * ESCALATION_BAND
+    v = evaluate_val_bpb_match(1.5, 1.5 + edge, tier=TIER_CHEAP, tolerance=tol)
+    assert v.escalate and not v.passed
+
+
+# --- reeval_val_bpb_on_sample (sampling math; compute_val_bpb mocked) -----
+class _FakeSpec:
+    bytes_per_token = 4.0
+    id = "stream_a"
+
+
+class _FakeBatch:
+    spec = _FakeSpec()
+
+    def __init__(self, n_tokens):
+        self.tokens = np.zeros(n_tokens, dtype=np.int64)
+
+
+def test_reeval_samples_ceil_fraction_of_windows(monkeypatch):
+    seen = {}
+
+    def fake_compute(model, tokens, seq_len, batch_size, device, *, bytes_per_token):
+        seen["n_tokens"] = len(tokens)
+        seen["bytes_per_token"] = bytes_per_token
+        return {"val_bpb": 1.234}
+
+    import eval.val_bpb as vb
+    monkeypatch.setattr(vb, "compute_val_bpb", fake_compute)
+
+    # 10 windows of seq_len 16; fraction 0.25 → ceil(2.5)=3 windows kept
+    batch = _FakeBatch(n_tokens=160)
+    out = reeval_val_bpb_on_sample(model=object(), batch=batch, seq_len=16,
+                                   fraction=0.25)
+    assert out == pytest.approx(1.234)
+    assert seen["n_tokens"] == 3 * 16
+    assert seen["bytes_per_token"] == 4.0
+
+
+def test_reeval_full_fraction_keeps_all_windows(monkeypatch):
+    seen = {}
+
+    def fake_compute(model, tokens, seq_len, batch_size, device, *, bytes_per_token):
+        seen["n_tokens"] = len(tokens)
+        return {"val_bpb": 1.0}
+
+    import eval.val_bpb as vb
+    monkeypatch.setattr(vb, "compute_val_bpb", fake_compute)
+
+    batch = _FakeBatch(n_tokens=160)
+    reeval_val_bpb_on_sample(model=object(), batch=batch, seq_len=16, fraction=1.0)
+    assert seen["n_tokens"] == 160
+
+
+def test_reeval_bad_fraction_raises():
+    batch = _FakeBatch(n_tokens=160)
+    with pytest.raises(ValueError, match="fraction must be in"):
+        reeval_val_bpb_on_sample(model=object(), batch=batch, seq_len=16, fraction=0.0)
+
+
+def test_gate4verdict_is_frozen():
+    v = Gate4Verdict(tier=TIER_NONE, claimed_val_bpb=1.0, recomputed_val_bpb=None,
+                     delta=None, tolerance=0.003, passed=True, escalate=False,
+                     reason="x")
+    with pytest.raises(Exception):
+        v.passed = False  # type: ignore[misc]


### PR DESCRIPTION
- auditor/gate4.py: the CPU-only decision spine for GPU re-eval
- tiering focuses the expensive re-run where weight rides on it: king-change candidates -> H200 full, meaningful_failure -> cheap sampled, plain_failure -> none (CPU gates 1-3 already cover it)
- val_bpb match verdict: pass band defaults to half the 0.0064 noise floor; escalation band re-runs a borderline sampled pass in full
- reeval_val_bpb_on_sample imports the validator's own compute_val_bpb (Gate-2-style fidelity), lazy torch -> module is CPU-importable
- exit code 4 = eval diverged
- 20 tests: tier/sampling/verdict + sampling math (compute_val_bpb mocked)
- README: Gate-4 documented as Phase-3 in-progress
- remaining: CLI wiring, bundle fetch + manifest verify, tolerance calibration vs measured cross-GPU drift