### PR TITLE
validator: version-aware reprocess + fair queue order

### DIFF
--- a/tests/test_hf_poller_attribution.py
+++ b/tests/test_hf_poller_attribution.py
@@ -1,0 +1,95 @@
+"""Tests for per-PR bundle attribution in the HF poller.
+
+list_repo_files(revision="refs/pr/N") returns the cumulative tree (base main +
+the PR's files), so the poller must isolate the bundle each PR actually adds —
+primarily via the PR title (`Submit proof bundle <hash12>`), falling back to a
+diff against main. These tests pin that behaviour with a fake HfApi.
+"""
+
+from datetime import datetime, timezone
+
+import huggingface_hub
+
+from validator.hf_poller import list_remote_submissions
+
+A = "a" * 64  # already merged on main
+B = "b" * 64  # added by PR 1
+C = "c" * 64  # added by PR 2
+D = "d" * 64  # added by PR 3
+E = "e" * 64  # added by PR 4 (non-standard title → fallback)
+X = "9" * 64  # in PR 3's cumulative tree but NOT on main (e.g. reverted mock)
+
+
+def _files(*bundle_ids):
+    out = ["README.md", ".gitattributes"]
+    for bid in bundle_ids:
+        out.append(f"submissions/{bid}/submission.json")
+        out.append(f"submissions/{bid}/checkpoint.pt")
+    return out
+
+
+class _FakeDiscussion:
+    def __init__(self, num, title, created, status="open", is_pr=True):
+        self.num = num
+        self.title = title
+        self.status = status
+        self.is_pull_request = is_pr
+        self.git_reference = f"refs/pr/{num}"
+        self.created_at = created
+
+
+class _FakeApi:
+    def __init__(self, discussions, trees):
+        self._discussions = discussions
+        self._trees = trees  # {None: main_files, "refs/pr/N": files}
+
+    def get_repo_discussions(self, repo_id=None, repo_type=None):
+        return iter(self._discussions)
+
+    def list_repo_files(self, repo_id, repo_type=None, revision=None, token=None):
+        return self._trees[revision]
+
+
+def _install(monkeypatch, discussions, trees):
+    api = _FakeApi(discussions, trees)
+    monkeypatch.setattr(huggingface_hub, "HfApi", lambda token=None: api)
+
+
+def test_attributes_only_each_prs_own_bundle(monkeypatch):
+    def t(n):
+        return datetime(2026, 6, n, tzinfo=timezone.utc)
+
+    discussions = [
+        _FakeDiscussion(2, f"Submit proof bundle {C[:12]}", t(2)),
+        _FakeDiscussion(1, f"Submit proof bundle {B[:12]}", t(1)),  # out of order on purpose
+        _FakeDiscussion(3, f"Submit proof bundle {D[:12]}", t(3)),
+        _FakeDiscussion(4, "rebrand: tidy dataset", t(4)),          # no hash → fallback
+        _FakeDiscussion(99, "an issue, not a PR", t(1), is_pr=False),
+        _FakeDiscussion(98, f"Submit proof bundle {C[:12]}", t(1), status="closed"),
+    ]
+    trees = {
+        None: _files(A),               # main
+        "refs/pr/1": _files(A, B),     # cumulative: base + own
+        "refs/pr/2": _files(A, B, C),
+        "refs/pr/3": _files(A, X, D),  # X present here but gone from main
+        "refs/pr/4": _files(A, E),     # title carries no hash
+    }
+    _install(monkeypatch, discussions, trees)
+
+    subs = list_remote_submissions("RalphLabsAI/proof-bundles")
+
+    # Oldest-first, one entry per open PR, each its own bundle.
+    assert [(s["pr_num"], s["bundle_id"]) for s in subs] == [
+        (1, B), (2, C), (3, D), (4, E),
+    ]
+    seen = {s["bundle_id"] for s in subs}
+    assert A not in seen  # merged baseline never re-attributed
+    assert X not in seen  # deleted-from-main bundle not mis-attributed to PR 3
+
+
+def test_fallback_skips_pr_with_no_identifiable_bundle(monkeypatch):
+    # Non-standard title AND nothing new vs main → nothing to attribute.
+    discussions = [_FakeDiscussion(7, "housekeeping", datetime(2026, 6, 7, tzinfo=timezone.utc))]
+    trees = {None: _files(A), "refs/pr/7": _files(A)}
+    _install(monkeypatch, discussions, trees)
+    assert list_remote_submissions("RalphLabsAI/proof-bundles") == []

--- a/tests/test_hf_poller_versioning.py
+++ b/tests/test_hf_poller_versioning.py
@@ -1,0 +1,66 @@
+"""Tests for HF-poller version-aware reprocessing + time-based queue ordering.
+
+Covers two fairness behaviours:
+  1. hf_state.json stamps each processed bundle with VALIDATOR_VERSION; entries
+     judged by an older version are reprocessed on a version bump.
+  2. poll_queue orders pending bundles by submission (PR creation) time, i.e.
+     first-come-first-validate — NOT by bundle-hash lexical order.
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+
+from validator import hf_poller as hp
+from validator.service import poll_queue
+from validator.version import VALIDATOR_VERSION
+
+
+def test_legacy_list_state_is_migrated_and_reprocessed(tmp_path):
+    (tmp_path / "hf_state.json").write_text(json.dumps({"processed": ["aaa", "bbb"]}))
+    st = hp._load_state(tmp_path)
+    assert st["processed"] == {"aaa": "legacy", "bbb": "legacy"}
+    assert st["validator_version"] == "legacy"
+    done = {b for b, v in st["processed"].items() if v == VALIDATOR_VERSION}
+    assert done == set()  # legacy entries do not count as done → reprocessed
+
+
+def test_only_current_version_counts_as_done(tmp_path):
+    (tmp_path / "hf_state.json").write_text(json.dumps({
+        "validator_version": VALIDATOR_VERSION,
+        "processed": {"new1": VALIDATOR_VERSION, "old1": "v0"},
+    }))
+    st = hp._load_state(tmp_path)
+    done = {b for b, v in st["processed"].items() if v == VALIDATOR_VERSION}
+    assert done == {"new1"}  # old1 (older version) will be reprocessed
+
+
+def test_fresh_state_defaults(tmp_path):
+    st = hp._load_state(tmp_path)
+    assert st == {"validator_version": VALIDATOR_VERSION, "processed": {}}
+
+
+def _mk_bundle(pending: Path, name: str, created=None, pr=None, mtime=None):
+    d = pending / name
+    d.mkdir(parents=True)
+    (d / "submission.json").write_text("{}")
+    if created is not None:
+        (d / ".hf_pr.json").write_text(json.dumps({"created_at": created, "pr_num": pr}))
+    if mtime is not None:
+        os.utime(d, (mtime, mtime))
+    return d
+
+
+def test_poll_queue_orders_by_submission_time_not_hash(tmp_path):
+    pending = tmp_path / "pending"
+    pending.mkdir()
+    # Names deliberately NOT in chronological order so a hash sort would differ.
+    _mk_bundle(pending, "zzz_first", created="2026-06-20T10:00:00+00:00", pr=5)
+    _mk_bundle(pending, "aaa_third", created="2026-06-22T10:00:00+00:00", pr=9)
+    _mk_bundle(pending, "mmm_second", created="2026-06-21T10:00:00+00:00", pr=7)
+    # Legacy/local bundle with no PR metadata → falls back to (older) mtime.
+    _mk_bundle(pending, "legacy_local", mtime=time.mktime((2026, 6, 19, 0, 0, 0, 0, 0, 0)))
+
+    order = [p.name for p in poll_queue(tmp_path)]
+    assert order == ["legacy_local", "zzz_first", "mmm_second", "aaa_third"]

--- a/validator/__init__.py
+++ b/validator/__init__.py
@@ -16,6 +16,7 @@ from .validator import (
     ValidatorResult,
     judge_submission,
 )
+from .version import VALIDATOR_VERSION
 
 __all__ = [
     "ValidatorResult",
@@ -23,4 +24,5 @@ __all__ = [
     "judge_submission",
     "ScoreReport",
     "score_bundle",
+    "VALIDATOR_VERSION",
 ]

--- a/validator/hf_poller.py
+++ b/validator/hf_poller.py
@@ -7,7 +7,10 @@ into `queue/pending/<bundle_hash>/` where the existing local-queue logic
 picks them up.
 
 State is tracked in queue/hf_state.json so we don't re-download already-
-processed bundles after restarts.
+processed bundles after restarts. Each processed bundle is stamped with the
+VALIDATOR_VERSION it was judged under; on a version bump, older-version entries
+are reprocessed (re-downloaded + re-validated) so evaluation stays fair across
+a logic upgrade.
 """
 
 from __future__ import annotations
@@ -18,6 +21,8 @@ import shutil
 from pathlib import Path
 from typing import Optional
 
+from validator.version import VALIDATOR_VERSION
+
 DEFAULT_REPO = "RalphLabsAI/proof-bundles"
 
 
@@ -25,14 +30,31 @@ def _state_path(queue_dir: Path) -> Path:
     return queue_dir / "hf_state.json"
 
 
+def _migrate_state(raw: dict) -> dict:
+    """Normalise to {"validator_version": str, "processed": {bundle_id: version}}.
+
+    Legacy state stored `processed` as a flat list of bundle_ids with no version;
+    those are mapped to "legacy" so they re-process under the current version.
+    """
+    processed = raw.get("processed", {})
+    if isinstance(processed, list):
+        processed = {bid: "legacy" for bid in processed}
+    elif not isinstance(processed, dict):
+        processed = {}
+    return {
+        "validator_version": raw.get("validator_version", "legacy"),
+        "processed": processed,
+    }
+
+
 def _load_state(queue_dir: Path) -> dict:
     p = _state_path(queue_dir)
     if not p.exists():
-        return {"processed": []}
+        return {"validator_version": VALIDATOR_VERSION, "processed": {}}
     try:
-        return json.loads(p.read_text())
+        return _migrate_state(json.loads(p.read_text()))
     except Exception:
-        return {"processed": []}
+        return {"validator_version": VALIDATOR_VERSION, "processed": {}}
 
 
 def _save_state(queue_dir: Path, state: dict) -> None:
@@ -40,8 +62,13 @@ def _save_state(queue_dir: Path, state: dict) -> None:
 
 
 def list_remote_submissions(repo_id: str, token: Optional[str] = None) -> list[dict]:
-    """Return the open HF PRs against the dataset, each as a dict with
-    bundle_id (= directory prefix under submissions/), pr_num, git_ref."""
+    """Return the open HF PRs against the dataset, oldest-first.
+
+    Each entry is a dict with bundle_id (= directory prefix under submissions/),
+    pr_num, git_ref, and created_at (ISO-8601 PR creation time). Ordering is
+    by created_at then pr_num so validation is first-come-first-served (fair),
+    not by bundle-hash lexical order.
+    """
     from huggingface_hub import HfApi
 
     api = HfApi(token=token)
@@ -66,9 +93,16 @@ def list_remote_submissions(repo_id: str, token: Optional[str] = None) -> list[d
         except Exception as e:
             print(f"[hf_poller] list PR #{d.num} files failed: {e}")
             continue
+        created_at = d.created_at.isoformat() if getattr(d, "created_at", None) else None
         bundle_ids = {f.split("/")[1] for f in files if f.startswith("submissions/") and len(f.split("/")) >= 3}
         for bid in bundle_ids:
-            pending.append({"bundle_id": bid, "pr_num": d.num, "git_ref": ref})
+            pending.append(
+                {"bundle_id": bid, "pr_num": d.num, "git_ref": ref, "created_at": created_at}
+            )
+
+    # First-come-first-validate: oldest PR first. created_at is ISO-8601 UTC so
+    # lexical order is chronological; pr_num breaks ties / covers a missing time.
+    pending.sort(key=lambda p: (p["created_at"] or "", p["pr_num"]))
     return pending
 
 
@@ -79,6 +113,7 @@ def download_one(
     token: Optional[str] = None,
     git_ref: str = "main",
     pr_num: int | None = None,
+    created_at: str | None = None,
 ) -> bool:
     """Download all files for one bundle into dest_dir/<bundle_id>/.
 
@@ -161,7 +196,12 @@ def download_one(
     # Annotate which PR this came from so the validator can merge later.
     if pr_num is not None:
         (out / ".hf_pr.json").write_text(json.dumps(
-            {"pr_num": pr_num, "git_ref": git_ref, "repo_id": "RalphLabsAI/proof-bundles"},
+            {
+                "pr_num": pr_num,
+                "git_ref": git_ref,
+                "repo_id": "RalphLabsAI/proof-bundles",
+                "created_at": created_at,
+            },
             indent=2,
         ))
     return True
@@ -182,13 +222,18 @@ def poll_hub(
     pending.mkdir(parents=True, exist_ok=True)
 
     state = _load_state(queue_dir)
-    processed = set(state.get("processed", []))
+    processed = state.get("processed", {})  # {bundle_id: validator_version}
 
-    remote_prs = list_remote_submissions(repo_id, token=token)
+    # A bundle counts as done only if it was judged by the CURRENT validator
+    # version. Entries from an older version are reprocessed: not in `done` →
+    # re-downloaded → re-judged → re-stamped below.
+    done = {bid for bid, ver in processed.items() if ver == VALIDATOR_VERSION}
+
+    remote_prs = list_remote_submissions(repo_id, token=token)  # oldest-first
     if not remote_prs:
         return []
 
-    new = [p for p in remote_prs if p["bundle_id"] not in processed]
+    new = [p for p in remote_prs if p["bundle_id"] not in done]
     if not new:
         return []
 
@@ -200,13 +245,15 @@ def poll_hub(
         bid = sub["bundle_id"]
         print(f"[hf_poller] downloading {bid} from PR #{sub['pr_num']} ({sub['git_ref']})...")
         if download_one(bid, repo_id, pending, token=token,
-                        git_ref=sub["git_ref"], pr_num=sub["pr_num"]):
+                        git_ref=sub["git_ref"], pr_num=sub["pr_num"],
+                        created_at=sub.get("created_at")):
             downloaded.append(bid)
-            processed.add(bid)
+            processed[bid] = VALIDATOR_VERSION
         else:
             print(f"[hf_poller] skipped {bid} (download failed)")
 
-    state["processed"] = sorted(processed)
+    state["validator_version"] = VALIDATOR_VERSION
+    state["processed"] = processed
     _save_state(queue_dir, state)
     return downloaded
 

--- a/validator/hf_poller.py
+++ b/validator/hf_poller.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import Optional
@@ -24,6 +25,38 @@ from typing import Optional
 from validator.version import VALIDATOR_VERSION
 
 DEFAULT_REPO = "RalphLabsAI/proof-bundles"
+
+# miner.hub titles every submission PR "Submit proof bundle <hash[:12]>".
+_TITLE_HASH_RE = re.compile(r"Submit proof bundle ([0-9a-f]{6,})", re.IGNORECASE)
+
+
+def _submission_dirs(files: list[str]) -> set[str]:
+    """Set of submissions/<bundle_id>/ directory ids present in a file listing."""
+    return {
+        f.split("/")[1]
+        for f in files
+        if f.startswith("submissions/") and len(f.split("/")) >= 3
+    }
+
+
+def _pr_own_bundles(title: str, pr_dirs: set[str], main_dirs: set[str]) -> list[str]:
+    """Identify the bundle dir(s) a PR actually introduces.
+
+    list_repo_files(revision="refs/pr/N") returns the *cumulative* tree (the
+    base main at PR-open time + the PR's added files), so the raw dir set is not
+    the PR's own bundle. Primary signal: the PR title (`Submit proof bundle
+    <hash12>`, set by miner.hub) — match its hash prefix to a dir at the PR ref.
+    Fallback (non-standard title): dirs present at the ref but not on main.
+    The fallback is avoided when the title parses, so a bundle deleted from main
+    (e.g. a reverted mock) can't be mis-attributed to a later PR.
+    """
+    m = _TITLE_HASH_RE.search(title or "")
+    if m:
+        prefix = m.group(1).lower()
+        matches = sorted(d for d in pr_dirs if d.lower().startswith(prefix))
+        if matches:
+            return matches
+    return sorted(pr_dirs - main_dirs)
 
 
 def _state_path(queue_dir: Path) -> Path:
@@ -65,9 +98,10 @@ def list_remote_submissions(repo_id: str, token: Optional[str] = None) -> list[d
     """Return the open HF PRs against the dataset, oldest-first.
 
     Each entry is a dict with bundle_id (= directory prefix under submissions/),
-    pr_num, git_ref, and created_at (ISO-8601 PR creation time). Ordering is
-    by created_at then pr_num so validation is first-come-first-served (fair),
-    not by bundle-hash lexical order.
+    pr_num, git_ref, and created_at (ISO-8601 PR creation time). Only the bundle
+    a PR actually *adds* is attributed to it (see _pr_own_bundles), not the whole
+    cumulative tree the PR ref exposes. Ordering is by created_at then pr_num so
+    validation is first-come-first-served (fair), not bundle-hash lexical order.
     """
     from huggingface_hub import HfApi
 
@@ -78,15 +112,20 @@ def list_remote_submissions(repo_id: str, token: Optional[str] = None) -> list[d
         print(f"[hf_poller] get_repo_discussions failed: {e}")
         return []
 
+    # Bundles already on main are the baseline a PR's tree is layered on top of;
+    # used only as the fallback when a PR title doesn't carry the bundle hash.
+    try:
+        main_dirs = _submission_dirs(api.list_repo_files(repo_id, repo_type="dataset"))
+    except Exception as e:
+        print(f"[hf_poller] list main files failed: {e}")
+        main_dirs = set()
+
     pending = []
     for d in discussions:
         if not d.is_pull_request:
             continue
         if d.status != "open":
             continue
-        # Each PR has a git_reference like 'refs/pr/3'. Files under
-        # submissions/<bundle_id>/ are what we want; find the bundle_id by
-        # listing the PR's commit tree.
         ref = d.git_reference  # e.g. "refs/pr/3"
         try:
             files = api.list_repo_files(repo_id, repo_type="dataset", revision=ref)
@@ -94,8 +133,13 @@ def list_remote_submissions(repo_id: str, token: Optional[str] = None) -> list[d
             print(f"[hf_poller] list PR #{d.num} files failed: {e}")
             continue
         created_at = d.created_at.isoformat() if getattr(d, "created_at", None) else None
-        bundle_ids = {f.split("/")[1] for f in files if f.startswith("submissions/") and len(f.split("/")) >= 3}
-        for bid in bundle_ids:
+        own = _pr_own_bundles(d.title, _submission_dirs(files), main_dirs)
+        if not own:
+            print(f"[hf_poller] PR #{d.num}: no own bundle identified (title={d.title!r}); skipping")
+            continue
+        if len(own) > 1:
+            print(f"[hf_poller] PR #{d.num}: multiple candidate bundles {own}; taking all")
+        for bid in own:
             pending.append(
                 {"bundle_id": bid, "pr_num": d.num, "git_ref": ref, "created_at": created_at}
             )

--- a/validator/service.py
+++ b/validator/service.py
@@ -35,6 +35,7 @@ import signal
 import sys
 import time
 import traceback
+from datetime import datetime
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -96,14 +97,40 @@ signal.signal(signal.SIGINT, _signal_handler)
 signal.signal(signal.SIGTERM, _signal_handler)
 
 
+def _submission_time_key(d: Path) -> tuple:
+    """Sort key for first-come-first-validate ordering.
+
+    Orders by the submission's HF PR creation time (from .hf_pr.json), falling
+    back to the directory mtime for local/legacy bundles without PR metadata.
+    Previously bundles were sorted by directory name (= bundle hash), which is
+    arbitrary w.r.t. submission time and so unfair.
+    """
+    info_path = d / ".hf_pr.json"
+    if info_path.exists():
+        try:
+            info = json.loads(info_path.read_text())
+            created = info.get("created_at")
+            if created:
+                ts = datetime.fromisoformat(created).timestamp()
+                return (ts, info.get("pr_num") or 0, d.name)
+        except Exception:
+            pass
+    try:
+        ts = d.stat().st_mtime
+    except OSError:
+        ts = 0.0
+    return (ts, 0, d.name)
+
+
 def poll_queue(queue_dir: Path) -> list[Path]:
-    """Return paths to pending submission bundles, oldest first."""
+    """Return paths to pending submission bundles, oldest (first-submitted) first."""
     pending = queue_dir / "pending"
     pending.mkdir(parents=True, exist_ok=True)
     bundles = []
-    for d in sorted(pending.iterdir()):
+    for d in pending.iterdir():
         if d.is_dir() and (d / "submission.json").exists():
             bundles.append(d)
+    bundles.sort(key=_submission_time_key)
     return bundles
 
 

--- a/validator/version.py
+++ b/validator/version.py
@@ -1,0 +1,13 @@
+"""Validator logic version.
+
+Bump this whenever the verify/score logic changes in a way that could alter a
+submission's outcome (op1–op4 checks, attestation verification, scoring/king
+rule). The HF poller stamps this version onto every processed bundle in
+`hf_state.json`; on a version bump, entries judged by an older version are
+dropped from the processed set so they are re-downloaded and re-validated under
+the new rules — keeping evaluation fair across a logic upgrade.
+"""
+
+VALIDATOR_VERSION = "v1"
+
+__all__ = ["VALIDATOR_VERSION"]


### PR DESCRIPTION
- add VALIDATOR_VERSION; bump to re-evaluate all submissions
- hf_state.processed: list -> {bundle_id: version} (auto-migrates)
- bundle counts done only if judged by current version; older
  + legacy entries re-download + re-validate on a version bump
- poll_queue: order by PR created_at (mtime fallback), not bundle hash — first-come-first-validate
- poller captures/stamps created_at into .hf_pr.json
- tests for migration, version gating, chronological ordering