### PR TITLE
poller: attribute only each PR's own bundle

### DIFF
--- a/tests/test_hf_poller_attribution.py
+++ b/tests/test_hf_poller_attribution.py
@@ -1,0 +1,95 @@
+"""Tests for per-PR bundle attribution in the HF poller.
+
+list_repo_files(revision="refs/pr/N") returns the cumulative tree (base main +
+the PR's files), so the poller must isolate the bundle each PR actually adds —
+primarily via the PR title (`Submit proof bundle <hash12>`), falling back to a
+diff against main. These tests pin that behaviour with a fake HfApi.
+"""
+
+from datetime import datetime, timezone
+
+import huggingface_hub
+
+from validator.hf_poller import list_remote_submissions
+
+A = "a" * 64  # already merged on main
+B = "b" * 64  # added by PR 1
+C = "c" * 64  # added by PR 2
+D = "d" * 64  # added by PR 3
+E = "e" * 64  # added by PR 4 (non-standard title → fallback)
+X = "9" * 64  # in PR 3's cumulative tree but NOT on main (e.g. reverted mock)
+
+
+def _files(*bundle_ids):
+    out = ["README.md", ".gitattributes"]
+    for bid in bundle_ids:
+        out.append(f"submissions/{bid}/submission.json")
+        out.append(f"submissions/{bid}/checkpoint.pt")
+    return out
+
+
+class _FakeDiscussion:
+    def __init__(self, num, title, created, status="open", is_pr=True):
+        self.num = num
+        self.title = title
+        self.status = status
+        self.is_pull_request = is_pr
+        self.git_reference = f"refs/pr/{num}"
+        self.created_at = created
+
+
+class _FakeApi:
+    def __init__(self, discussions, trees):
+        self._discussions = discussions
+        self._trees = trees  # {None: main_files, "refs/pr/N": files}
+
+    def get_repo_discussions(self, repo_id=None, repo_type=None):
+        return iter(self._discussions)
+
+    def list_repo_files(self, repo_id, repo_type=None, revision=None, token=None):
+        return self._trees[revision]
+
+
+def _install(monkeypatch, discussions, trees):
+    api = _FakeApi(discussions, trees)
+    monkeypatch.setattr(huggingface_hub, "HfApi", lambda token=None: api)
+
+
+def test_attributes_only_each_prs_own_bundle(monkeypatch):
+    def t(n):
+        return datetime(2026, 6, n, tzinfo=timezone.utc)
+
+    discussions = [
+        _FakeDiscussion(2, f"Submit proof bundle {C[:12]}", t(2)),
+        _FakeDiscussion(1, f"Submit proof bundle {B[:12]}", t(1)),  # out of order on purpose
+        _FakeDiscussion(3, f"Submit proof bundle {D[:12]}", t(3)),
+        _FakeDiscussion(4, "rebrand: tidy dataset", t(4)),          # no hash → fallback
+        _FakeDiscussion(99, "an issue, not a PR", t(1), is_pr=False),
+        _FakeDiscussion(98, f"Submit proof bundle {C[:12]}", t(1), status="closed"),
+    ]
+    trees = {
+        None: _files(A),               # main
+        "refs/pr/1": _files(A, B),     # cumulative: base + own
+        "refs/pr/2": _files(A, B, C),
+        "refs/pr/3": _files(A, X, D),  # X present here but gone from main
+        "refs/pr/4": _files(A, E),     # title carries no hash
+    }
+    _install(monkeypatch, discussions, trees)
+
+    subs = list_remote_submissions("RalphLabsAI/proof-bundles")
+
+    # Oldest-first, one entry per open PR, each its own bundle.
+    assert [(s["pr_num"], s["bundle_id"]) for s in subs] == [
+        (1, B), (2, C), (3, D), (4, E),
+    ]
+    seen = {s["bundle_id"] for s in subs}
+    assert A not in seen  # merged baseline never re-attributed
+    assert X not in seen  # deleted-from-main bundle not mis-attributed to PR 3
+
+
+def test_fallback_skips_pr_with_no_identifiable_bundle(monkeypatch):
+    # Non-standard title AND nothing new vs main → nothing to attribute.
+    discussions = [_FakeDiscussion(7, "housekeeping", datetime(2026, 6, 7, tzinfo=timezone.utc))]
+    trees = {None: _files(A), "refs/pr/7": _files(A)}
+    _install(monkeypatch, discussions, trees)
+    assert list_remote_submissions("RalphLabsAI/proof-bundles") == []

--- a/validator/hf_poller.py
+++ b/validator/hf_poller.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import Optional
@@ -24,6 +25,38 @@ from typing import Optional
 from validator.version import VALIDATOR_VERSION
 
 DEFAULT_REPO = "RalphLabsAI/proof-bundles"
+
+# miner.hub titles every submission PR "Submit proof bundle <hash[:12]>".
+_TITLE_HASH_RE = re.compile(r"Submit proof bundle ([0-9a-f]{6,})", re.IGNORECASE)
+
+
+def _submission_dirs(files: list[str]) -> set[str]:
+    """Set of submissions/<bundle_id>/ directory ids present in a file listing."""
+    return {
+        f.split("/")[1]
+        for f in files
+        if f.startswith("submissions/") and len(f.split("/")) >= 3
+    }
+
+
+def _pr_own_bundles(title: str, pr_dirs: set[str], main_dirs: set[str]) -> list[str]:
+    """Identify the bundle dir(s) a PR actually introduces.
+
+    list_repo_files(revision="refs/pr/N") returns the *cumulative* tree (the
+    base main at PR-open time + the PR's added files), so the raw dir set is not
+    the PR's own bundle. Primary signal: the PR title (`Submit proof bundle
+    <hash12>`, set by miner.hub) — match its hash prefix to a dir at the PR ref.
+    Fallback (non-standard title): dirs present at the ref but not on main.
+    The fallback is avoided when the title parses, so a bundle deleted from main
+    (e.g. a reverted mock) can't be mis-attributed to a later PR.
+    """
+    m = _TITLE_HASH_RE.search(title or "")
+    if m:
+        prefix = m.group(1).lower()
+        matches = sorted(d for d in pr_dirs if d.lower().startswith(prefix))
+        if matches:
+            return matches
+    return sorted(pr_dirs - main_dirs)
 
 
 def _state_path(queue_dir: Path) -> Path:
@@ -65,9 +98,10 @@ def list_remote_submissions(repo_id: str, token: Optional[str] = None) -> list[d
     """Return the open HF PRs against the dataset, oldest-first.
 
     Each entry is a dict with bundle_id (= directory prefix under submissions/),
-    pr_num, git_ref, and created_at (ISO-8601 PR creation time). Ordering is
-    by created_at then pr_num so validation is first-come-first-served (fair),
-    not by bundle-hash lexical order.
+    pr_num, git_ref, and created_at (ISO-8601 PR creation time). Only the bundle
+    a PR actually *adds* is attributed to it (see _pr_own_bundles), not the whole
+    cumulative tree the PR ref exposes. Ordering is by created_at then pr_num so
+    validation is first-come-first-served (fair), not bundle-hash lexical order.
     """
     from huggingface_hub import HfApi
 
@@ -78,15 +112,20 @@ def list_remote_submissions(repo_id: str, token: Optional[str] = None) -> list[d
         print(f"[hf_poller] get_repo_discussions failed: {e}")
         return []
 
+    # Bundles already on main are the baseline a PR's tree is layered on top of;
+    # used only as the fallback when a PR title doesn't carry the bundle hash.
+    try:
+        main_dirs = _submission_dirs(api.list_repo_files(repo_id, repo_type="dataset"))
+    except Exception as e:
+        print(f"[hf_poller] list main files failed: {e}")
+        main_dirs = set()
+
     pending = []
     for d in discussions:
         if not d.is_pull_request:
             continue
         if d.status != "open":
             continue
-        # Each PR has a git_reference like 'refs/pr/3'. Files under
-        # submissions/<bundle_id>/ are what we want; find the bundle_id by
-        # listing the PR's commit tree.
         ref = d.git_reference  # e.g. "refs/pr/3"
         try:
             files = api.list_repo_files(repo_id, repo_type="dataset", revision=ref)
@@ -94,8 +133,13 @@ def list_remote_submissions(repo_id: str, token: Optional[str] = None) -> list[d
             print(f"[hf_poller] list PR #{d.num} files failed: {e}")
             continue
         created_at = d.created_at.isoformat() if getattr(d, "created_at", None) else None
-        bundle_ids = {f.split("/")[1] for f in files if f.startswith("submissions/") and len(f.split("/")) >= 3}
-        for bid in bundle_ids:
+        own = _pr_own_bundles(d.title, _submission_dirs(files), main_dirs)
+        if not own:
+            print(f"[hf_poller] PR #{d.num}: no own bundle identified (title={d.title!r}); skipping")
+            continue
+        if len(own) > 1:
+            print(f"[hf_poller] PR #{d.num}: multiple candidate bundles {own}; taking all")
+        for bid in own:
             pending.append(
                 {"bundle_id": bid, "pr_num": d.num, "git_ref": ref, "created_at": created_at}
             )


### PR DESCRIPTION
- list_repo_files(refs/pr/N) returns the cumulative tree (base main + PR files), so the old code attributed every dir in the tree to the PR — merged bundles reappeared in later open PRs
- _pr_own_bundles: resolve the bundle from the PR title ("Submit proof bundle <hash12>"), fall back to diff-vs-main
- title-primary avoids mis-attributing a bundle deleted from main (e.g. a reverted mock) to a later PR
- skip PRs with no identifiable own bundle
- hermetic tests with a fake HfApi (cumulative tree, deleted bundle, fallback, skip)