### PR TITLE
validator: hold sitting king on idle epochs (don't burn)

### DIFF
--- a/tests/test_idle_epoch_holds_king.py
+++ b/tests/test_idle_epoch_holds_king.py
@@ -1,0 +1,59 @@
+"""Idle-epoch weight behavior: a king-based subnet must KEEP weighting the
+sitting king when no new submission beats it (king earns until dethroned).
+Burning is correct ONLY when there is no king at all (genesis / post-reset).
+
+Regression for the bug where empty epochs burned to uid 0 even with a sitting
+king, starving the reigning king.
+"""
+
+import json
+
+from chain_layer.interface import KingRecord
+from chain_layer.local import LocalChain
+from validator.service import run_epoch
+
+
+def _last_weights(chain):
+    events = [
+        json.loads(ln)
+        for ln in (chain.chain_dir / "events.jsonl").read_text().splitlines()
+        if ln.strip()
+    ]
+    ws = [e for e in events if e["type"] == "weights_set"]
+    return ws[-1] if ws else None
+
+
+def _run_idle(chain, tmp_path):
+    qd = tmp_path / "queue"
+    (qd / "pending").mkdir(parents=True, exist_ok=True)
+    return run_epoch(
+        chain, qd, noise_floor_margin=0.013,
+        hf_repo=None, audit_reports_enabled=False,
+    )
+
+
+def test_idle_epoch_holds_sitting_king(tmp_path):
+    chain = LocalChain(tmp_path / "chain")
+    chain.set_king(KingRecord(
+        miner_hotkey="5KINGhotkeyAAA", bundle_hash="bh", val_bpb=1.5,
+        benchmark_accuracy=0.2, compute_cost=0.0, crowned_at=0.0,
+    ))
+
+    res = _run_idle(chain, tmp_path)
+
+    assert res["submissions"] == 0
+    w = _last_weights(chain)
+    assert w is not None
+    assert w.get("burn") is not True, "must NOT burn while a king sits"
+    assert w["weights"] == {"5KINGhotkeyAAA": 1.0}, "sitting king keeps the weight"
+
+
+def test_idle_epoch_with_no_king_burns(tmp_path):
+    chain = LocalChain(tmp_path / "chain")  # no king set
+
+    _run_idle(chain, tmp_path)
+
+    w = _last_weights(chain)
+    assert w is not None
+    assert w.get("burn") is True, "no king (genesis) → burn is correct"
+    assert w["weights"] == {"uid:0": 1.0}

--- a/validator/service.py
+++ b/validator/service.py
@@ -543,18 +543,20 @@ def run_epoch(
     if recovered:
         log_info(f"recovered {len(recovered)} pending weights from previous epoch")
 
+    # NOTE: do NOT early-burn on an empty epoch. A king-based subnet must keep
+    # weighting the SITTING king until someone dethrones it — burning idle
+    # epochs would starve the reigning king and is exactly the behavior miners /
+    # validators distrust. We fall through to the normal end-of-epoch weight
+    # block: with zero bundles the scoring loop no-ops, _apply_pool_split()
+    # re-asserts the sitting king (king → 1.0), and the BURN fallback there
+    # fires ONLY when there is genuinely nothing to weight — i.e. NO king at all
+    # (genesis, or right after the king is reset).
     if not bundles and not recovered:
-        # Zero submissions this epoch — the validator would otherwise set no
-        # weights at all. BURN FALLBACK: still set weights to uid 0 so it keeps
-        # its vTrust alive + burns to the owner (standard). Best-effort; the
-        # chain's rate-limit guard skips it when set too often.
-        if _burn_fallback_enabled():
-            log_info("no pending submissions this epoch — setting BURN weights (uid 0)")
-            try:
-                chain.set_burn_weights()
-            except Exception as e:
-                log_warn(f"burn fallback failed (non-fatal): {e}")
-        return {"submissions": 0, "accepted": 0, "rejected": 0}
+        king = chain.get_king()
+        if king is not None:
+            log_info(f"no new submissions — holding king {king.miner_hotkey[:12]}… (weights below)")
+        else:
+            log_info("no submissions and no king yet — burning to uid 0 (genesis)")
 
     log_info(f"found {len(bundles)} pending submission(s)")
     epoch_results = {"submissions": len(bundles), "accepted": 0, "rejected": 0}


### PR DESCRIPTION
CRITICAL: the empty-epoch path burned to uid 0 even when a king was seated, starving the reigning king. King-based subnets must keep weighting the king until someone dethrones it.

- remove the early-return BURN on no-submission epochs
- fall through to the normal weight block: _apply_pool_split re-asserts the sitting king (king -> 1.0); burn fires ONLY when there is no king at all (genesis / post-reset)
- tests: idle epoch holds sitting king; idle epoch w/ no king burns