### PR TITLE
validator: verify handshake against on-chain commitment

### DIFF
--- a/chain_layer/bittensor_chain.py
+++ b/chain_layer/bittensor_chain.py
@@ -41,6 +41,20 @@ import torch
 from .interface import ChainInterface, HandshakeRecord, KingRecord
 
 
+def handshake_commit_hash(miner_hotkey: str, patch_hash: str, nonce: str) -> str:
+    """The on-chain handshake commitment payload hash — SINGLE SOURCE OF TRUTH.
+
+    Used by request_handshake_nonce (the miner commits this hash) and by
+    verify_handshake_onchain (the validator reconstructs it from the submission
+    and compares against the miner's on-chain commitment). Binding all three of
+    hotkey/patch_hash/nonce into the preimage means one hash compare verifies
+    all three at once.
+    """
+    return hashlib.sha256(
+        f"karpa:handshake:{miner_hotkey}:{patch_hash}:{nonce}".encode()
+    ).hexdigest()
+
+
 def _locked_append(path: Path, text: str) -> None:
     """Append text to a file with an advisory exclusive lock.
 
@@ -121,8 +135,7 @@ class BittensorChain(ChainInterface):
         invisible to the chain.
         """
         nonce = "0x" + secrets.token_hex(32)
-        commit_data = f"karpa:handshake:{miner_hotkey}:{patch_hash}:{nonce}"
-        commit_hash = hashlib.sha256(commit_data.encode()).hexdigest()
+        commit_hash = handshake_commit_hash(miner_hotkey, patch_hash, nonce)
 
         try:
             self.subtensor.set_commitment(
@@ -224,6 +237,35 @@ class BittensorChain(ChainInterface):
                     timestamp=entry["timestamp"],
                 )
         return None
+
+    def verify_handshake_onchain(
+        self, miner_hotkey: str, patch_hash: str, nonce: str
+    ) -> tuple[bool, str]:
+        """Verify the handshake against the miner's LIVE on-chain commitment.
+
+        Reads the miner's commitment via subtensor.get_commitment(netuid, uid)
+        and compares it to the hash reconstructed from this submission. This is
+        the real chain query — unlike the local handshakes.jsonl lookup, it works
+        for any external miner whose commit lives on the actual chain. Note that
+        set_commitment overwrites per submission, so the submission's nonce must
+        match the miner's most-recent commitment.
+        """
+        uid = self.get_uid(miner_hotkey)
+        if uid is None:
+            return False, "hotkey not registered on subnet"
+        try:
+            committed = self.subtensor.get_commitment(netuid=self.netuid, uid=uid)
+        except Exception as e:
+            return False, f"get_commitment failed: {type(e).__name__}: {e}"
+        if not committed:
+            return False, "no on-chain handshake commitment for this hotkey"
+        expected = handshake_commit_hash(miner_hotkey, patch_hash or "", nonce)
+        if str(committed).strip().lower() != expected.lower():
+            return False, (
+                f"on-chain commitment mismatch (chain={str(committed)[:16]}, "
+                f"expected={expected[:16]})"
+            )
+        return True, "handshake verified on-chain"
 
     def is_hotkey_registered(self, hotkey: str) -> bool:
         """Check if a hotkey is registered on the subnet's metagraph."""

--- a/chain_layer/interface.py
+++ b/chain_layer/interface.py
@@ -64,6 +64,26 @@ class ChainInterface(ABC):
     def lookup_handshake(self, nonce: str) -> Optional[HandshakeRecord]:
         """Verify a nonce was committed. Returns the record or None."""
 
+    def verify_handshake_onchain(
+        self, miner_hotkey: str, patch_hash: str, nonce: str
+    ) -> tuple[bool, str]:
+        """Verify a miner's handshake binds (hotkey, patch_hash, nonce).
+
+        Default implementation uses the local `lookup_handshake` record;
+        BittensorChain overrides this to query the live on-chain commitment.
+        """
+        rec = self.lookup_handshake(nonce)
+        if rec is None:
+            return False, "handshake nonce not found on chain"
+        if rec.miner_hotkey != miner_hotkey:
+            return False, "handshake nonce was committed by a different miner"
+        if patch_hash and rec.patch_hash and rec.patch_hash != patch_hash:
+            return False, (
+                f"on-chain patch_hash mismatch: chain={rec.patch_hash[:12]}, "
+                f"bundle={patch_hash[:12]}"
+            )
+        return True, "handshake verified"
+
     @abstractmethod
     def is_hotkey_registered(self, hotkey: str) -> bool:
         """Check if a hotkey is registered on the subnet."""

--- a/tests/test_handshake_onchain.py
+++ b/tests/test_handshake_onchain.py
@@ -1,0 +1,95 @@
+"""On-chain handshake verification (the fix for external miners being rejected
+at op1 because lookup_handshake read a local file the validator never had).
+
+Covers the shared commit-hash helper, LocalChain's inherited (local) verify,
+and BittensorChain's real get_commitment-based verify (with a fake subtensor).
+"""
+from __future__ import annotations
+
+from chain_layer.bittensor_chain import BittensorChain, handshake_commit_hash
+from chain_layer.local import LocalChain
+
+
+# ------------------------------------------------- shared commit-hash helper
+def test_handshake_commit_hash_binds_all_three():
+    h = handshake_commit_hash("5GminerHK", "patchsha", "0xnonce")
+    assert len(h) == 64
+    # changing ANY of the three inputs changes the hash
+    assert h != handshake_commit_hash("5GotherHK", "patchsha", "0xnonce")
+    assert h != handshake_commit_hash("5GminerHK", "OTHER", "0xnonce")
+    assert h != handshake_commit_hash("5GminerHK", "patchsha", "0xOTHER")
+    assert h == handshake_commit_hash("5GminerHK", "patchsha", "0xnonce")  # deterministic
+
+
+# ------------------------------------------------- LocalChain (inherited default)
+def test_localchain_verify_handshake_matrix(tmp_path):
+    lc = LocalChain(tmp_path / "chain")
+    nonce = lc.request_handshake_nonce("5GminerHK", "patchsha123")
+    assert lc.verify_handshake_onchain("5GminerHK", "patchsha123", nonce)[0]
+    # wrong hotkey / wrong patch / wrong nonce all reject
+    assert not lc.verify_handshake_onchain("5GotherHK", "patchsha123", nonce)[0]
+    assert not lc.verify_handshake_onchain("5GminerHK", "DIFFERENT", nonce)[0]
+    ok, detail = lc.verify_handshake_onchain("5GminerHK", "patchsha123", "0xmissing")
+    assert not ok and "not found" in detail.lower()
+
+
+# ------------------------------------------------- BittensorChain on-chain logic
+class _FakeSub:
+    def __init__(self, commitment):
+        self._c = commitment
+
+    def get_commitment(self, netuid, uid, block=None):
+        return self._c
+
+
+class _FakeChain:
+    """Minimal stand-in exposing what verify_handshake_onchain touches."""
+    netuid = 40
+
+    def __init__(self, uid, commitment):
+        self._uid = uid
+        self.subtensor = _FakeSub(commitment)
+
+    def get_uid(self, hotkey):
+        return self._uid
+
+
+def _verify(fc, hk, patch, nonce):
+    # call the real BittensorChain method with the fake as self
+    return BittensorChain.verify_handshake_onchain(fc, hk, patch, nonce)
+
+
+def test_bittensorchain_verify_matches_onchain_commitment():
+    hk, patch, nonce = "5Gminer", "patchabc", "0xdead"
+    good = handshake_commit_hash(hk, patch, nonce)
+    ok, detail = _verify(_FakeChain(7, good), hk, patch, nonce)
+    assert ok, detail
+
+
+def test_bittensorchain_verify_rejects_wrong_nonce_patch_hotkey():
+    hk, patch, nonce = "5Gminer", "patchabc", "0xdead"
+    good = handshake_commit_hash(hk, patch, nonce)
+    fc = _FakeChain(7, good)
+    assert not _verify(fc, hk, patch, "0xbeef")[0]      # nonce changed
+    assert not _verify(fc, hk, "otherpatch", nonce)[0]  # patch changed
+    assert not _verify(fc, "5Gother", patch, nonce)[0]  # different hotkey's preimage
+
+
+def test_bittensorchain_verify_rejects_missing_commitment_and_unregistered():
+    hk, patch, nonce = "5Gminer", "patchabc", "0xdead"
+    ok1, d1 = _verify(_FakeChain(7, None), hk, patch, nonce)
+    assert not ok1 and "no on-chain" in d1.lower()
+    ok2, d2 = _verify(_FakeChain(None, "x"), hk, patch, nonce)
+    assert not ok2 and "not registered" in d2.lower()
+
+
+class _BoomSub:
+    def get_commitment(self, netuid, uid, block=None):
+        raise RuntimeError("rpc down")
+
+
+def test_bittensorchain_verify_handles_get_commitment_error():
+    fc = _FakeChain(7, None)
+    fc.subtensor = _BoomSub()
+    ok, detail = _verify(fc, "5Gminer", "p", "0xn")
+    assert not ok and "get_commitment failed" in detail

--- a/validator/service.py
+++ b/validator/service.py
@@ -253,7 +253,7 @@ def score_and_decide(
     noise_floor_margin: float,
 ) -> dict:
     """Score one submission against the current king. Returns a result dict."""
-    result = judge_submission(RALPH_ROOT, bundle_dir)
+    result = judge_submission(RALPH_ROOT, bundle_dir, chain=chain)
 
     if result.rejected:
         return {

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -172,6 +172,7 @@ def op1_diff_and_integrity(
     ralph_root: Path,
     submission_payload: dict,
     proof_dir: Path,
+    chain=None,
 ) -> tuple[bool, str]:
     """Verify miner signature + bundle integrity + restricted-file scan.
 
@@ -256,20 +257,30 @@ def op1_diff_and_integrity(
     # miners — set RALPH_SKIP_HANDSHAKE=1 to skip in that mode.
     import os as _os
     if not _os.environ.get("RALPH_SKIP_HANDSHAKE"):
-        chain_entry = lookup_handshake(ralph_root, submission_payload["handshake_nonce"])
-        if chain_entry is None:
-            return False, "handshake nonce not found on chain"
-        if chain_entry.get("miner_hotkey") != submission_payload["miner_hotkey"]:
-            return False, "handshake nonce was committed by a different miner"
-        # #9: cross-check that the patch the miner committed on-chain matches
-        # the patch in the bundle. Without this, a miner can commit "look
-        # I'm running patch X" and ship a bundle for entirely different patch Y.
-        chain_patch_hash = chain_entry.get("patch_hash")
-        if chain_patch_hash and patch_sha and chain_patch_hash != patch_sha:
-            return False, (
-                f"on-chain patch_hash mismatch: chain={chain_patch_hash[:12]}, "
-                f"bundle={patch_sha[:12]}"
+        # Verify the handshake binds (hotkey, patch_hash, nonce). With a chain
+        # handle this queries the miner's LIVE on-chain commitment (works for
+        # any external miner — #9 patch cross-check is folded into the hash).
+        # Without one, fall back to the local handshakes.jsonl record.
+        if chain is not None and hasattr(chain, "verify_handshake_onchain"):
+            ok_hs, detail_hs = chain.verify_handshake_onchain(
+                submission_payload["miner_hotkey"],
+                patch_sha or "",
+                submission_payload["handshake_nonce"],
             )
+            if not ok_hs:
+                return False, detail_hs
+        else:
+            chain_entry = lookup_handshake(ralph_root, submission_payload["handshake_nonce"])
+            if chain_entry is None:
+                return False, "handshake nonce not found on chain"
+            if chain_entry.get("miner_hotkey") != submission_payload["miner_hotkey"]:
+                return False, "handshake nonce was committed by a different miner"
+            chain_patch_hash = chain_entry.get("patch_hash")
+            if chain_patch_hash and patch_sha and chain_patch_hash != patch_sha:
+                return False, (
+                    f"on-chain patch_hash mismatch: chain={chain_patch_hash[:12]}, "
+                    f"bundle={patch_sha[:12]}"
+                )
 
     # #12: restricted-file scanner now runs on the validator side. The
     # miner-side scan in proof.runner was bypassable by a miner who skipped
@@ -583,8 +594,13 @@ def op4_hidden_eval(
 def judge_submission(
     ralph_root: Path,
     proof_dir: Path,
+    chain=None,
 ) -> ValidatorResult:
-    """Run the four ops in order. Any failure shorts out and returns a rejection."""
+    """Run the four ops in order. Any failure shorts out and returns a rejection.
+
+    `chain`, when provided, lets op1 verify the handshake against the live
+    on-chain commitment instead of the local handshakes.jsonl record.
+    """
     sub_path = proof_dir / "submission.json"
     if not sub_path.exists():
         return ValidatorResult(
@@ -602,7 +618,7 @@ def judge_submission(
         handshake_nonce=submission["handshake_nonce"],
     )
 
-    ok, detail = op1_diff_and_integrity(ralph_root, submission, proof_dir)
+    ok, detail = op1_diff_and_integrity(ralph_root, submission, proof_dir, chain=chain)
     result.operations["op1_diff_integrity"] = {"ok": ok, "detail": detail}
     if not ok:
         result.rejected = ValidatorReject("op1_diff_integrity", detail)


### PR DESCRIPTION
- lookup_handshake only read a local handshakes.jsonl the validator never has -> every EXTERNAL miner rejected at op1 "handshake nonce not found" (real or mock), the true blocker for accepting submissions
- add verify_handshake_onchain: read the miner's get_commitment(netuid,uid) and compare it to sha256("karpa:handshake:<hotkey>:<patch>:<nonce>") reconstructed from the submission — binds hotkey+patch+nonce in one hash
- handshake_commit_hash helper = single source of truth (commit + verify)
- ChainInterface default keeps the local-file lookup (tests/LocalChain); thread chain through judge_submission -> op1_diff_and_integrity
- 6 tests