### PR TITLE
fix: stub reads eat_nonce from nested GPU EAT (issue 6)

### DIFF
--- a/proof/real_attest.py
+++ b/proof/real_attest.py
@@ -399,6 +399,42 @@ def _extract_gpu_jwt(token):
     return token
 
 
+def _all_bundle_jwts(token) -> list[str]:
+    """Recursively collect every JWT string in a get_token() bundle.
+
+    The real NRAS token is NESTED (2026-06-22 CC report, Issue 6):
+        [["JWT", <outer_eat>], {"REMOTE_GPU_CLAIMS": [["JWT", <gpu_eat>], {…}]}]
+    The outer EAT is only an envelope (iss/iat/exp/jti — NO eat_nonce); the real
+    `eat_nonce` + NVIDIA claims live on the inner REMOTE_GPU_CLAIMS submodule EAT.
+    Walk the whole structure (any depth / key names) and return every string that
+    looks like a JWT (header.payload.signature), so the caller can find the layer
+    that actually carries the claim it needs.
+    """
+    import json as _json
+
+    out: list[str] = []
+
+    def walk(x):
+        if isinstance(x, str):
+            s = x.strip()
+            if s.count(".") == 2 and not s.startswith(("[", "{")):
+                out.append(s)
+            elif s.startswith(("[", "{")):
+                try:
+                    walk(_json.loads(s))
+                except Exception:
+                    pass
+        elif isinstance(x, (list, tuple)):
+            for i in x:
+                walk(i)
+        elif isinstance(x, dict):
+            for v in x.values():
+                walk(v)
+
+    walk(token)
+    return out
+
+
 def verify_gpu_token(token: str, expected_nonce: str) -> tuple[bool, str]:
     """Verify an NVIDIA GPU attestation JWT token.
 
@@ -428,11 +464,20 @@ def verify_gpu_token(token: str, expected_nonce: str) -> tuple[bool, str]:
         )
         try:
             import jwt
-            # get_token() returns the detached-EAT bundle; decode the OUTER JWT,
-            # not the whole bundle (fixes "Invalid header string").
-            inner = _extract_gpu_jwt(token)
-            claims = jwt.decode(inner, options={"verify_signature": False})
-            token_nonce = claims.get("eat_nonce", claims.get("nonce", ""))
+            # get_token() returns a NESTED detached-EAT bundle. eat_nonce lives
+            # on the inner REMOTE_GPU_CLAIMS submodule EAT, NOT the outer envelope
+            # (Issue 6). Search every JWT layer for the nonce claim rather than
+            # only decoding the outer one.
+            token_nonce = ""
+            jwts = _all_bundle_jwts(token) or [_extract_gpu_jwt(token)]
+            for _j in jwts:
+                try:
+                    _c = jwt.decode(_j, options={"verify_signature": False})
+                except Exception:
+                    continue
+                token_nonce = _c.get("eat_nonce") or _c.get("nonce") or ""
+                if token_nonce:
+                    break
             # Compare in the SDK's 64-hex form (token claim has no 0x prefix).
             exp = gpu_sdk_nonce(expected_nonce) if expected_nonce else ""
             if exp and gpu_sdk_nonce(token_nonce) != exp:

--- a/tests/test_real_attest_nonce.py
+++ b/tests/test_real_attest_nonce.py
@@ -98,3 +98,37 @@ def test_stub_accepts_real_get_token_bundle(monkeypatch):
     bundle = _json.dumps([["JWT", outer], {"GPU-0": outer}])  # nv-sdk shape
     ok, detail = RA.verify_gpu_token(bundle, onchain)
     assert ok, detail
+
+
+def test_all_bundle_jwts_collects_nested():
+    """Issue 6: the real NRAS token nests the GPU EAT under REMOTE_GPU_CLAIMS."""
+    import json as _json
+
+    nested = [["JWT", "outer.env.sig"],
+              {"REMOTE_GPU_CLAIMS": [["JWT", "gpu.claims.sig"], {}]}]
+    got = RA._all_bundle_jwts(nested)
+    assert "outer.env.sig" in got and "gpu.claims.sig" in got
+    # also works from a JSON string
+    assert set(RA._all_bundle_jwts(_json.dumps(nested))) == {"outer.env.sig", "gpu.claims.sig"}
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("jwt") is None, reason="PyJWT not installed"
+)
+def test_stub_finds_eat_nonce_on_nested_gpu_submodule(monkeypatch):
+    """Issue 6 regression: eat_nonce is on the inner REMOTE_GPU_CLAIMS EAT, NOT
+    the outer envelope. The stub must search the nested layer."""
+    import json as _json
+
+    import jwt
+
+    monkeypatch.setenv("RALPH_ALLOW_REAL_ATTEST_STUB", "1")
+    bare = "2fcc0dbc" * 8  # 64 hex
+    onchain = "0x" + bare
+    # outer envelope has NO eat_nonce (just iss/exp/jti) — like the real token
+    outer = jwt.encode({"iss": "NRAS", "exp": 9999999999, "jti": "x"}, "s", algorithm="HS256")
+    gpu_eat = jwt.encode({"sub": "...", "eat_nonce": bare,
+                          "x-nvidia-overall-att-result": True}, "s", algorithm="HS256")
+    bundle = _json.dumps([["JWT", outer], {"REMOTE_GPU_CLAIMS": [["JWT", gpu_eat], {}]}])
+    ok, detail = RA.verify_gpu_token(bundle, onchain)
+    assert ok, detail


### PR DESCRIPTION
The real NRAS token nests the GPU EAT under the REMOTE_GPU_CLAIMS submodule:
  [["JWT",<outer>],{"REMOTE_GPU_CLAIMS":[["JWT",<gpu_eat>],{}]}]
The outer EAT is envelope-only (iss/exp/jti — no eat_nonce); the real eat_nonce is on the inner submodule EAT. The stub read it off the outer (absent -> "") -> nonce mismatch.

- _all_bundle_jwts: recursively collect every JWT in the bundle (any depth)
- stub searches all layers for eat_nonce / nonce
- unblocks generation -> stub-verify E2E on testnet (real CC hardware)
- reported by miner with 10 real bundles on a GCP CC H100