### PR TITLE
validator: minimum king tenure (earn ≥1 weight cycle)

### DIFF
--- a/chain_layer/bittensor_chain.py
+++ b/chain_layer/bittensor_chain.py
@@ -391,6 +391,7 @@ class BittensorChain(ChainInterface):
             benchmark_accuracy=d.get("benchmark_accuracy", 0.0),
             compute_cost=d.get("compute_cost_h100h", 0.0),
             crowned_at=d.get("crowned_at", 0.0),
+            crowned_at_block=d.get("crowned_at_block", 0),
             proof_dir=d.get("proof_dir"),
             previous_king=d.get("previous_king"),
             king_attestation_hash=d.get("king_attestation_hash", ""),
@@ -414,6 +415,7 @@ class BittensorChain(ChainInterface):
             "benchmark_accuracy": king.benchmark_accuracy,
             "compute_cost_h100h": king.compute_cost,
             "crowned_at": king.crowned_at,
+            "crowned_at_block": king.crowned_at_block,
             "proof_dir": king.proof_dir,
         }
         if king.previous_king:

--- a/chain_layer/interface.py
+++ b/chain_layer/interface.py
@@ -49,6 +49,10 @@ class KingRecord:
     compute_cost: float
     crowned_at: float
     proof_dir: Optional[str] = None
+    # Block height at which this king was crowned. Enforces a minimum reign
+    # (RALPH_KING_MIN_TENURE_BLOCKS) so a new king earns ≥1 weight cycle before
+    # it can be dethroned. 0 = legacy/unknown (treated as no protection).
+    crowned_at_block: int = 0
     previous_king: Optional[dict] = None
     king_attestation_hash: str = ""
     parent_king_attestation_hash: Optional[str] = None

--- a/chain_layer/local.py
+++ b/chain_layer/local.py
@@ -96,6 +96,7 @@ class LocalChain(ChainInterface):
             benchmark_accuracy=d.get("benchmark_accuracy", 0.0),
             compute_cost=d.get("compute_cost_h100h", 0.0),
             crowned_at=d.get("crowned_at", 0.0),
+            crowned_at_block=d.get("crowned_at_block", 0),
             proof_dir=d.get("proof_dir"),
             previous_king=d.get("previous_king"),
             king_attestation_hash=d.get("king_attestation_hash", ""),
@@ -110,6 +111,7 @@ class LocalChain(ChainInterface):
             "benchmark_accuracy": king.benchmark_accuracy,
             "compute_cost_h100h": king.compute_cost,
             "crowned_at": king.crowned_at,
+            "crowned_at_block": king.crowned_at_block,
             "proof_dir": king.proof_dir,
         }
         if king.previous_king:

--- a/tests/test_king_tenure.py
+++ b/tests/test_king_tenure.py
@@ -3,9 +3,9 @@
 king earns at least one weight cycle. Challengers inside the tenure are deferred
 (left pending, not crowned, not archived)."""
 
+import validator.service as service
 from chain_layer.interface import KingRecord
 from chain_layer.local import LocalChain
-import validator.service as service
 
 
 def _king(block, hk="5KINGold"):

--- a/tests/test_king_tenure.py
+++ b/tests/test_king_tenure.py
@@ -1,0 +1,69 @@
+"""King-tenure guard: a freshly-crowned king reigns a minimum number of blocks
+(RALPH_KING_MIN_TENURE_BLOCKS) before a challenger can dethrone it, so every
+king earns at least one weight cycle. Challengers inside the tenure are deferred
+(left pending, not crowned, not archived)."""
+
+from chain_layer.interface import KingRecord
+from chain_layer.local import LocalChain
+import validator.service as service
+
+
+def _king(block, hk="5KINGold"):
+    return KingRecord(
+        miner_hotkey=hk, bundle_hash="kbh", val_bpb=2.0, benchmark_accuracy=0.1,
+        compute_cost=0.0, crowned_at=0.0, crowned_at_block=block,
+    )
+
+
+class _Score:
+    compute_cost = 0.0
+
+
+def _accepted_result(hk="5CHALLENGER"):
+    return {
+        "status": "king_change", "classification": "king_change", "weight_credit": 1.0,
+        "miner_hotkey": hk, "miner_github": "", "pr_url": "", "bundle_hash": "cbh",
+        "val_bpb": 1.0, "benchmark_accuracy": 0.5, "quality_gain": 0.5, "score": 0.5,
+        "tier": "verified", "decisive": True, "accepted": True, "is_first": False,
+        "result": None, "score_report": _Score(),
+    }
+
+
+def _setup(tmp_path, monkeypatch, current_block, king_block):
+    chain = LocalChain(tmp_path / "chain")
+    chain.set_king(_king(king_block))
+    monkeypatch.setattr(chain, "get_current_block", lambda: current_block)
+    monkeypatch.setattr(chain, "is_hotkey_registered", lambda hk: True)
+    monkeypatch.setattr(service, "score_and_decide", lambda *a, **k: _accepted_result())
+    qd = tmp_path / "queue"
+    b = qd / "pending" / "cbh"
+    b.mkdir(parents=True)
+    (b / "submission.json").write_text("{}")
+    return chain, qd
+
+
+def test_crowned_at_block_round_trips(tmp_path):
+    chain = LocalChain(tmp_path / "chain")
+    chain.set_king(_king(8_477_000))
+    assert chain.get_king().crowned_at_block == 8_477_000
+
+
+def test_challenger_deferred_within_tenure(tmp_path, monkeypatch):
+    monkeypatch.setenv("RALPH_KING_MIN_TENURE_BLOCKS", "300")
+    chain, qd = _setup(tmp_path, monkeypatch, current_block=1000, king_block=950)  # age 50 < 300
+    service.run_epoch(chain, qd, noise_floor_margin=0.013, hf_repo=None, audit_reports_enabled=False)
+
+    assert chain.get_king().miner_hotkey == "5KINGold", "king must NOT change inside tenure"
+    assert (qd / "pending" / "cbh" / "submission.json").exists(), "challenger left pending for re-eval"
+    assert not (qd / "scored" / "cbh").exists(), "challenger not archived while deferred"
+
+
+def test_challenger_crowns_after_tenure(tmp_path, monkeypatch):
+    monkeypatch.setenv("RALPH_KING_MIN_TENURE_BLOCKS", "300")
+    chain, qd = _setup(tmp_path, monkeypatch, current_block=1000, king_block=600)  # age 400 > 300
+    service.run_epoch(chain, qd, noise_floor_margin=0.013, hf_repo=None, audit_reports_enabled=False)
+
+    k = chain.get_king()
+    assert k.miner_hotkey == "5CHALLENGER", "tenure lapsed → challenger crowns"
+    assert k.crowned_at_block == 1000, "new king stamps current block"
+    assert (qd / "scored" / "cbh").exists(), "crowned bundle archived to scored"

--- a/validator/service.py
+++ b/validator/service.py
@@ -134,6 +134,14 @@ def poll_queue(queue_dir: Path) -> list[Path]:
     return bundles
 
 
+def _safe_current_block(chain) -> int:
+    """Current block height, or 0 if it can't be read (best-effort)."""
+    try:
+        return int(chain.get_current_block())
+    except Exception:
+        return 0
+
+
 def archive_bundle(bundle_dir: Path, queue_dir: Path, dest: str) -> None:
     """Move a processed bundle to scored/ or rejected/."""
     target = queue_dir / dest / bundle_dir.name
@@ -797,11 +805,34 @@ def run_epoch(
             continue
 
         if result["accepted"]:
+            from chain_layer.interface import KingRecord
+            king_before = chain.get_king()
+
+            # KING TENURE GUARD: a freshly-crowned king must reign a minimum
+            # number of blocks (RALPH_KING_MIN_TENURE_BLOCKS, default 300 — just
+            # under sn40's ~360-block weight-set window) so it earns at least
+            # one weight cycle before it can be dethroned. A challenger arriving
+            # inside the incumbent's tenure is DEFERRED: left in queue/pending
+            # (not archived, not crowned) and re-evaluated in a later epoch once
+            # tenure lapses. crowned_at_block == 0 means legacy/unknown → no
+            # protection (the bundle is crowned normally).
+            if king_before is not None and getattr(king_before, "crowned_at_block", 0):
+                tenure = int(os.environ.get("RALPH_KING_MIN_TENURE_BLOCKS", "300"))
+                try:
+                    age = chain.get_current_block() - king_before.crowned_at_block
+                except Exception:
+                    age = tenure  # can't read block → don't block dethroning
+                if age < tenure:
+                    log_info(
+                        f"king {king_before.miner_hotkey[:12]}… in protected tenure "
+                        f"({age}/{tenure} blocks) — deferring challenger "
+                        f"{miner_hotkey[:12]}… (left pending, re-evaluated later)"
+                    )
+                    continue  # do NOT crown, do NOT archive — re-eval next epoch
+
             gh = result.get("miner_github", "")
             who = f"{gh} ({miner_hotkey[:12]}...)" if gh else f"{miner_hotkey[:20]}..."
             log_info(f"NEW KING: {who} val_bpb={result['val_bpb']:.4f}")
-            from chain_layer.interface import KingRecord
-            king_before = chain.get_king()
             new_king = KingRecord(
                 miner_hotkey=miner_hotkey,
                 bundle_hash=result["bundle_hash"],
@@ -809,6 +840,7 @@ def run_epoch(
                 benchmark_accuracy=result["benchmark_accuracy"],
                 compute_cost=result["score_report"].compute_cost,
                 crowned_at=time.time(),
+                crowned_at_block=_safe_current_block(chain),
                 # proof_dir is updated AFTER archive_bundle moves the
                 # bundle to scored/, so the king pointer survives the move.
                 proof_dir=str(queue_dir / "scored" / bundle_dir.name),


### PR DESCRIPTION
Problem: kings churned every 120s epoch while weights only land every ~360 blocks, so a king could be crowned and dethroned without ever earning an on-chain payout.

- KingRecord.crowned_at_block (persisted by both chains)
- on crowning, stamp current block
- tenure guard: a challenger arriving within RALPH_KING_MIN_TENURE_BLOCKS (default 300, ~one weight-set window) of the incumbent's crowning is DEFERRED — left in queue/pending, not crowned, not archived, re-evaluated in a later epoch once tenure lapses
- crowned_at_block==0 (legacy) → no protection
- tests: defer-within-tenure, crown-after-tenure, block round-trip