### PR TITLE
validator: close losing HF/GitHub PRs on terminal outcome

### DIFF
--- a/tests/test_pr_cleanup.py
+++ b/tests/test_pr_cleanup.py
@@ -1,0 +1,69 @@
+"""Tests for closing losing HF/GitHub PRs on terminal classification."""
+
+import json
+
+import validator.github_bot as github_bot
+import validator.hf_bot as hf_bot
+import validator.service as service
+
+
+def _bundle(tmp_path, pr_num=42, pr_url="https://github.com/RalphLabsAI/recipe/pull/9"):
+    d = tmp_path / "bundle"
+    d.mkdir()
+    (d / ".hf_pr.json").write_text(json.dumps(
+        {"pr_num": pr_num, "repo_id": "RalphLabsAI/proof-bundles", "git_ref": f"refs/pr/{pr_num}"}
+    ))
+    (d / "submission.json").write_text(json.dumps({"pr_url": pr_url}))
+    return d
+
+
+def test_github_close_pr_noop_without_url():
+    ok, detail = github_bot.close_pr("", token="t")
+    assert ok is False and detail == "no pr_url"
+
+
+def test_close_losing_prs_closes_both(tmp_path, monkeypatch):
+    monkeypatch.setenv("RALPH_CLOSE_LOSING_PRS", "1")
+    monkeypatch.setenv("HF_TOKEN", "hf-tok")
+    monkeypatch.setenv("RALPH_BOT_GH_TOKEN", "gh-tok")
+    calls = {}
+
+    def fake_hf_close(repo_id, pr_num, token, comment=None, repo_type="dataset"):
+        calls["hf"] = (repo_id, pr_num, comment)
+        return True, "closed"
+
+    def fake_gh_close(pr_url, token, comment=None):
+        calls["gh"] = (pr_url, comment)
+        return True, "closed"
+
+    monkeypatch.setattr(hf_bot, "close_pr", fake_hf_close)
+    monkeypatch.setattr(github_bot, "close_pr", fake_gh_close)
+
+    service._close_losing_prs(_bundle(tmp_path), "below threshold (gain -2.69)")
+
+    assert calls["hf"][0] == "RalphLabsAI/proof-bundles"
+    assert calls["hf"][1] == 42
+    assert "below threshold" in calls["hf"][2]
+    assert calls["gh"][0] == "https://github.com/RalphLabsAI/recipe/pull/9"
+    assert "below threshold" in calls["gh"][1]
+
+
+def test_close_losing_prs_disabled_flag(tmp_path, monkeypatch):
+    monkeypatch.setenv("RALPH_CLOSE_LOSING_PRS", "0")
+    monkeypatch.setenv("HF_TOKEN", "hf-tok")
+    called = {"n": 0}
+    monkeypatch.setattr(hf_bot, "close_pr", lambda *a, **k: called.update(n=called["n"] + 1) or (True, "x"))
+    service._close_losing_prs(_bundle(tmp_path), "reason")
+    assert called["n"] == 0  # disabled → no close attempted
+
+
+def test_close_losing_prs_noop_without_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("RALPH_CLOSE_LOSING_PRS", "1")
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("RALPH_BOT_HF_TOKEN", raising=False)
+    monkeypatch.delenv("RALPH_BOT_GH_TOKEN", raising=False)
+    called = {"n": 0}
+    monkeypatch.setattr(hf_bot, "close_pr", lambda *a, **k: called.update(n=called["n"] + 1) or (True, "x"))
+    monkeypatch.setattr(github_bot, "close_pr", lambda *a, **k: called.update(n=called["n"] + 1) or (True, "x"))
+    service._close_losing_prs(_bundle(tmp_path), "reason")
+    assert called["n"] == 0  # no tokens → nothing attempted

--- a/validator/github_bot.py
+++ b/validator/github_bot.py
@@ -60,6 +60,27 @@ def _parse_pr_url(pr_url: str) -> tuple[str, str, int]:
     return m.group(1), m.group(2), int(m.group(3))
 
 
+def close_pr(pr_url: str, token: str, comment: str | None = None) -> tuple[bool, str]:
+    """Close (not merge) a losing recipe PR, posting a reason comment first.
+
+    Best-effort — returns (ok, detail), never raises. No-ops on an empty pr_url
+    (many submissions don't link a recipe PR).
+    """
+    if not pr_url:
+        return False, "no pr_url"
+    try:
+        owner, repo, num = _parse_pr_url(pr_url)
+    except ValueError as e:
+        return False, str(e)
+    try:
+        if comment:
+            _gh("POST", f"/repos/{owner}/{repo}/issues/{num}/comments", token, {"body": comment})
+        _gh("PATCH", f"/repos/{owner}/{repo}/pulls/{num}", token, {"state": "closed"})
+        return True, "closed"
+    except Exception as e:
+        return False, f"close failed: {e}"
+
+
 # Real GitHub handle rules: 1–39 chars, ASCII alphanumerics or hyphen.
 # (GitHub additionally disallows leading/trailing hyphens, but we keep the
 # regex strict-but-simple here; the practical attack we block is newlines,

--- a/validator/hf_bot.py
+++ b/validator/hf_bot.py
@@ -50,3 +50,30 @@ def merge_pr(
         return HfMergeResult(pr_num=pr_num, merged=True, detail="merged")
     except Exception as e:
         return HfMergeResult(pr_num=pr_num, merged=False, detail=f"merge failed: {e}")
+
+
+def close_pr(
+    repo_id: str,
+    pr_num: int,
+    token: str,
+    comment: str | None = None,
+    repo_type: str = "dataset",
+) -> tuple[bool, str]:
+    """Close (not merge) a losing HF dataset PR, posting a reason comment.
+
+    Best-effort — returns (ok, detail), never raises. Used to stop non-crowned
+    submission PRs from piling up open on the dataset repo.
+    """
+    from huggingface_hub import HfApi
+    api = HfApi(token=token)
+    try:
+        api.change_discussion_status(
+            repo_id=repo_id,
+            repo_type=repo_type,
+            discussion_num=pr_num,
+            new_status="closed",
+            comment=comment or "Closed by Ralph validator (not crowned).",
+        )
+        return True, "closed"
+    except Exception as e:
+        return False, f"close failed: {e}"

--- a/validator/service.py
+++ b/validator/service.py
@@ -143,6 +143,46 @@ def archive_bundle(bundle_dir: Path, queue_dir: Path, dest: str) -> None:
     shutil.move(str(bundle_dir), str(target))
 
 
+def _close_losing_prs(bundle_dir: Path, reason: str) -> None:
+    """Close the HF (and GitHub recipe) PRs for a non-crowned submission so the
+    repos don't accumulate open losing PRs. A king change MERGES its PRs instead
+    and never reaches here. Call BEFORE archive_bundle (reads files in-place).
+
+    Opt out with RALPH_CLOSE_LOSING_PRS=0. Best-effort — never raises, never
+    affects scoring or weights.
+    """
+    if os.environ.get("RALPH_CLOSE_LOSING_PRS", "1").strip().lower() in {"0", "false", "no", "off"}:
+        return
+    note = f"Closed by Ralph validator — not crowned: {reason}."
+    # HF dataset PR (mapping written into .hf_pr.json at download time).
+    try:
+        hf_path = bundle_dir / ".hf_pr.json"
+        if hf_path.exists():
+            info = json.loads(hf_path.read_text(encoding="utf-8", errors="replace"))
+            tok = os.environ.get("RALPH_BOT_HF_TOKEN") or os.environ.get("HF_TOKEN", "")
+            if tok and info.get("pr_num"):
+                from validator.hf_bot import close_pr as _hf_close
+                ok, detail = _hf_close(
+                    repo_id=info.get("repo_id", "RalphLabsAI/proof-bundles"),
+                    pr_num=info["pr_num"], token=tok, comment=note,
+                )
+                log_info(f"  HF PR #{info['pr_num']} {'closed' if ok else 'close failed'}: {detail}")
+    except Exception as e:
+        log_warn(f"HF PR close skipped for {bundle_dir.name}: {e}")
+    # GitHub recipe PR (from submission.json pr_url; often empty → no-op).
+    try:
+        sub_path = bundle_dir / "submission.json"
+        if sub_path.exists():
+            pr_url = json.loads(sub_path.read_text(encoding="utf-8", errors="replace")).get("pr_url", "")
+            tok = os.environ.get("RALPH_BOT_GH_TOKEN", "")
+            if tok and pr_url:
+                from validator.github_bot import close_pr as _gh_close
+                ok, detail = _gh_close(pr_url, tok, comment=note)
+                log_info(f"  GitHub PR {pr_url} {'closed' if ok else 'close failed'}: {detail}")
+    except Exception as e:
+        log_warn(f"GitHub PR close skipped for {bundle_dir.name}: {e}")
+
+
 def _verify_pr_if_required(result, bundle_dir: Path) -> tuple[bool, str]:
     """If $RALPH_BOT_GH_TOKEN is set and the submission carries a pr_url,
     verify the PR's diff is byte-equal to the bundle's patch.diff.
@@ -589,6 +629,7 @@ def run_epoch(
         except Exception as e:
             log_err(f"error scoring {bundle_id}: {e}")
             log_debug(traceback.format_exc())
+            _close_losing_prs(bundle_dir, f"scoring error: {e}")
             archive_bundle(bundle_dir, queue_dir, "rejected")
             epoch_results["rejected"] += 1
             chain.append_event({
@@ -601,6 +642,7 @@ def run_epoch(
 
         if result["status"] == "rejected":
             log_warn(f"rejected {bundle_id}: {result['reason']}")
+            _close_losing_prs(bundle_dir, result["reason"])
             archive_bundle(bundle_dir, queue_dir, "rejected")
             epoch_results["rejected"] += 1
             chain.append_event({
@@ -619,6 +661,7 @@ def run_epoch(
         # and stops the §5.7 audit dispatcher from wasting time.
         if not chain.is_hotkey_registered(miner_hotkey):
             log_warn(f"rejected {bundle_id}: miner hotkey {miner_hotkey[:16]}... not registered")
+            _close_losing_prs(bundle_dir, "miner hotkey not registered on subnet")
             archive_bundle(bundle_dir, queue_dir, "rejected")
             epoch_results["rejected"] += 1
             chain.append_event({
@@ -639,6 +682,7 @@ def run_epoch(
         if (val_bpb is None or not _math.isfinite(val_bpb)
                 or bench_acc is None or not _math.isfinite(bench_acc)):
             log_warn(f"rejected {bundle_id}: non-finite metrics (val_bpb={val_bpb}, bench={bench_acc})")
+            _close_losing_prs(bundle_dir, "non-finite metrics")
             archive_bundle(bundle_dir, queue_dir, "rejected")
             epoch_results["rejected"] += 1
             chain.append_event({
@@ -705,6 +749,11 @@ def run_epoch(
                 f"MEANINGFUL FAILURE: {who} val_bpb={result['val_bpb']:.4f} "
                 f"(king {king_bpb_str}); rationale archived to corpus, "
                 f"will get equal share of 10% pool"
+            )
+            _close_losing_prs(
+                bundle_dir,
+                f"meaningful failure — credited (10% pool), not crowned "
+                f"(val_bpb {result['val_bpb']:.4f} vs king {king_bpb_str})",
             )
             archive_bundle(bundle_dir, queue_dir, "meaningful_failure")
             epoch_results.setdefault("meaningful_failures", 0)
@@ -924,6 +973,7 @@ def run_epoch(
                     log_warn(f"king changed but no HF token to merge PR #{hf_pr['pr_num']}")
         else:
             log_info(f"below threshold: {miner_hotkey[:20]}... gain={result['quality_gain']:+.4f}")
+            _close_losing_prs(bundle_dir, f"below threshold (gain {result['quality_gain']:+.4f})")
 
         archive_bundle(bundle_dir, queue_dir, "scored")
 


### PR DESCRIPTION
- hf_bot.close_pr / github_bot.close_pr: close (not merge) a PR with a reason comment, best-effort
- service._close_losing_prs: close the bundle's HF + recipe PRs for every non-crowned terminal outcome (rejected, hotkey-unregistered, non-finite, meaningful_failure, below-threshold) before archiving
- king_change still MERGES its PRs (never closed)
- opt out with RALPH_CLOSE_LOSING_PRS=0; no-ops without tokens
- stops losing submission PRs piling up open on the repos
- tests for close wiring, disable flag, no-token no-op